### PR TITLE
chore(rdb): remove deprecated packages

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.21.0.20231031124126-92880abb72d2 h1:8sXDQUn4FSpxPFvrY5Ep6CI7VLrwCQvK0S6p8Zu5TkI=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.21.0.20231031124126-92880abb72d2/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.21.0.20231113154526-f7d9669f9369 h1:EmtsNvuv6ID2Mtj0rn7ed+uxNMiPjbOkinCWJi8d7IM=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.21.0.20231113154526-f7d9669f9369/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=

--- a/scaleway/resource_rdb_instance.go
+++ b/scaleway/resource_rdb_instance.go
@@ -3,7 +3,7 @@ package scaleway
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -424,7 +424,7 @@ func resourceScalewayRdbInstanceRead(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	certContent, err := ioutil.ReadAll(cert.Content)
+	certContent, err := io.ReadAll(cert.Content)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/scaleway/testdata/data-source-rdb-acl-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-acl-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:32 GMT
+      - Thu, 16 Nov 2023 15:51:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb8fe6be-4537-4197-a247-df449b291f18
+      - 9f7b7644-3635-40ec-83bf-dc3ff3944197
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayDataSourceRDBAcl_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayDataSourceRDBAcl_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "753"
+      - "780"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 15:52:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c727a597-fd36-4114-92d7-e018366f9352
+      - 889bf2e6-3c42-410b-8452-802a2757b618
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "753"
+      - "780"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98916dad-c143-4f55-90be-deef6f85762c
+      - b314d8ab-d824-4627-a028-2fa267c93d1a
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "753"
+      - "780"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:09 GMT
+      - Thu, 16 Nov 2023 15:52:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3533768-6902-4bf7-981a-215fca7ebd81
+      - e76c897e-3480-4fc0-8e1e-3671ee0b9e04
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "753"
+      - "780"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:39 GMT
+      - Thu, 16 Nov 2023 15:53:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebdb483f-bc8a-452e-bb03-ced201ebdc49
+      - 035e9ffa-8f8e-4017-80e5-4e123844647e
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "753"
+      - "780"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:09 GMT
+      - Thu, 16 Nov 2023 15:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a339142-6396-4611-b920-f76ccbcc8112
+      - 53fae62c-f056-45d4-b5ea-ed924bd40514
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "753"
+      - "780"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:39 GMT
+      - Thu, 16 Nov 2023 15:54:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f056fbfd-33bf-4061-848a-6ba65afcee08
+      - e7f87acb-a8b3-4fc9-8277-ec69eaa26cba
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "753"
+      - "780"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:09 GMT
+      - Thu, 16 Nov 2023 15:54:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0387883-f994-4c9b-9c44-519ced9a3ffd
+      - 21e6b9b7-ea3a-496b-8aef-12704c60718f
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1055"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a11cff5f-316b-4803-a60c-f3806ec4bf48
+      - 36062520-f06e-47ee-88c4-79f7a9f42ffc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1274"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:55:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - db936eed-1aad-43b5-a295-ac5c8409eee6
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f74c37e1-84aa-4ffa-b66d-754f34475867
+      - a6a32c92-c4ec-4021-9752-49b18abff4f1
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 817bebba-ef18-44b1-a691-25205ddfecfc
+      - e09be2a1-c98f-4e7b-ad8a-e7ae19b72cd6
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVWnMvc0VPTTZIVzlJbkRoK2had1l0a0RCNlQ0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXlXaGNOTXpNeE1ETXdNVGcwTnpJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxXNmtJT2x3TDIzSTNHK3dVR0Q1UDdjNnZIc1EzQy9lREtUcGorVkZkU1cxajVtVUlxdGNna28KZDZVSmhNY1FPMVZMK0JwWWhjZjlINmVwQXFvaHZvaEJuYWNPK0gvRHY0aGl1dnF0VEV5MGNJNXV5NHRiaEtzMApDUDJRZkdpa2dnOHNLb2YzWVZDejlLK2dQcE9jR0ZPWTdtK09td25GVGZjTEdnRHFjdU52MkZITVlVUW1lVUluCkYyU2hybEpQMjJhZzBJY2xZb0RSdFZpV1JnVEMrR05jV2lBbXdsaDBZWnRTYWJPS1Jxakh6OTFpQlBDSE1BWnYKdWxUbWg5UWRYVkgwdkV1NDVMUDY1YUhpZzdUV1g5UUF3WnNPOGlvZkc5cmUwUHVMTHYzZ3dGNGZBNEVoa0xnagpPR3B3VGFOSUpPdDIxSktkTWd1RG9zK0hpMXZ4MmowQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TVRZeFpHSTFPREV0TkdRM09DMDBNbU14TFdGbE5EQXROR1ZsWmpkbFlUVTMKTXpFeExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpNYmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1prZktBM2NhZittVGx6S1VUMDJVekRlQk9Ya0gyR2RYQ1dJaFo5cStWd0pueW1qRTkwRXlVCkNRdjBYK05oQ1VFdnJUZ1R2UHJGTzF2MHd2ZjVUM0ppS1lsMDNxZENmTWI2SDlWZEFFOGc0SHJjb21sT2JMMGsKWElZeVMvai9iWmtQa2U1dXlxQTdWcmt4WEVDYmtyU2pjUjFTdnFHMFczWXRvR2o1dUVBZzNXWWFPalJrczdZTApsYmlZVDRjclJKYnljMUM1MkRpUDQ2ZVRKR3BCUnRDRUtpbW9jRDhJRVlNNjIwTjZPZmdIQmFrT2c5WFBRSVBYCjN2K0l6SzhYZUpHRmptbFE5SnZlMUptNGFzZkJzeGgrbzFaY2ZnS1hpV0hob3FjcWNjeE5WRTNMZCtwdFhnRkUKdzZGdDJuWnNRdld6NXRMVEN0eFBiV0VMZitsZGUzamIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVUG00LzhPemxHR29GWDl1MGxKR1FFeGpBMnE4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UVXhORm9YRFRNek1URXhNekUxTlRVeE5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTM1MGNKSHpzZWVucnZDR0QvZGR6eEdSUzQwOFBhNWJNY3ZaeXh5NWs5UzJqYVgxdEljVjQKOEJpc1NDeUkvRSsxbFhUWU9yY1QrVVphZlJ4QTlOc3d0dUhBeGpwTXhBYVhJZ0hCSnlMTGYvMDNvbzdvTzh5Qgp1eGhLSk9rd1BkU3AxdHlpMHoyZzNkN2lJT3hGNHRMcXkvNHRaYWRyb2loeC9mK0tNVUxsMjhIWmRDQXUyUkhICjN3NGc0K3h1Zmw5QzZhVmdsc1ZrZDAyMkNOSUVrVTJaN0k2NEozL21rTlF1cHA0U0FMSmtqZmhLUWFiS0pMZjEKTFdiTVk2MWkzQjVwcVR6MS9kWDFCc2Q2a3pTRlJYZmhaNjM0K3AwSGlFTkY1a3oycEhrMGpEL1pqa2hFeXAvegpyUVhxRnI2L2FaZXlhYTVURDROTHNjKzRSVHd0Y3FQeU13SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE9ETmxPRGhrWVRNdFpEWXhOUzAwT1RCbExXRmpZamd0WkRGbU1XSmgKWTJFd09XRTFMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrcitod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF2K00yWG1jMmRCS2JMSjYwOHY5UEVyQkh4bnlWR1hjcDZ0NmgxYlIxc0YwcjZlMU9KCjBzcndGVVBqMnB0a0FjZzRYOEpGWXZaMTA1U2YwVEgwazZzWnpheHZkVy9CUzhmRzZxYU01OUM1NEN6N1JSeGEKYklSUlRpdGdmb2xucnlabk1td0k1eCtpYXBMNDNzUmw3ejFUUUhyd1VGdk8rRDgrSzNIT1B1ejlSaWIzTzlUcApCeENUSzRrcU9jcmFtelUrSkJoZ2J5UWZ0dGJscTBxSzhabWo0ZE5WdkhieDljMnUyZ2JqZFRndzNReU1QUmhnCk0wT0hrcDk0TytKeStlL0Z4bEVFWmQyQW54aGs1WXExaENhYllxWXR6QzVuVFY2UFd6Nk03ckZSNVB6emUvMncKV0ptZGlqS2o3K0FNdmZRdG5KMEpZNFFTTndqcENPZElwMXhpCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07078e70-cbdf-41ea-b9f5-169731fa05e0
+      - d14c989f-f3db-4a3a-9ba8-cd6ff2897a02
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95cab0fb-314b-4513-96d6-c0d45811adea
+      - 2adedfd2-3859-4fc8-8fad-d5b9f958af21
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/acls
     method: PUT
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":29594,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":29594,"protocol":"tcp"}]}'
     headers:
       Content-Length:
-      - "229"
+      - "240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1726f6db-7c3f-4ed0-a122-7396401bc42a
+      - a3d25bde-672d-481a-94f0-fde71c15203f
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1280"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 888b7d37-1a36-420b-87bd-f566295c88d3
+      - 1178b27e-8a0f-49d3-a43c-b1f16b404cd3
     status: 200 OK
     code: 200
     duration: ""
@@ -807,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:10 GMT
+      - Thu, 16 Nov 2023 15:56:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb52f405-f509-4e2f-901e-ed1a19c71eee
+      - bd1e7c95-a7e3-4ada-a9e8-086e3fcadc55
     status: 200 OK
     code: 200
     duration: ""
@@ -840,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":29594,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":29594,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "257"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:10 GMT
+      - Thu, 16 Nov 2023 15:56:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6cd07ebc-28a1-42cf-be51-12c481a2ee26
+      - e7297974-5c9b-42ea-8067-a88fe4e22b9a
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 15:56:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef4a882c-c161-4d43-aaaf-1e3847956c11
+      - 1199c831-7fd2-40f9-8376-567c8387fc5f
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVWnMvc0VPTTZIVzlJbkRoK2had1l0a0RCNlQ0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXlXaGNOTXpNeE1ETXdNVGcwTnpJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxXNmtJT2x3TDIzSTNHK3dVR0Q1UDdjNnZIc1EzQy9lREtUcGorVkZkU1cxajVtVUlxdGNna28KZDZVSmhNY1FPMVZMK0JwWWhjZjlINmVwQXFvaHZvaEJuYWNPK0gvRHY0aGl1dnF0VEV5MGNJNXV5NHRiaEtzMApDUDJRZkdpa2dnOHNLb2YzWVZDejlLK2dQcE9jR0ZPWTdtK09td25GVGZjTEdnRHFjdU52MkZITVlVUW1lVUluCkYyU2hybEpQMjJhZzBJY2xZb0RSdFZpV1JnVEMrR05jV2lBbXdsaDBZWnRTYWJPS1Jxakh6OTFpQlBDSE1BWnYKdWxUbWg5UWRYVkgwdkV1NDVMUDY1YUhpZzdUV1g5UUF3WnNPOGlvZkc5cmUwUHVMTHYzZ3dGNGZBNEVoa0xnagpPR3B3VGFOSUpPdDIxSktkTWd1RG9zK0hpMXZ4MmowQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TVRZeFpHSTFPREV0TkdRM09DMDBNbU14TFdGbE5EQXROR1ZsWmpkbFlUVTMKTXpFeExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpNYmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1prZktBM2NhZittVGx6S1VUMDJVekRlQk9Ya0gyR2RYQ1dJaFo5cStWd0pueW1qRTkwRXlVCkNRdjBYK05oQ1VFdnJUZ1R2UHJGTzF2MHd2ZjVUM0ppS1lsMDNxZENmTWI2SDlWZEFFOGc0SHJjb21sT2JMMGsKWElZeVMvai9iWmtQa2U1dXlxQTdWcmt4WEVDYmtyU2pjUjFTdnFHMFczWXRvR2o1dUVBZzNXWWFPalJrczdZTApsYmlZVDRjclJKYnljMUM1MkRpUDQ2ZVRKR3BCUnRDRUtpbW9jRDhJRVlNNjIwTjZPZmdIQmFrT2c5WFBRSVBYCjN2K0l6SzhYZUpHRmptbFE5SnZlMUptNGFzZkJzeGgrbzFaY2ZnS1hpV0hob3FjcWNjeE5WRTNMZCtwdFhnRkUKdzZGdDJuWnNRdld6NXRMVEN0eFBiV0VMZitsZGUzamIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVUG00LzhPemxHR29GWDl1MGxKR1FFeGpBMnE4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UVXhORm9YRFRNek1URXhNekUxTlRVeE5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTM1MGNKSHpzZWVucnZDR0QvZGR6eEdSUzQwOFBhNWJNY3ZaeXh5NWs5UzJqYVgxdEljVjQKOEJpc1NDeUkvRSsxbFhUWU9yY1QrVVphZlJ4QTlOc3d0dUhBeGpwTXhBYVhJZ0hCSnlMTGYvMDNvbzdvTzh5Qgp1eGhLSk9rd1BkU3AxdHlpMHoyZzNkN2lJT3hGNHRMcXkvNHRaYWRyb2loeC9mK0tNVUxsMjhIWmRDQXUyUkhICjN3NGc0K3h1Zmw5QzZhVmdsc1ZrZDAyMkNOSUVrVTJaN0k2NEozL21rTlF1cHA0U0FMSmtqZmhLUWFiS0pMZjEKTFdiTVk2MWkzQjVwcVR6MS9kWDFCc2Q2a3pTRlJYZmhaNjM0K3AwSGlFTkY1a3oycEhrMGpEL1pqa2hFeXAvegpyUVhxRnI2L2FaZXlhYTVURDROTHNjKzRSVHd0Y3FQeU13SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE9ETmxPRGhrWVRNdFpEWXhOUzAwT1RCbExXRmpZamd0WkRGbU1XSmgKWTJFd09XRTFMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrcitod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF2K00yWG1jMmRCS2JMSjYwOHY5UEVyQkh4bnlWR1hjcDZ0NmgxYlIxc0YwcjZlMU9KCjBzcndGVVBqMnB0a0FjZzRYOEpGWXZaMTA1U2YwVEgwazZzWnpheHZkVy9CUzhmRzZxYU01OUM1NEN6N1JSeGEKYklSUlRpdGdmb2xucnlabk1td0k1eCtpYXBMNDNzUmw3ejFUUUhyd1VGdk8rRDgrSzNIT1B1ejlSaWIzTzlUcApCeENUSzRrcU9jcmFtelUrSkJoZ2J5UWZ0dGJscTBxSzhabWo0ZE5WdkhieDljMnUyZ2JqZFRndzNReU1QUmhnCk0wT0hrcDk0TytKeStlL0Z4bEVFWmQyQW54aGs1WXExaENhYllxWXR6QzVuVFY2UFd6Nk03ckZSNVB6emUvMncKV0ptZGlqS2o3K0FNdmZRdG5KMEpZNFFTTndqcENPZElwMXhpCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 15:56:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9235daa2-79c3-4e13-bc5d-ff6c29520ebc
+      - cdcabf25-97f2-46a4-94ff-2129d3a89647
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 15:56:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82afcab5-0453-4f2a-9aae-b1b5a0f31552
+      - 9461d4b3-1d6b-4a1c-a123-b130bc00a744
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":29594,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":29594,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "257"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 15:56:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 111aa8d4-7a46-4459-a406-c650610d0c76
+      - 2385fe04-6ba4-4d9d-ad55-abd879b35838
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:12 GMT
+      - Thu, 16 Nov 2023 15:56:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00980610-e79b-4a92-8c15-ff1af2ca116a
+      - b58f86ff-4053-4424-84fb-9ac60478d6ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVWnMvc0VPTTZIVzlJbkRoK2had1l0a0RCNlQ0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXlXaGNOTXpNeE1ETXdNVGcwTnpJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxXNmtJT2x3TDIzSTNHK3dVR0Q1UDdjNnZIc1EzQy9lREtUcGorVkZkU1cxajVtVUlxdGNna28KZDZVSmhNY1FPMVZMK0JwWWhjZjlINmVwQXFvaHZvaEJuYWNPK0gvRHY0aGl1dnF0VEV5MGNJNXV5NHRiaEtzMApDUDJRZkdpa2dnOHNLb2YzWVZDejlLK2dQcE9jR0ZPWTdtK09td25GVGZjTEdnRHFjdU52MkZITVlVUW1lVUluCkYyU2hybEpQMjJhZzBJY2xZb0RSdFZpV1JnVEMrR05jV2lBbXdsaDBZWnRTYWJPS1Jxakh6OTFpQlBDSE1BWnYKdWxUbWg5UWRYVkgwdkV1NDVMUDY1YUhpZzdUV1g5UUF3WnNPOGlvZkc5cmUwUHVMTHYzZ3dGNGZBNEVoa0xnagpPR3B3VGFOSUpPdDIxSktkTWd1RG9zK0hpMXZ4MmowQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TVRZeFpHSTFPREV0TkdRM09DMDBNbU14TFdGbE5EQXROR1ZsWmpkbFlUVTMKTXpFeExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpNYmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1prZktBM2NhZittVGx6S1VUMDJVekRlQk9Ya0gyR2RYQ1dJaFo5cStWd0pueW1qRTkwRXlVCkNRdjBYK05oQ1VFdnJUZ1R2UHJGTzF2MHd2ZjVUM0ppS1lsMDNxZENmTWI2SDlWZEFFOGc0SHJjb21sT2JMMGsKWElZeVMvai9iWmtQa2U1dXlxQTdWcmt4WEVDYmtyU2pjUjFTdnFHMFczWXRvR2o1dUVBZzNXWWFPalJrczdZTApsYmlZVDRjclJKYnljMUM1MkRpUDQ2ZVRKR3BCUnRDRUtpbW9jRDhJRVlNNjIwTjZPZmdIQmFrT2c5WFBRSVBYCjN2K0l6SzhYZUpHRmptbFE5SnZlMUptNGFzZkJzeGgrbzFaY2ZnS1hpV0hob3FjcWNjeE5WRTNMZCtwdFhnRkUKdzZGdDJuWnNRdld6NXRMVEN0eFBiV0VMZitsZGUzamIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVUG00LzhPemxHR29GWDl1MGxKR1FFeGpBMnE4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UVXhORm9YRFRNek1URXhNekUxTlRVeE5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTM1MGNKSHpzZWVucnZDR0QvZGR6eEdSUzQwOFBhNWJNY3ZaeXh5NWs5UzJqYVgxdEljVjQKOEJpc1NDeUkvRSsxbFhUWU9yY1QrVVphZlJ4QTlOc3d0dUhBeGpwTXhBYVhJZ0hCSnlMTGYvMDNvbzdvTzh5Qgp1eGhLSk9rd1BkU3AxdHlpMHoyZzNkN2lJT3hGNHRMcXkvNHRaYWRyb2loeC9mK0tNVUxsMjhIWmRDQXUyUkhICjN3NGc0K3h1Zmw5QzZhVmdsc1ZrZDAyMkNOSUVrVTJaN0k2NEozL21rTlF1cHA0U0FMSmtqZmhLUWFiS0pMZjEKTFdiTVk2MWkzQjVwcVR6MS9kWDFCc2Q2a3pTRlJYZmhaNjM0K3AwSGlFTkY1a3oycEhrMGpEL1pqa2hFeXAvegpyUVhxRnI2L2FaZXlhYTVURDROTHNjKzRSVHd0Y3FQeU13SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE9ETmxPRGhrWVRNdFpEWXhOUzAwT1RCbExXRmpZamd0WkRGbU1XSmgKWTJFd09XRTFMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrcitod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF2K00yWG1jMmRCS2JMSjYwOHY5UEVyQkh4bnlWR1hjcDZ0NmgxYlIxc0YwcjZlMU9KCjBzcndGVVBqMnB0a0FjZzRYOEpGWXZaMTA1U2YwVEgwazZzWnpheHZkVy9CUzhmRzZxYU01OUM1NEN6N1JSeGEKYklSUlRpdGdmb2xucnlabk1td0k1eCtpYXBMNDNzUmw3ejFUUUhyd1VGdk8rRDgrSzNIT1B1ejlSaWIzTzlUcApCeENUSzRrcU9jcmFtelUrSkJoZ2J5UWZ0dGJscTBxSzhabWo0ZE5WdkhieDljMnUyZ2JqZFRndzNReU1QUmhnCk0wT0hrcDk0TytKeStlL0Z4bEVFWmQyQW54aGs1WXExaENhYllxWXR6QzVuVFY2UFd6Nk03ckZSNVB6emUvMncKV0ptZGlqS2o3K0FNdmZRdG5KMEpZNFFTTndqcENPZElwMXhpCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:12 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3eb2edc9-f90b-44bb-9bd7-9b61bf519c08
+      - 661806c4-3f4e-4321-82ab-98d6807de082
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:12 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d53bae2-4510-4e6c-89d5-fb65defbc4a5
+      - 48740e6a-7ea9-4f7b-b8fb-48f6c2052596
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:12 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fb3f25e-ef50-4325-b146-8cb14c32978e
+      - 731ad1ff-662c-482c-891b-7ba8990e1920
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":29594,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":29594,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "257"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:12 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cea169f2-ba30-45e0-98f4-61be25f06ce2
+      - 2ca1f2aa-4fbe-4395-8ecf-5461119ddc0a
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1203,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":29594,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":29594,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "257"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:12 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d2c42f9-3d1c-4dd5-9e40-7901981e1df3
+      - 5ccdcb8f-78b3-4edc-b2dc-d143210f90dc
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,19 +1236,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:13 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 289b722b-c4c9-4083-b3f4-1dd1a0772fba
+      - aac8a92f-676e-4346-8704-e9608a09466b
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1269,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":29594,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":29594,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "257"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:13 GMT
+      - Thu, 16 Nov 2023 15:56:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7aa32d09-adeb-45fe-a52b-ec04ddb7f046
+      - 760a0a08-b26e-4637-84ca-83a2d8fff822
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1302,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:13 GMT
+      - Thu, 16 Nov 2023 15:56:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 565377e2-7e3d-4b72-bc03-b584c579c9c0
+      - 4fbfd960-0422-4e09-929a-b772abc7138f
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,19 +1335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":29594,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":29594,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "257"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:13 GMT
+      - Thu, 16 Nov 2023 15:56:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce5ce677-4995-46d5-b3b4-018413fd806e
+      - 55ff194c-dc00-458e-9d6e-c4e73f1fc646
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,19 +1368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 15:56:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92263ac4-e108-4bcd-8565-6ecd51ce099e
+      - 4e6f656d-22fe-4597-aba2-8c0257f6c7a0
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,19 +1401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVWnMvc0VPTTZIVzlJbkRoK2had1l0a0RCNlQ0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXlXaGNOTXpNeE1ETXdNVGcwTnpJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxXNmtJT2x3TDIzSTNHK3dVR0Q1UDdjNnZIc1EzQy9lREtUcGorVkZkU1cxajVtVUlxdGNna28KZDZVSmhNY1FPMVZMK0JwWWhjZjlINmVwQXFvaHZvaEJuYWNPK0gvRHY0aGl1dnF0VEV5MGNJNXV5NHRiaEtzMApDUDJRZkdpa2dnOHNLb2YzWVZDejlLK2dQcE9jR0ZPWTdtK09td25GVGZjTEdnRHFjdU52MkZITVlVUW1lVUluCkYyU2hybEpQMjJhZzBJY2xZb0RSdFZpV1JnVEMrR05jV2lBbXdsaDBZWnRTYWJPS1Jxakh6OTFpQlBDSE1BWnYKdWxUbWg5UWRYVkgwdkV1NDVMUDY1YUhpZzdUV1g5UUF3WnNPOGlvZkc5cmUwUHVMTHYzZ3dGNGZBNEVoa0xnagpPR3B3VGFOSUpPdDIxSktkTWd1RG9zK0hpMXZ4MmowQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TVRZeFpHSTFPREV0TkdRM09DMDBNbU14TFdGbE5EQXROR1ZsWmpkbFlUVTMKTXpFeExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpNYmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1prZktBM2NhZittVGx6S1VUMDJVekRlQk9Ya0gyR2RYQ1dJaFo5cStWd0pueW1qRTkwRXlVCkNRdjBYK05oQ1VFdnJUZ1R2UHJGTzF2MHd2ZjVUM0ppS1lsMDNxZENmTWI2SDlWZEFFOGc0SHJjb21sT2JMMGsKWElZeVMvai9iWmtQa2U1dXlxQTdWcmt4WEVDYmtyU2pjUjFTdnFHMFczWXRvR2o1dUVBZzNXWWFPalJrczdZTApsYmlZVDRjclJKYnljMUM1MkRpUDQ2ZVRKR3BCUnRDRUtpbW9jRDhJRVlNNjIwTjZPZmdIQmFrT2c5WFBRSVBYCjN2K0l6SzhYZUpHRmptbFE5SnZlMUptNGFzZkJzeGgrbzFaY2ZnS1hpV0hob3FjcWNjeE5WRTNMZCtwdFhnRkUKdzZGdDJuWnNRdld6NXRMVEN0eFBiV0VMZitsZGUzamIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVUG00LzhPemxHR29GWDl1MGxKR1FFeGpBMnE4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UVXhORm9YRFRNek1URXhNekUxTlRVeE5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTM1MGNKSHpzZWVucnZDR0QvZGR6eEdSUzQwOFBhNWJNY3ZaeXh5NWs5UzJqYVgxdEljVjQKOEJpc1NDeUkvRSsxbFhUWU9yY1QrVVphZlJ4QTlOc3d0dUhBeGpwTXhBYVhJZ0hCSnlMTGYvMDNvbzdvTzh5Qgp1eGhLSk9rd1BkU3AxdHlpMHoyZzNkN2lJT3hGNHRMcXkvNHRaYWRyb2loeC9mK0tNVUxsMjhIWmRDQXUyUkhICjN3NGc0K3h1Zmw5QzZhVmdsc1ZrZDAyMkNOSUVrVTJaN0k2NEozL21rTlF1cHA0U0FMSmtqZmhLUWFiS0pMZjEKTFdiTVk2MWkzQjVwcVR6MS9kWDFCc2Q2a3pTRlJYZmhaNjM0K3AwSGlFTkY1a3oycEhrMGpEL1pqa2hFeXAvegpyUVhxRnI2L2FaZXlhYTVURDROTHNjKzRSVHd0Y3FQeU13SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE9ETmxPRGhrWVRNdFpEWXhOUzAwT1RCbExXRmpZamd0WkRGbU1XSmgKWTJFd09XRTFMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrcitod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF2K00yWG1jMmRCS2JMSjYwOHY5UEVyQkh4bnlWR1hjcDZ0NmgxYlIxc0YwcjZlMU9KCjBzcndGVVBqMnB0a0FjZzRYOEpGWXZaMTA1U2YwVEgwazZzWnpheHZkVy9CUzhmRzZxYU01OUM1NEN6N1JSeGEKYklSUlRpdGdmb2xucnlabk1td0k1eCtpYXBMNDNzUmw3ejFUUUhyd1VGdk8rRDgrSzNIT1B1ejlSaWIzTzlUcApCeENUSzRrcU9jcmFtelUrSkJoZ2J5UWZ0dGJscTBxSzhabWo0ZE5WdkhieDljMnUyZ2JqZFRndzNReU1QUmhnCk0wT0hrcDk0TytKeStlL0Z4bEVFWmQyQW54aGs1WXExaENhYllxWXR6QzVuVFY2UFd6Nk03ckZSNVB6emUvMncKV0ptZGlqS2o3K0FNdmZRdG5KMEpZNFFTTndqcENPZElwMXhpCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 15:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8cb9e8e-52d0-4315-92ae-676cad763559
+      - d1d5b3f5-6c3e-4aeb-983c-86a305a2965d
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,19 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 15:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e866011-d0c9-469e-a041-f18466d7d782
+      - 1120a647-8bb6-4978-9ceb-97ee42e2f245
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 15:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0b01b52-b97c-44e5-80e7-31f17dd3a46b
+      - c917df3b-b55f-46df-bed1-dd829e1ce49b
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,19 +1500,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":29594,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":29594,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "257"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 15:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00e50848-51b2-455a-a436-9246266b9e17
+      - 7a52aa6c-f552-4421-ae4d-fabd8418055f
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":29594,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":29594,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "257"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 15:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a78e7a8-d0d5-419f-8d8e-09de744695f9
+      - 0bd18fc1-c4ec-43a8-881b-d2f6e4065514
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,19 +1566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 15:56:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 866455e0-20e3-468c-b50e-2c973b6e6a6d
+      - 572db9cb-b0cd-4940-87ce-70d352d99ff7
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,19 +1599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":29594,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":29594,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "257"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 15:56:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87397804-a0ad-47d9-9674-ab05b0537025
+      - 8d6bc0bb-b82c-434b-98eb-2e5218e57274
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,19 +1632,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:15 GMT
+      - Thu, 16 Nov 2023 15:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47b4c4c3-12a2-4114-8df5-0561acbde405
+      - 1f84f5a0-033c-4836-82a3-acf3248d92f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,19 +1667,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5/acls
     method: DELETE
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19454,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19454,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":29594,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":29594,"protocol":"tcp"}]}'
     headers:
       Content-Length:
-      - "229"
+      - "240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:15 GMT
+      - Thu, 16 Nov 2023 15:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69d81b0f-1943-4347-aaa1-b73e26162e1d
+      - f7fbf276-29ae-4e6a-b8e0-e812b4c7a226
     status: 200 OK
     code: 200
     duration: ""
@@ -1667,19 +1700,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1280"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:15 GMT
+      - Thu, 16 Nov 2023 15:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c53fc80-50bc-4326-ab8f-a0cf75887c80
+      - 05421722-d3b9-410f-b0fd-c2955397cc2e
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,19 +1733,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:46 GMT
+      - Thu, 16 Nov 2023 15:56:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1722,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 850102af-f79d-4816-87d5-caa1b93bc445
+      - 9597b603-3cce-4d77-b386-311be705ad6e
     status: 200 OK
     code: 200
     duration: ""
@@ -1733,19 +1766,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:49 GMT
+      - Thu, 16 Nov 2023 15:56:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1755,7 +1788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed858e4f-6978-484c-bbe6-27a5f3c3398a
+      - af506404-6599-4f0b-8de2-81010f31b718
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,19 +1799,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1277"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:49 GMT
+      - Thu, 16 Nov 2023 15:56:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1788,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ab7394e-d2a7-4d4c-b765-62e71850c74b
+      - 139f72a5-e6ce-4d9f-bf61-d032eea781eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,19 +1832,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.156195Z","retention":7},"created_at":"2023-11-02T18:46:38.156195Z","endpoint":{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454},"endpoints":[{"id":"304ebbc7-9938-4e8f-96e9-166398952efc","ip":"51.159.26.223","load_balancer":{},"name":null,"port":19454}],"engine":"PostgreSQL-15","id":"161db581-4d78-42c1-ae40-4eef7ea57311","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.706362Z","retention":7},"created_at":"2023-11-16T15:52:09.706362Z","endpoint":{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594},"endpoints":[{"id":"8812c066-035f-4eb1-b947-8debfb059727","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29594}],"engine":"PostgreSQL-15","id":"83e88da3-d615-490e-acb8-d1f1baca09a5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1277"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:49 GMT
+      - Thu, 16 Nov 2023 15:56:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1821,7 +1854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca52ef53-460f-4d89-bba7-897a0d028b35
+      - 3bf85f31-1726-4e42-bcfa-79d10d7bf88e
     status: 200 OK
     code: 200
     duration: ""
@@ -1832,10 +1865,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"161db581-4d78-42c1-ae40-4eef7ea57311","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"83e88da3-d615-490e-acb8-d1f1baca09a5","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1844,7 +1877,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:19 GMT
+      - Thu, 16 Nov 2023 15:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1854,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a1d6816-bd48-4ce6-b701-851e6267097e
+      - c9dda228-3048-4f6b-aac9-1ee916fae55c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1865,10 +1898,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/161db581-4d78-42c1-ae40-4eef7ea57311
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/83e88da3-d615-490e-acb8-d1f1baca09a5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"161db581-4d78-42c1-ae40-4eef7ea57311","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"83e88da3-d615-490e-acb8-d1f1baca09a5","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1877,7 +1910,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:20 GMT
+      - Thu, 16 Nov 2023 15:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1887,7 +1920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d66f58c2-487a-4a2d-bff7-29a7ce056db8
+      - fc462c0a-03a9-407d-890f-ccd2f585fba7
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-database-backup-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-database-backup-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:32 GMT
+      - Thu, 16 Nov 2023 15:51:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40c2f487-9ba3-42cf-ab7d-66f3ae5a6a43
+      - 8d5c21eb-4c2b-4dc2-88b1-d7d8b5644180
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "730"
+      - "757"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:52 GMT
+      - Thu, 16 Nov 2023 16:06:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eef5f00a-8c59-4e45-a436-746e6b356dd3
+      - be2a3566-bfb7-496e-a87f-dd393d1fbcb3
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "730"
+      - "757"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:52 GMT
+      - Thu, 16 Nov 2023 16:06:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fbcfb72-d499-461c-a0f3-9d871eb593d4
+      - 4e328070-0fd9-4f70-9001-6cb734ee1633
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "730"
+      - "757"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:22 GMT
+      - Thu, 16 Nov 2023 16:06:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ba3996f-179c-46d6-928d-5a8d8637fa29
+      - 0f075eca-3893-4e2a-a38f-5fbd7f8e3e1b
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "730"
+      - "757"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:52 GMT
+      - Thu, 16 Nov 2023 16:07:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9e46209-1671-4192-9911-51dc109accd4
+      - a7661cf2-d916-49f2-b47d-065015000103
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "730"
+      - "757"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:22 GMT
+      - Thu, 16 Nov 2023 16:07:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0fd7eaf-a7be-42bb-a1b1-ae249dd1c784
+      - ced7bea4-2bb9-4e67-8913-e65ef84fa987
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "730"
+      - "757"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:52 GMT
+      - Thu, 16 Nov 2023 16:08:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0a1240b-b0d2-49df-aa5f-08e60b03dc03
+      - 3cb18add-3913-4267-85c0-95bf9831de0a
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1032"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:23 GMT
+      - Thu, 16 Nov 2023 16:08:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efdff264-2781-4943-935b-3a4eed46dcad
+      - 7a41b2b7-3dc4-4a8b-b315-4b15d225020f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1251"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:09:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9df0d9e3-d2cf-4689-9d8d-08fbe58ed38e
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1251"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:23 GMT
+      - Thu, 16 Nov 2023 16:09:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df85baef-e6c2-4a30-ab38-27289b84ff41
+      - bc638529-7eda-43f4-bd63-dc69b6d92f13
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1251"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:23 GMT
+      - Thu, 16 Nov 2023 16:09:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e264098-06ca-4add-ba2b-bb6ad12c2e7e
+      - 0707ee10-561f-4286-b3ae-38c58ca26616
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRURUSkZhM1htUkVGQXhsdVVoQjBra2xhVjZBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU5ESTFXaGNOTXpNeE1ETXdNVGcxTkRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5GNnRISi9YTUdKZllqY2g1YkcvTUJRV2ljTGUwUTRRSERjOUJyS1NndEd0UHVrNjIvYWpYM0wKQXdWMjQ0czQwbjE5YUovMlRlcEk2Skg0bHdDSnl6eDFyU1pldkhpWFFSOVE1K3A5VVRCaTIxTTAwcWoraGZ2OApuZ1FkMWVvQWVacU03U0hnSlVBSGNGdzEwTzJIYW9URUx3cHQ4VjJWeW0yVVQ2TENTaThyOXltOEJXWThZTjZwCkY1RmppVDZ1YUNQcjhrc0QyRzRJc01jWHZtQjZkSFZMb0psb1JFTWdHTTZURGtsSEtLNTR6bDZYR01WZnRtZkEKbEVLam1WOHpyc0piSm9seFArZmxLWXFJdG82T0FQalptSFdSSlovUm9uYk5iTmljWmxZYkR2SHpHSURGK0huNgpUcjJGSVVRNVNkOWJSR2d1cjJ0S09uY0FQYUVORFVjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0WkRZMk0yVmlNR0V0Wm1JMllTMDBObVpoTFRsalltTXRPV1E1TWpZNE5qSmkKT0dOaUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckptamh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXJqeVcyZ2ZZUTc0eDdiaENzK2JobEZUUXBJcDdweWs3L0ZMSUlYa3ZkWkNtZXVuVDV5UjdtCk5KUUNaamVibTlIa3VQYno5SEk3V0dQT0lWWDF0cFdMT1pxMWJRMHJqNDQwLzhQWDhaWEZSZ25aUEhHcW9xNjcKMGJoTkxOQXh3Q2ZHTUFBVnc3RjVNS2d1SVQ3d0I2ZTBDUkh1Ym1nb25JbER2REZhclZBMnhrdytyU25KYlFuYgpzZG1MZEtodFdlaGZLVmMwWk05YWIvM3h3bi9YdDBVOGdqd0xjTDR4RWU1dERLREZHbGdpcnNTMUNyK0hEZjdMClAyMVg0ZnhsWDhpTytKeXFoT01xQ3F4N3k0ZWhuekVwUWpTVjlzanpoWTFoK2hSMEJZaWZrVjJERlRUdjJiZWEKRkRTNzRtSlBLUW1IS2YzK29kZUE0NnRKQ0phckUrZm4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVYllsOEF5eWFFbndEN0ZsRHhtRDdXRHVZdGRzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EZ3pNMW9YRFRNek1URXhNekUyTURnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQW56eEloWXllWmhRUDY3ZXVIMHZBK3NSTG5FRWFaUXRwNkZXcnlNWk1jTjBTMFNRRnFBNmsKY0hLclpLRWVUK1g5UmRaMDJFa3ZNdDFxTmhjUWVmVzhjaEFuNGJ1d0FyVHRXWWU3YXBMV3lLSkZoSEdrN2lJcwowYkxpcXVvRXczSFN0T05WNEc3UURUczN0K2RRVytaQUFEb1NrZ29GbGZ6R3VYYUxVN2NtNFZMR2VXTEw4ZVgvCjlyOXU3cFY2dEQ1dkcxTjBFS0hoU1NBNmMwWE92UG95dm1sajhyUW40dGdOUVVwZkdTNEdRNEl5TkRYMDFRYXoKbG1RaGlWbER2SHk0NVpZQnpsVHQyZlVhK3NzSlJleDVHNkM1c1Z6MHVaUzYvbGNSMFJnUE5hU2hVZzZwNlUxRgpiZnNucFNYNVVWVmg4ZlBleGE1ajNydlU0SzcyRXF2Ry9RSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWTFPR0kyTTJZdE16bGtaUzAwWXpVeExUZ3lNekV0TUdVNE5UUTEKTXpkaVpHSmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQ4b3Zod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNlamdRc3hpTU16TW1ndUpFR0NBY0tWc0x4ZUs0QXFGWWRvT2JHTytEbHBwRFVFOTAwCkhqdmRMUmxUYk5CWHN0Umd2dnc1c1owNFpnZlhjK2JnZTY2UmI4S3pTQnJyUTJZYWdWQnRFWmZ4UFVmZHBkb1QKRENYUndidWQ4WC9OUHlneENFdU85c1dzWXZkcTlKb3ZneW5TZW9sWHVKc2JVOENYUDlsOGlJMmh1YVNVK0V0KwpSdFRwc0k0eTFLcVZTNHdaU2p2OGNaaGtycGlaYTNxQjZKcHZ6UnM4RG1ydUxHU2MrSTV2enM4TGpEV2dhV2dSClBwTHQ1eTFzcGdESUhydkF0YmF4MGZPVkdTSS9TWWtkRWxFRVN4RDhPbldhSHdxbHZkK0RxdU9nZmF0ZGIyMDAKajBmYU12UTFZQjFVM2crQ0haUGxEajBKY2Y2MnU0VkZ0aTVECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:23 GMT
+      - Thu, 16 Nov 2023 16:09:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d71157ae-3026-430a-a6f8-5615d48b7db3
+      - 29fbeac4-0ac5-4462-bb7b-d8c434beb686
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1251"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:23 GMT
+      - Thu, 16 Nov 2023 16:09:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adf736e9-d89a-4828-b810-801b48fa8fa3
+      - f1a99dc5-0f1e-4291-b17e-19867080f346
     status: 200 OK
     code: 200
     duration: ""
@@ -708,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe/databases
     method: POST
   response:
     body: '{"managed":true,"name":"test-terraform","owner":"","size":0}'
     headers:
       Content-Length:
-      - "60"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:23 GMT
+      - Thu, 16 Nov 2023 16:09:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9505770c-2fa8-4780-89ce-74fff590a06e
+      - e0c06125-1b47-4c40-8326-e7504bede5b8
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1251"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:23 GMT
+      - Thu, 16 Nov 2023 16:09:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75182f4c-a5fb-49a0-88dd-0a8335aa790f
+      - 492f4021-ab71-47aa-a153-b7bae7bd5835
     status: 200 OK
     code: 200
     duration: ""
@@ -774,118 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases?name=test-terraform&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "113"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:56:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 69150f20-e15c-4b3e-96dc-4f0416d957ee
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1203"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:56:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d6689337-fa01-4687-a71f-49b3fb017f7c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRURUSkZhM1htUkVGQXhsdVVoQjBra2xhVjZBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU5ESTFXaGNOTXpNeE1ETXdNVGcxTkRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5GNnRISi9YTUdKZllqY2g1YkcvTUJRV2ljTGUwUTRRSERjOUJyS1NndEd0UHVrNjIvYWpYM0wKQXdWMjQ0czQwbjE5YUovMlRlcEk2Skg0bHdDSnl6eDFyU1pldkhpWFFSOVE1K3A5VVRCaTIxTTAwcWoraGZ2OApuZ1FkMWVvQWVacU03U0hnSlVBSGNGdzEwTzJIYW9URUx3cHQ4VjJWeW0yVVQ2TENTaThyOXltOEJXWThZTjZwCkY1RmppVDZ1YUNQcjhrc0QyRzRJc01jWHZtQjZkSFZMb0psb1JFTWdHTTZURGtsSEtLNTR6bDZYR01WZnRtZkEKbEVLam1WOHpyc0piSm9seFArZmxLWXFJdG82T0FQalptSFdSSlovUm9uYk5iTmljWmxZYkR2SHpHSURGK0huNgpUcjJGSVVRNVNkOWJSR2d1cjJ0S09uY0FQYUVORFVjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0WkRZMk0yVmlNR0V0Wm1JMllTMDBObVpoTFRsalltTXRPV1E1TWpZNE5qSmkKT0dOaUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckptamh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXJqeVcyZ2ZZUTc0eDdiaENzK2JobEZUUXBJcDdweWs3L0ZMSUlYa3ZkWkNtZXVuVDV5UjdtCk5KUUNaamVibTlIa3VQYno5SEk3V0dQT0lWWDF0cFdMT1pxMWJRMHJqNDQwLzhQWDhaWEZSZ25aUEhHcW9xNjcKMGJoTkxOQXh3Q2ZHTUFBVnc3RjVNS2d1SVQ3d0I2ZTBDUkh1Ym1nb25JbER2REZhclZBMnhrdytyU25KYlFuYgpzZG1MZEtodFdlaGZLVmMwWk05YWIvM3h3bi9YdDBVOGdqd0xjTDR4RWU1dERLREZHbGdpcnNTMUNyK0hEZjdMClAyMVg0ZnhsWDhpTytKeXFoT01xQ3F4N3k0ZWhuekVwUWpTVjlzanpoWTFoK2hSMEJZaWZrVjJERlRUdjJiZWEKRkRTNzRtSlBLUW1IS2YzK29kZUE0NnRKQ0phckUrZm4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1843"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:56:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 505cf918-d35e-4601-bdee-ff1c4db59654
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "113"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:24 GMT
+      - Thu, 16 Nov 2023 16:09:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 484daf0c-22f3-48e8-820b-bb4056d9208d
+      - 7a296c2f-3375-4b55-b730-922b523ec5dd
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1251"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:25 GMT
+      - Thu, 16 Nov 2023 16:09:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b858b430-cf78-4764-ae09-c1e528adc112
+      - 88f4b841-d074-4887-a1c7-3e53e13b89eb
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRURUSkZhM1htUkVGQXhsdVVoQjBra2xhVjZBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU5ESTFXaGNOTXpNeE1ETXdNVGcxTkRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5GNnRISi9YTUdKZllqY2g1YkcvTUJRV2ljTGUwUTRRSERjOUJyS1NndEd0UHVrNjIvYWpYM0wKQXdWMjQ0czQwbjE5YUovMlRlcEk2Skg0bHdDSnl6eDFyU1pldkhpWFFSOVE1K3A5VVRCaTIxTTAwcWoraGZ2OApuZ1FkMWVvQWVacU03U0hnSlVBSGNGdzEwTzJIYW9URUx3cHQ4VjJWeW0yVVQ2TENTaThyOXltOEJXWThZTjZwCkY1RmppVDZ1YUNQcjhrc0QyRzRJc01jWHZtQjZkSFZMb0psb1JFTWdHTTZURGtsSEtLNTR6bDZYR01WZnRtZkEKbEVLam1WOHpyc0piSm9seFArZmxLWXFJdG82T0FQalptSFdSSlovUm9uYk5iTmljWmxZYkR2SHpHSURGK0huNgpUcjJGSVVRNVNkOWJSR2d1cjJ0S09uY0FQYUVORFVjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0WkRZMk0yVmlNR0V0Wm1JMllTMDBObVpoTFRsalltTXRPV1E1TWpZNE5qSmkKT0dOaUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckptamh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXJqeVcyZ2ZZUTc0eDdiaENzK2JobEZUUXBJcDdweWs3L0ZMSUlYa3ZkWkNtZXVuVDV5UjdtCk5KUUNaamVibTlIa3VQYno5SEk3V0dQT0lWWDF0cFdMT1pxMWJRMHJqNDQwLzhQWDhaWEZSZ25aUEhHcW9xNjcKMGJoTkxOQXh3Q2ZHTUFBVnc3RjVNS2d1SVQ3d0I2ZTBDUkh1Ym1nb25JbER2REZhclZBMnhrdytyU25KYlFuYgpzZG1MZEtodFdlaGZLVmMwWk05YWIvM3h3bi9YdDBVOGdqd0xjTDR4RWU1dERLREZHbGdpcnNTMUNyK0hEZjdMClAyMVg0ZnhsWDhpTytKeXFoT01xQ3F4N3k0ZWhuekVwUWpTVjlzanpoWTFoK2hSMEJZaWZrVjJERlRUdjJiZWEKRkRTNzRtSlBLUW1IS2YzK29kZUE0NnRKQ0phckUrZm4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVYllsOEF5eWFFbndEN0ZsRHhtRDdXRHVZdGRzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EZ3pNMW9YRFRNek1URXhNekUyTURnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQW56eEloWXllWmhRUDY3ZXVIMHZBK3NSTG5FRWFaUXRwNkZXcnlNWk1jTjBTMFNRRnFBNmsKY0hLclpLRWVUK1g5UmRaMDJFa3ZNdDFxTmhjUWVmVzhjaEFuNGJ1d0FyVHRXWWU3YXBMV3lLSkZoSEdrN2lJcwowYkxpcXVvRXczSFN0T05WNEc3UURUczN0K2RRVytaQUFEb1NrZ29GbGZ6R3VYYUxVN2NtNFZMR2VXTEw4ZVgvCjlyOXU3cFY2dEQ1dkcxTjBFS0hoU1NBNmMwWE92UG95dm1sajhyUW40dGdOUVVwZkdTNEdRNEl5TkRYMDFRYXoKbG1RaGlWbER2SHk0NVpZQnpsVHQyZlVhK3NzSlJleDVHNkM1c1Z6MHVaUzYvbGNSMFJnUE5hU2hVZzZwNlUxRgpiZnNucFNYNVVWVmg4ZlBleGE1ajNydlU0SzcyRXF2Ry9RSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWTFPR0kyTTJZdE16bGtaUzAwWXpVeExUZ3lNekV0TUdVNE5UUTEKTXpkaVpHSmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQ4b3Zod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNlamdRc3hpTU16TW1ndUpFR0NBY0tWc0x4ZUs0QXFGWWRvT2JHTytEbHBwRFVFOTAwCkhqdmRMUmxUYk5CWHN0Umd2dnc1c1owNFpnZlhjK2JnZTY2UmI4S3pTQnJyUTJZYWdWQnRFWmZ4UFVmZHBkb1QKRENYUndidWQ4WC9OUHlneENFdU85c1dzWXZkcTlKb3ZneW5TZW9sWHVKc2JVOENYUDlsOGlJMmh1YVNVK0V0KwpSdFRwc0k0eTFLcVZTNHdaU2p2OGNaaGtycGlaYTNxQjZKcHZ6UnM4RG1ydUxHU2MrSTV2enM4TGpEV2dhV2dSClBwTHQ1eTFzcGdESUhydkF0YmF4MGZPVkdTSS9TWWtkRWxFRVN4RDhPbldhSHdxbHZkK0RxdU9nZmF0ZGIyMDAKajBmYU12UTFZQjFVM2crQ0haUGxEajBKY2Y2MnU0VkZ0aTVECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:25 GMT
+      - Thu, 16 Nov 2023 16:09:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c8abb35-6129-4cd5-804f-783d411c054b
+      - b7b3da70-6806-48a4-85bf-8c61d58c8058
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "113"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:25 GMT
+      - Thu, 16 Nov 2023 16:09:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,12 +928,111 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3304f8e0-8e08-4e93-811b-25958bc5e44f
+      - 434f0619-a579-4a00-bcf2-5c2a1ed0f744
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","database_name":"test-terraform","name":"test_backup_datasource"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1251"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:09:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 241b90de-be99-43ca-9247-faebd5b8d629
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVYllsOEF5eWFFbndEN0ZsRHhtRDdXRHVZdGRzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EZ3pNMW9YRFRNek1URXhNekUyTURnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQW56eEloWXllWmhRUDY3ZXVIMHZBK3NSTG5FRWFaUXRwNkZXcnlNWk1jTjBTMFNRRnFBNmsKY0hLclpLRWVUK1g5UmRaMDJFa3ZNdDFxTmhjUWVmVzhjaEFuNGJ1d0FyVHRXWWU3YXBMV3lLSkZoSEdrN2lJcwowYkxpcXVvRXczSFN0T05WNEc3UURUczN0K2RRVytaQUFEb1NrZ29GbGZ6R3VYYUxVN2NtNFZMR2VXTEw4ZVgvCjlyOXU3cFY2dEQ1dkcxTjBFS0hoU1NBNmMwWE92UG95dm1sajhyUW40dGdOUVVwZkdTNEdRNEl5TkRYMDFRYXoKbG1RaGlWbER2SHk0NVpZQnpsVHQyZlVhK3NzSlJleDVHNkM1c1Z6MHVaUzYvbGNSMFJnUE5hU2hVZzZwNlUxRgpiZnNucFNYNVVWVmg4ZlBleGE1ajNydlU0SzcyRXF2Ry9RSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWTFPR0kyTTJZdE16bGtaUzAwWXpVeExUZ3lNekV0TUdVNE5UUTEKTXpkaVpHSmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQ4b3Zod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNlamdRc3hpTU16TW1ndUpFR0NBY0tWc0x4ZUs0QXFGWWRvT2JHTytEbHBwRFVFOTAwCkhqdmRMUmxUYk5CWHN0Umd2dnc1c1owNFpnZlhjK2JnZTY2UmI4S3pTQnJyUTJZYWdWQnRFWmZ4UFVmZHBkb1QKRENYUndidWQ4WC9OUHlneENFdU85c1dzWXZkcTlKb3ZneW5TZW9sWHVKc2JVOENYUDlsOGlJMmh1YVNVK0V0KwpSdFRwc0k0eTFLcVZTNHdaU2p2OGNaaGtycGlaYTNxQjZKcHZ6UnM4RG1ydUxHU2MrSTV2enM4TGpEV2dhV2dSClBwTHQ1eTFzcGdESUhydkF0YmF4MGZPVkdTSS9TWWtkRWxFRVN4RDhPbldhSHdxbHZkK0RxdU9nZmF0ZGIyMDAKajBmYU12UTFZQjFVM2crQ0haUGxEajBKY2Y2MnU0VkZ0aTVECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1849"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:09:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 835c820f-1125-4d70-9b53-a8de7d9b9ac1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe/databases?name=test-terraform&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "117"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:09:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 13f73751-a00e-4c0a-9b5a-d6390329de32
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","database_name":"test-terraform","name":"test_backup_datasource"}'
     form: {}
     headers:
       Content-Type:
@@ -1010,16 +1043,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups
     method: POST
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
-      - "396"
+      - "409"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:27 GMT
+      - Thu, 16 Nov 2023 16:09:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1029,7 +1062,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73bb6029-1507-42f1-a4f6-0659c5c43bef
+      - 2c593c4b-4c27-4d7f-bbba-58343621eea2
     status: 200 OK
     code: 200
     duration: ""
@@ -1040,19 +1073,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
-      - "396"
+      - "409"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:27 GMT
+      - Thu, 16 Nov 2023 16:09:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1062,7 +1095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23a298c4-62af-4646-b6a0-8005f8a7f6fd
+      - d2e6ec29-000d-4967-88d5-019ef1357b57
     status: 200 OK
     code: 200
     duration: ""
@@ -1073,19 +1106,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:57 GMT
+      - Thu, 16 Nov 2023 16:09:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1095,7 +1128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bca0a636-de3f-487f-8502-71a86cbf4a05
+      - ee89cbc0-281f-44f3-b755-16b7df47c1c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,19 +1139,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:58 GMT
+      - Thu, 16 Nov 2023 16:09:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1128,40 +1161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b9b2491-19d2-4aeb-beff-6f743256ec9a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
-    headers:
-      Content-Length:
-      - "418"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:56:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e76a7ac8-6ffd-428d-870b-b786c1e02a04
+      - 1c971ae4-25cf-4575-91ae-0f59d41a071c
     status: 200 OK
     code: 200
     duration: ""
@@ -1175,16 +1175,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "457"
+      - "471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:58 GMT
+      - Thu, 16 Nov 2023 16:09:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1194,7 +1194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a3360d3-ad48-411b-bd2e-30a12dc0101e
+      - 92ef02c4-8f5d-40b6-a8b6-25376e9a280c
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,19 +1205,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=d663eb0a-fb6a-46fa-9cbc-9d926862b8cb&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "457"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:59 GMT
+      - Thu, 16 Nov 2023 16:09:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1227,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2c2940a-47ba-413a-b15d-8749e6b6fd1b
+      - a598dc63-825f-4c20-b086-2b1fc7c250dd
     status: 200 OK
     code: 200
     duration: ""
@@ -1238,19 +1238,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=ef58b63f-39de-4c51-8231-0e854537bdbe&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"database_backups":[{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "418"
+      - "471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:59 GMT
+      - Thu, 16 Nov 2023 16:09:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83dac3a4-0779-4ffe-8014-ebf5eb808006
+      - beeb2db3-360d-416f-a29e-a332dea2ca5c
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,19 +1271,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:00 GMT
+      - Thu, 16 Nov 2023 16:09:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16c42f3b-fbfe-49dd-9ac1-d562bd7300c5
+      - 9e5f8602-fa0a-4263-ac98-714be76f55fe
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,19 +1304,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
+    headers:
+      Content-Length:
+      - "431"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:09:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 69aed52f-a25a-4054-a41e-c15725a351d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "113"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:00 GMT
+      - Thu, 16 Nov 2023 16:09:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aab9b15d-65e5-4271-9b34-048a709b15c9
+      - 0e9d44fb-8a7e-4246-a433-c69e01d6d3e4
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,19 +1370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:00 GMT
+      - Thu, 16 Nov 2023 16:09:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d650a2f8-9e4c-4da5-b2ad-edfba67ee23f
+      - 0144b502-8cd7-4c43-8da6-162b64f335ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,19 +1403,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:00 GMT
+      - Thu, 16 Nov 2023 16:09:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1392,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e8dfc8e-0ed7-41cf-b081-0fac052d14e0
+      - 72c7c601-9ac3-4efe-b83a-fa74e5fd7ba0
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,19 +1436,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=d663eb0a-fb6a-46fa-9cbc-9d926862b8cb&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=ef58b63f-39de-4c51-8231-0e854537bdbe&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "457"
+      - "471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:00 GMT
+      - Thu, 16 Nov 2023 16:09:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1458,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b964d9b-9936-4303-a61b-40531cd995bd
+      - a2504922-fe2e-4461-a1d3-6f0f202253a7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
+    headers:
+      Content-Length:
+      - "431"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:09:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4590ff69-3c46-418f-99da-01e63963d211
     status: 200 OK
     code: 200
     duration: ""
@@ -1439,16 +1505,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "457"
+      - "471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:00 GMT
+      - Thu, 16 Nov 2023 16:09:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46432f91-74ce-4f85-bdea-19850cd7086f
+      - f0e33693-c713-427a-a54c-58ce9b0f0b55
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,19 +1535,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:00 GMT
+      - Thu, 16 Nov 2023 16:09:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82417896-e0cb-40b6-b508-94eea9241fe2
+      - 27791823-24b1-415b-89ee-57f6e0aa5500
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,19 +1568,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "418"
+      - "1251"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:00 GMT
+      - Thu, 16 Nov 2023 16:10:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1524,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1e2e281-ddeb-4f7b-a875-f02827390d62
+      - 9d401fef-0ee9-4cc7-9fd6-c5b36cfd26af
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,19 +1601,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVYllsOEF5eWFFbndEN0ZsRHhtRDdXRHVZdGRzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EZ3pNMW9YRFRNek1URXhNekUyTURnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQW56eEloWXllWmhRUDY3ZXVIMHZBK3NSTG5FRWFaUXRwNkZXcnlNWk1jTjBTMFNRRnFBNmsKY0hLclpLRWVUK1g5UmRaMDJFa3ZNdDFxTmhjUWVmVzhjaEFuNGJ1d0FyVHRXWWU3YXBMV3lLSkZoSEdrN2lJcwowYkxpcXVvRXczSFN0T05WNEc3UURUczN0K2RRVytaQUFEb1NrZ29GbGZ6R3VYYUxVN2NtNFZMR2VXTEw4ZVgvCjlyOXU3cFY2dEQ1dkcxTjBFS0hoU1NBNmMwWE92UG95dm1sajhyUW40dGdOUVVwZkdTNEdRNEl5TkRYMDFRYXoKbG1RaGlWbER2SHk0NVpZQnpsVHQyZlVhK3NzSlJleDVHNkM1c1Z6MHVaUzYvbGNSMFJnUE5hU2hVZzZwNlUxRgpiZnNucFNYNVVWVmg4ZlBleGE1ajNydlU0SzcyRXF2Ry9RSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWTFPR0kyTTJZdE16bGtaUzAwWXpVeExUZ3lNekV0TUdVNE5UUTEKTXpkaVpHSmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQ4b3Zod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNlamdRc3hpTU16TW1ndUpFR0NBY0tWc0x4ZUs0QXFGWWRvT2JHTytEbHBwRFVFOTAwCkhqdmRMUmxUYk5CWHN0Umd2dnc1c1owNFpnZlhjK2JnZTY2UmI4S3pTQnJyUTJZYWdWQnRFWmZ4UFVmZHBkb1QKRENYUndidWQ4WC9OUHlneENFdU85c1dzWXZkcTlKb3ZneW5TZW9sWHVKc2JVOENYUDlsOGlJMmh1YVNVK0V0KwpSdFRwc0k0eTFLcVZTNHdaU2p2OGNaaGtycGlaYTNxQjZKcHZ6UnM4RG1ydUxHU2MrSTV2enM4TGpEV2dhV2dSClBwTHQ1eTFzcGdESUhydkF0YmF4MGZPVkdTSS9TWWtkRWxFRVN4RDhPbldhSHdxbHZkK0RxdU9nZmF0ZGIyMDAKajBmYU12UTFZQjFVM2crQ0haUGxEajBKY2Y2MnU0VkZ0aTVECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1203"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:01 GMT
+      - Thu, 16 Nov 2023 16:10:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1557,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efdfc7da-409e-46bf-a472-052b465cdbeb
+      - ba7ef134-35bd-47f5-9fcd-c2fad0e2de4a
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,52 +1634,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRURUSkZhM1htUkVGQXhsdVVoQjBra2xhVjZBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU5ESTFXaGNOTXpNeE1ETXdNVGcxTkRJMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5GNnRISi9YTUdKZllqY2g1YkcvTUJRV2ljTGUwUTRRSERjOUJyS1NndEd0UHVrNjIvYWpYM0wKQXdWMjQ0czQwbjE5YUovMlRlcEk2Skg0bHdDSnl6eDFyU1pldkhpWFFSOVE1K3A5VVRCaTIxTTAwcWoraGZ2OApuZ1FkMWVvQWVacU03U0hnSlVBSGNGdzEwTzJIYW9URUx3cHQ4VjJWeW0yVVQ2TENTaThyOXltOEJXWThZTjZwCkY1RmppVDZ1YUNQcjhrc0QyRzRJc01jWHZtQjZkSFZMb0psb1JFTWdHTTZURGtsSEtLNTR6bDZYR01WZnRtZkEKbEVLam1WOHpyc0piSm9seFArZmxLWXFJdG82T0FQalptSFdSSlovUm9uYk5iTmljWmxZYkR2SHpHSURGK0huNgpUcjJGSVVRNVNkOWJSR2d1cjJ0S09uY0FQYUVORFVjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0WkRZMk0yVmlNR0V0Wm1JMllTMDBObVpoTFRsalltTXRPV1E1TWpZNE5qSmkKT0dOaUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckptamh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXJqeVcyZ2ZZUTc0eDdiaENzK2JobEZUUXBJcDdweWs3L0ZMSUlYa3ZkWkNtZXVuVDV5UjdtCk5KUUNaamVibTlIa3VQYno5SEk3V0dQT0lWWDF0cFdMT1pxMWJRMHJqNDQwLzhQWDhaWEZSZ25aUEhHcW9xNjcKMGJoTkxOQXh3Q2ZHTUFBVnc3RjVNS2d1SVQ3d0I2ZTBDUkh1Ym1nb25JbER2REZhclZBMnhrdytyU25KYlFuYgpzZG1MZEtodFdlaGZLVmMwWk05YWIvM3h3bi9YdDBVOGdqd0xjTDR4RWU1dERLREZHbGdpcnNTMUNyK0hEZjdMClAyMVg0ZnhsWDhpTytKeXFoT01xQ3F4N3k0ZWhuekVwUWpTVjlzanpoWTFoK2hSMEJZaWZrVjJERlRUdjJiZWEKRkRTNzRtSlBLUW1IS2YzK29kZUE0NnRKQ0phckUrZm4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1843"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:57:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f6884c01-e581-4d1b-bd24-5ebf5e8eaf83
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "113"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:01 GMT
+      - Thu, 16 Nov 2023 16:10:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee04c87d-f488-43ba-be84-67a58d2754dd
+      - a839f862-041e-4d31-9baf-c971cb7b019d
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,19 +1667,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:01 GMT
+      - Thu, 16 Nov 2023 16:10:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 991973b0-4d37-4f69-9b90-2e93b50b0367
+      - 4331a19a-e29b-416e-a8a0-ce1c5d4188f0
     status: 200 OK
     code: 200
     duration: ""
@@ -1667,19 +1700,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:01 GMT
+      - Thu, 16 Nov 2023 16:10:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce127dde-d24c-4241-afe2-9deda85df069
+      - cb6511f6-e694-4af5-9790-c4f25e76dbe8
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,19 +1733,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=d663eb0a-fb6a-46fa-9cbc-9d926862b8cb&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=ef58b63f-39de-4c51-8231-0e854537bdbe&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "457"
+      - "471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:02 GMT
+      - Thu, 16 Nov 2023 16:10:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1722,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2562298-accd-45a0-8dec-1f78c2a952fd
+      - 156a29eb-24c7-4f92-9976-9bc021b4f34b
     status: 200 OK
     code: 200
     duration: ""
@@ -1736,16 +1769,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "457"
+      - "471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:02 GMT
+      - Thu, 16 Nov 2023 16:10:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1755,7 +1788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 249f8d56-bd10-4b87-8bb2-3723780dc564
+      - 1a591f21-e1c6-49b2-a0de-20415206c7f0
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,19 +1799,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:02 GMT
+      - Thu, 16 Nov 2023 16:10:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1788,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f2003df-8b5c-4c43-a78e-10f4118b883c
+      - c36b41d2-3f0b-4961-9173-63325af37692
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,19 +1832,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:02 GMT
+      - Thu, 16 Nov 2023 16:10:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1821,7 +1854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74362be1-be86-4bd0-85e1-771e7640b013
+      - 87ac6f23-74ee-4323-b79c-fc040588de96
     status: 200 OK
     code: 200
     duration: ""
@@ -1832,19 +1865,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:02 GMT
+      - Thu, 16 Nov 2023 16:10:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1854,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24359e26-1d01-4d92-ac00-2478fc1d22e5
+      - 3fc51fa7-0343-4091-b4c7-0ffcb3ebc49e
     status: 200 OK
     code: 200
     duration: ""
@@ -1865,19 +1898,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=d663eb0a-fb6a-46fa-9cbc-9d926862b8cb&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=ef58b63f-39de-4c51-8231-0e854537bdbe&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "457"
+      - "471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:02 GMT
+      - Thu, 16 Nov 2023 16:10:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1887,7 +1920,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bc4f984-550a-41be-bd89-c3760f2ca65d
+      - 1f2cabc4-164e-4d14-b453-fb418e319d27
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
+    headers:
+      Content-Length:
+      - "431"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:10:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 844e5f82-425f-4dea-8fc4-d65bb391afab
     status: 200 OK
     code: 200
     duration: ""
@@ -1901,16 +1967,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "457"
+      - "471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:02 GMT
+      - Thu, 16 Nov 2023 16:10:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1920,7 +1986,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7619bf53-c85c-4805-8cc8-97c80590e687
+      - 9eb9cb0f-1a1c-432d-9478-d646e7c687a6
     status: 200 OK
     code: 200
     duration: ""
@@ -1931,19 +1997,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:02 GMT
+      - Thu, 16 Nov 2023 16:10:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1953,7 +2019,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e158fd20-e7cc-4ca0-955f-c7d0782550d7
+      - 4269ce68-e4ca-485e-9e88-791cd9286aaa
     status: 200 OK
     code: 200
     duration: ""
@@ -1964,19 +2030,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "418"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:02 GMT
+      - Thu, 16 Nov 2023 16:10:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1986,7 +2052,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5ad3aba-a8a6-4078-8c70-4ca47052c19e
+      - 04354dd5-8cef-43a6-9909-9ed7fe2794cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1997,52 +2063,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-11-02T18:56:28.848960Z"}'
-    headers:
-      Content-Length:
-      - "418"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:57:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 04487ca1-0ee7-446f-b8c8-8f7c0dd2da57
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: DELETE
   response:
-    body: '{"created_at":"2023-11-02T18:56:27.168442Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","instance_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"deleting","updated_at":"2023-11-02T18:56:28.848960Z"}'
+    body: '{"created_at":"2023-11-16T16:09:16.456424Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9536491-5065-4d12-8023-dad76e68b96b","instance_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"deleting","updated_at":"2023-11-16T16:09:18.034299Z"}'
     headers:
       Content-Length:
-      - "421"
+      - "434"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:03 GMT
+      - Thu, 16 Nov 2023 16:10:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2052,7 +2085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 448fb487-4e0d-44e5-8df2-2fc978c57a35
+      - 5ca5dd9c-63b8-46a9-b702-b73d3c0d6f10
     status: 200 OK
     code: 200
     duration: ""
@@ -2063,10 +2096,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"e9536491-5065-4d12-8023-dad76e68b96b","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2075,7 +2108,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:03 GMT
+      - Thu, 16 Nov 2023 16:10:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2085,7 +2118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24c52f27-dfbf-466c-9fc7-c69710276ab7
+      - d410060a-0b92-4259-82a2-64864d6e9e56
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2096,19 +2129,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1251"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:03 GMT
+      - Thu, 16 Nov 2023 16:10:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2118,7 +2151,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7e9e8e5-90f5-4641-a223-76c0090ae17e
+      - c4292f13-e0e2-4a23-92b2-eb6ef1f94a19
     status: 200 OK
     code: 200
     duration: ""
@@ -2129,7 +2162,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb/databases/test-terraform
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe/databases/test-terraform
     method: DELETE
   response:
     body: ""
@@ -2139,7 +2172,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:04 GMT
+      - Thu, 16 Nov 2023 16:10:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2149,7 +2182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e525a7db-b9df-4097-9845-01474285b101
+      - 71334a25-4de8-4bf2-a71a-9d6803c5fdcf
     status: 204 No Content
     code: 204
     duration: ""
@@ -2160,19 +2193,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1251"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:04 GMT
+      - Thu, 16 Nov 2023 16:10:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2182,7 +2215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8dc8839-fff6-4327-a584-dced6ca2d56e
+      - 151331cd-0bd2-4f2f-a2e1-b7957f79ae93
     status: 200 OK
     code: 200
     duration: ""
@@ -2193,19 +2226,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1251"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:04 GMT
+      - Thu, 16 Nov 2023 16:10:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2215,7 +2248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cef145a2-79c5-4085-8fc8-36f4e83b8109
+      - 469a3ce8-8c39-4e59-9b72-d4bf9cf34b77
     status: 200 OK
     code: 200
     duration: ""
@@ -2226,19 +2259,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1206"
+      - "1254"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:04 GMT
+      - Thu, 16 Nov 2023 16:10:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2248,7 +2281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4a2ef95-3e50-4d01-a41d-55dfe96aa8d5
+      - 86ef0a2c-728c-44de-aea5-74e8faa1497b
     status: 200 OK
     code: 200
     duration: ""
@@ -2259,19 +2292,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:53:52.184460Z","retention":7},"created_at":"2023-11-02T18:53:52.184460Z","endpoint":{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033},"endpoints":[{"id":"08dff754-f2ef-4348-bd9c-468c66952f4f","ip":"51.158.56.230","load_balancer":{},"name":null,"port":23033}],"engine":"PostgreSQL-15","id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:06:11.191934Z","retention":7},"created_at":"2023-11-16T16:06:11.191934Z","endpoint":{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836},"endpoints":[{"id":"78a9251e-0d68-42fe-a59f-c42445f558bf","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15836}],"engine":"PostgreSQL-15","id":"ef58b63f-39de-4c51-8231-0e854537bdbe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1206"
+      - "1254"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:04 GMT
+      - Thu, 16 Nov 2023 16:10:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2281,7 +2314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a71dd2ca-879b-43a5-9af3-aad4b579fdf8
+      - c4cd68a7-a950-4389-b08d-a468e030a644
     status: 200 OK
     code: 200
     duration: ""
@@ -2292,10 +2325,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2304,7 +2337,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:35 GMT
+      - Thu, 16 Nov 2023 16:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2314,7 +2347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52bdc3c2-9d6e-45b5-b470-9d9fd453e645
+      - 16886cfd-2163-4d65-89a4-a350fa00f414
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2325,10 +2358,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d663eb0a-fb6a-46fa-9cbc-9d926862b8cb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ef58b63f-39de-4c51-8231-0e854537bdbe
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"d663eb0a-fb6a-46fa-9cbc-9d926862b8cb","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"ef58b63f-39de-4c51-8231-0e854537bdbe","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2337,7 +2370,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:35 GMT
+      - Thu, 16 Nov 2023 16:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2347,7 +2380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afb8d553-4f29-4ff1-a326-9eee364875f6
+      - 5cb47797-f689-4b35-8185-b8a69371167d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2358,10 +2391,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"e9536491-5065-4d12-8023-dad76e68b96b","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2370,7 +2403,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:35 GMT
+      - Thu, 16 Nov 2023 16:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2380,7 +2413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fcaf535-6756-4c1e-83c4-2f6c8bc428a8
+      - ce13776d-de4a-4bf2-8b6f-7c858f606049
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2391,10 +2424,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"e9536491-5065-4d12-8023-dad76e68b96b","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2403,7 +2436,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:35 GMT
+      - Thu, 16 Nov 2023 16:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2413,7 +2446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25f509e5-335d-4e6a-b655-1bbe39b0878f
+      - d1a58274-049b-49b9-a86a-b5a2aacd927e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2424,10 +2457,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"e9536491-5065-4d12-8023-dad76e68b96b","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2436,7 +2469,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:35 GMT
+      - Thu, 16 Nov 2023 16:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2446,7 +2479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f22d7df6-9db7-49ef-9629-3a10cff9e437
+      - 8edf6c60-3111-44a2-b663-662417675763
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2457,10 +2490,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4d10490b-8b81-45f9-85cf-0257d94a34b6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9536491-5065-4d12-8023-dad76e68b96b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"4d10490b-8b81-45f9-85cf-0257d94a34b6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"e9536491-5065-4d12-8023-dad76e68b96b","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2469,7 +2502,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:35 GMT
+      - Thu, 16 Nov 2023 16:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2479,7 +2512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7dfb0d0e-f5b5-4c23-9ee1-82ed8a2c2b59
+      - f45816ef-35f8-456d-a499-8c02765b7dcb
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-database-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-database-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:32 GMT
+      - Thu, 16 Nov 2023 15:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 139ca6d2-3a33-402d-ad8c-b61a44c1c164
+      - 2d2495d1-3ae4-49ed-bcac-614c463b9b5d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "730"
+      - "757"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:15 GMT
+      - Thu, 16 Nov 2023 16:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a024e5c-5527-439c-a0e4-d13458e20a9f
+      - 3b0adce9-d972-4903-a9f8-ab616c5b9c23
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "730"
+      - "757"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:15 GMT
+      - Thu, 16 Nov 2023 16:00:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42add12a-5e5b-4868-8b53-bf8ed331c0b1
+      - 8023ad14-e039-49ca-8b50-dd0fc8554d65
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "730"
+      - "757"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:52 GMT
+      - Thu, 16 Nov 2023 16:01:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c0fef40-31e4-4dc2-9420-497bee9d7ad7
+      - 020cd5d1-3a5a-4879-a769-567a8388f436
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "730"
+      - "757"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:22 GMT
+      - Thu, 16 Nov 2023 16:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 203f7e2e-8705-4c70-bbea-35bbad6b65ec
+      - 740824b9-7efd-4516-8c40-88c8316cd6ce
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "730"
+      - "757"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:52 GMT
+      - Thu, 16 Nov 2023 16:02:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aad07b65-a527-4e1c-a4a4-e7139117ab8d
+      - 9e74f50e-43f1-44e6-bfa8-14cb1bf9f033
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "730"
+      - "757"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:22 GMT
+      - Thu, 16 Nov 2023 16:02:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c38163d4-2a2e-4233-bf1c-b651166c259c
+      - 4fd6c9ea-6b41-4cce-bfdf-31fae40b9164
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1032"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 16:03:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df0627a0-b537-4e56-900e-8f7d27826111
+      - 4f04a5c8-d328-414b-95e9-a0d164a3ff6e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1249"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:03:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cb6fd4b4-77d2-4583-abca-5b4de7186d35
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 16:03:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96b12304-5c2f-4fdc-ade4-c5911d33272e
+      - e4bb45f0-fbcd-4586-a5eb-07b24143a527
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 16:03:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b3318c8-1503-43a3-bc1d-3cafbbe06287
+      - c2e811f0-832b-4438-b263-4d4ff80d6403
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVRTlwRzhjdWRaTnhmQy9FRG9FWGVQRWlMWWI4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1URTFNQjRYCkRUSXpNVEV3TWpFNE5UQTFORm9YRFRNek1UQXpNREU0TlRBMU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRFMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXU5VllmRnNveXBESWtLekkvVXBwMHoxOFE4ZldxakdYTUpXYTlDRXJsTVJzMG5INEh0SWcKbExXNFpyd3lxbm1YZGhTZjhpNEJvMitaSjM0eUlmRktsUGdtcWFvYk1keCs4MlRoVFFNek9NUE96TFJzWTdoNApWdDJja2hsZ2RzTy9IOVg4Ti8yb1k5aGt5cklCZzAxRlk5dXFEZTMzaU9iTittTm50djcrSGU3RmZ1RGhGcThCClpPY0t0bGlEU3dYVEc4SEp6a29XTWRWVDBoSzhkUUpoWXlGamFERlpwdEQrYXpMcjB0L3A5amZYL05WZHZHREwKaVdsQmhIZVRSRXpKd1UyeWY3YkJud25oaU9jM0o0NVR5M1JPK2RieVRrZTFrRlMrSTdoSnIxNXJZY0NscDFMQQpGODZEVE1ZSzZRdWxlQ05sWnF1LzdLM1prbkRJNmpKTjF3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRXhOWUk4Y25jdE1HVTNaVGM0TldJdE5Ea3pNeTAwTnpJd0xUa3pNVGN0TkRBeE56SXkKTnpjeE9XVXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJMSllod1F6bjgxek1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFIbW1iOFgyc2x0RU1TU1dFU2FBYk54M1hWayszRXBaNGRSZVJmNHpWeWNiODNYUDZhCjB5aFErS1F5UURxL0M0QXNyUzZ2M2ZYeTk4VmhDdUFWMDJlMlEvSTB1eGVhWEdLVHdrd005R0dRR3czQVdIdHUKY3hseXltd043QmF6cjZSU1g0SndtUUdxajdsd3R2WElvUTNjeHV1WUFzMjRmbnJGZDJVY2E0MnBodUIxQWZQagpqeitORmxyNDZESmVLdXRIbmt5Q1ZsZ0hrNkE3Z0laQXFXL05sR2hDWXRTK21xYVovL0NCeGNVdkNJWlNmYnEyClBPQ3FYd0hib0RaSWllNmlhY1IrUEdmUGxTWTFVT1Y5MWE3Y2FGb1ZxTzN1b1BFeWZhVHp1Rm5pYkc0cVNhVjIKQWlyalJYMndUMVZWMzBMY1pTVGMzUGRxeFZwTnZoZlB5S1o4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQk16TG1saXgvMXVMR2Y4VU03UDgzY3pkbFNrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRZd016QTNXaGNOTXpNeE1URXpNVFl3TXpBM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUorWXE1SFAvdlNHWWxtMkp2WnVHK0xkRDVBbENQWFRDR3R0Y1RxLzRjdUhEQzI4SlRmdVlVWWsKeXg2cURpMUptZnVoc1ZWcFBiMHR5dHFES3MyTG1jMEd3QU9qcDFnS0FWYkRmM2ZyWkNYYTduRS9wU0dLSmZaNQpLSEU5RHlqOGVmR051d1Y2dlJTdzkrdHBwZjZ1anRJWnc1ek5MRHpIRUpoajQyMDN6eFFHQ3ZBUlVVdDZWY0dYCnpRamg5czl6V2dRRGxSd2RmM1V0c2J2SThuTUh4djdRUCs3TUdZRm1ZTGRpbjhFQWlScnBDZEJkNVdjVmxjTVAKeG9CcndmbE13T2V4T0xLRDZDUElzRGw3ckd4cFpKU0x2NmsrT28vLzY2bW05V2VoUUZJR3NJZURTMUpuUGFQeQpPUmpmWGI4K0ZNckNtZ0N6Qzl4TktMRlRQdWZxeGI4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0TkRBME16UXlaamd0TW1Jek9DMDBPREkyTFdFMk9USXROMk15T1dSaU1tUTUKTVRJekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqcklRZWh3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQmZ2MU9WUEVRU0poZ3FuUmJNYmpHejNieDI0SVdsajYzay9tVFd4dFJnd3Q0RENmdm1VdUp5CmJzbTUwQ2ZXMjFNUTZ3aEdCSWYyTzZEbXhpSHlkQm81R3ZiTDR4RCtTR29jMkM0TFIrTE9UdlFXWERFQ2REZUUKRHI5Y1JOWEpxbFNybUFCcFNUczFYS3pVdGxRZ0lHY2tzL2F6QmIyYUlGVVNxSW50WlpaaFdsaHdpNGJQV2xGRQpxRnFzY0x1TFRZNWMzS3h0eDVqQzczQnBsNnRlQzI3NnRNYjJLQTRHZkFiN2hOUjc5cFF3d093c1ZkQ2tFbEVuCnN0S3Iwcld0bStOMjdvOStDdkYzQnVId20zNzUweW1qYkRnMWFob0FpL0VQMFBjcEkzT2pOa1JlelZTZklPU2sKSTZES1o5SkhXUlpmY1NOdklkcXcrZzZxZ3BmalY3NSsKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 16:03:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c151b1f7-0502-43d1-8b48-c7a7ddb11b3d
+      - 6e7f81d8-4838-452e-addb-c3540b35e200
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:53 GMT
+      - Thu, 16 Nov 2023 16:03:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b70b958c-48b7-429f-8ad0-7387fa911fd6
+      - d3ea98e2-486f-40c9-95d7-bbbe01b33416
     status: 200 OK
     code: 200
     duration: ""
@@ -708,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/databases
     method: POST
   response:
     body: '{"managed":true,"name":"test-terraform","owner":"","size":0}'
     headers:
       Content-Length:
-      - "60"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:53 GMT
+      - Thu, 16 Nov 2023 16:03:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dab7091-9f51-4d16-9ea6-b292045e141b
+      - 602cbdc3-6031-4c42-b4e5-cf32a7c968c6
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:53 GMT
+      - Thu, 16 Nov 2023 16:03:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ba4e098-7157-4bdc-95a0-dde4f3f633d2
+      - 81809547-9cc3-4daa-8300-3eef0a910bc5
     status: 200 OK
     code: 200
     duration: ""
@@ -774,118 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "113"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:52:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3112f254-3bd9-4910-86ff-41b956ec678d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1203"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:52:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a73f134f-4d0a-4dde-ae7f-ff491cc4fd9e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVRTlwRzhjdWRaTnhmQy9FRG9FWGVQRWlMWWI4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1URTFNQjRYCkRUSXpNVEV3TWpFNE5UQTFORm9YRFRNek1UQXpNREU0TlRBMU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRFMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXU5VllmRnNveXBESWtLekkvVXBwMHoxOFE4ZldxakdYTUpXYTlDRXJsTVJzMG5INEh0SWcKbExXNFpyd3lxbm1YZGhTZjhpNEJvMitaSjM0eUlmRktsUGdtcWFvYk1keCs4MlRoVFFNek9NUE96TFJzWTdoNApWdDJja2hsZ2RzTy9IOVg4Ti8yb1k5aGt5cklCZzAxRlk5dXFEZTMzaU9iTittTm50djcrSGU3RmZ1RGhGcThCClpPY0t0bGlEU3dYVEc4SEp6a29XTWRWVDBoSzhkUUpoWXlGamFERlpwdEQrYXpMcjB0L3A5amZYL05WZHZHREwKaVdsQmhIZVRSRXpKd1UyeWY3YkJud25oaU9jM0o0NVR5M1JPK2RieVRrZTFrRlMrSTdoSnIxNXJZY0NscDFMQQpGODZEVE1ZSzZRdWxlQ05sWnF1LzdLM1prbkRJNmpKTjF3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRXhOWUk4Y25jdE1HVTNaVGM0TldJdE5Ea3pNeTAwTnpJd0xUa3pNVGN0TkRBeE56SXkKTnpjeE9XVXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJMSllod1F6bjgxek1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFIbW1iOFgyc2x0RU1TU1dFU2FBYk54M1hWayszRXBaNGRSZVJmNHpWeWNiODNYUDZhCjB5aFErS1F5UURxL0M0QXNyUzZ2M2ZYeTk4VmhDdUFWMDJlMlEvSTB1eGVhWEdLVHdrd005R0dRR3czQVdIdHUKY3hseXltd043QmF6cjZSU1g0SndtUUdxajdsd3R2WElvUTNjeHV1WUFzMjRmbnJGZDJVY2E0MnBodUIxQWZQagpqeitORmxyNDZESmVLdXRIbmt5Q1ZsZ0hrNkE3Z0laQXFXL05sR2hDWXRTK21xYVovL0NCeGNVdkNJWlNmYnEyClBPQ3FYd0hib0RaSWllNmlhY1IrUEdmUGxTWTFVT1Y5MWE3Y2FGb1ZxTzN1b1BFeWZhVHp1Rm5pYkc0cVNhVjIKQWlyalJYMndUMVZWMzBMY1pTVGMzUGRxeFZwTnZoZlB5S1o4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1847"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:52:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7836318a-f770-4ba4-984d-67241c48e84d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "113"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:54 GMT
+      - Thu, 16 Nov 2023 16:03:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e451fe12-4390-4365-8b08-3eda3bb26637
+      - 2557ff4e-4493-45a0-8d6e-b0c814f49ef7
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:59 GMT
+      - Thu, 16 Nov 2023 16:03:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89ad0fba-c494-4276-9246-4b1552a613d0
+      - 41e03d9e-529c-45cf-b8c3-9c24fd8c5106
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVRTlwRzhjdWRaTnhmQy9FRG9FWGVQRWlMWWI4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1URTFNQjRYCkRUSXpNVEV3TWpFNE5UQTFORm9YRFRNek1UQXpNREU0TlRBMU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRFMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXU5VllmRnNveXBESWtLekkvVXBwMHoxOFE4ZldxakdYTUpXYTlDRXJsTVJzMG5INEh0SWcKbExXNFpyd3lxbm1YZGhTZjhpNEJvMitaSjM0eUlmRktsUGdtcWFvYk1keCs4MlRoVFFNek9NUE96TFJzWTdoNApWdDJja2hsZ2RzTy9IOVg4Ti8yb1k5aGt5cklCZzAxRlk5dXFEZTMzaU9iTittTm50djcrSGU3RmZ1RGhGcThCClpPY0t0bGlEU3dYVEc4SEp6a29XTWRWVDBoSzhkUUpoWXlGamFERlpwdEQrYXpMcjB0L3A5amZYL05WZHZHREwKaVdsQmhIZVRSRXpKd1UyeWY3YkJud25oaU9jM0o0NVR5M1JPK2RieVRrZTFrRlMrSTdoSnIxNXJZY0NscDFMQQpGODZEVE1ZSzZRdWxlQ05sWnF1LzdLM1prbkRJNmpKTjF3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRXhOWUk4Y25jdE1HVTNaVGM0TldJdE5Ea3pNeTAwTnpJd0xUa3pNVGN0TkRBeE56SXkKTnpjeE9XVXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJMSllod1F6bjgxek1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFIbW1iOFgyc2x0RU1TU1dFU2FBYk54M1hWayszRXBaNGRSZVJmNHpWeWNiODNYUDZhCjB5aFErS1F5UURxL0M0QXNyUzZ2M2ZYeTk4VmhDdUFWMDJlMlEvSTB1eGVhWEdLVHdrd005R0dRR3czQVdIdHUKY3hseXltd043QmF6cjZSU1g0SndtUUdxajdsd3R2WElvUTNjeHV1WUFzMjRmbnJGZDJVY2E0MnBodUIxQWZQagpqeitORmxyNDZESmVLdXRIbmt5Q1ZsZ0hrNkE3Z0laQXFXL05sR2hDWXRTK21xYVovL0NCeGNVdkNJWlNmYnEyClBPQ3FYd0hib0RaSWllNmlhY1IrUEdmUGxTWTFVT1Y5MWE3Y2FGb1ZxTzN1b1BFeWZhVHp1Rm5pYkc0cVNhVjIKQWlyalJYMndUMVZWMzBMY1pTVGMzUGRxeFZwTnZoZlB5S1o4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQk16TG1saXgvMXVMR2Y4VU03UDgzY3pkbFNrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRZd016QTNXaGNOTXpNeE1URXpNVFl3TXpBM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUorWXE1SFAvdlNHWWxtMkp2WnVHK0xkRDVBbENQWFRDR3R0Y1RxLzRjdUhEQzI4SlRmdVlVWWsKeXg2cURpMUptZnVoc1ZWcFBiMHR5dHFES3MyTG1jMEd3QU9qcDFnS0FWYkRmM2ZyWkNYYTduRS9wU0dLSmZaNQpLSEU5RHlqOGVmR051d1Y2dlJTdzkrdHBwZjZ1anRJWnc1ek5MRHpIRUpoajQyMDN6eFFHQ3ZBUlVVdDZWY0dYCnpRamg5czl6V2dRRGxSd2RmM1V0c2J2SThuTUh4djdRUCs3TUdZRm1ZTGRpbjhFQWlScnBDZEJkNVdjVmxjTVAKeG9CcndmbE13T2V4T0xLRDZDUElzRGw3ckd4cFpKU0x2NmsrT28vLzY2bW05V2VoUUZJR3NJZURTMUpuUGFQeQpPUmpmWGI4K0ZNckNtZ0N6Qzl4TktMRlRQdWZxeGI4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0TkRBME16UXlaamd0TW1Jek9DMDBPREkyTFdFMk9USXROMk15T1dSaU1tUTUKTVRJekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqcklRZWh3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQmZ2MU9WUEVRU0poZ3FuUmJNYmpHejNieDI0SVdsajYzay9tVFd4dFJnd3Q0RENmdm1VdUp5CmJzbTUwQ2ZXMjFNUTZ3aEdCSWYyTzZEbXhpSHlkQm81R3ZiTDR4RCtTR29jMkM0TFIrTE9UdlFXWERFQ2REZUUKRHI5Y1JOWEpxbFNybUFCcFNUczFYS3pVdGxRZ0lHY2tzL2F6QmIyYUlGVVNxSW50WlpaaFdsaHdpNGJQV2xGRQpxRnFzY0x1TFRZNWMzS3h0eDVqQzczQnBsNnRlQzI3NnRNYjJLQTRHZkFiN2hOUjc5cFF3d093c1ZkQ2tFbEVuCnN0S3Iwcld0bStOMjdvOStDdkYzQnVId20zNzUweW1qYkRnMWFob0FpL0VQMFBjcEkzT2pOa1JlelZTZklPU2sKSTZES1o5SkhXUlpmY1NOdklkcXcrZzZxZ3BmalY3NSsKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:01 GMT
+      - Thu, 16 Nov 2023 16:03:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77b4755f-ecd7-4296-9bdf-2e0841dbf915
+      - fa43de5e-197f-418a-80ae-c48a914a1d49
     status: 200 OK
     code: 200
     duration: ""
@@ -972,52 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "113"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3d0a4a83-32a3-4a60-9c42-f693084ff1c7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "113"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:01 GMT
+      - Thu, 16 Nov 2023 16:03:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bc8af99-95eb-4504-822c-9f24f41c88fc
+      - 36400a4a-0013-4f1f-9c3f-bcb660dffcbc
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +939,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1249"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:03:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 33038dbd-246a-4f06-b797-626f2d9ed0df
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQk16TG1saXgvMXVMR2Y4VU03UDgzY3pkbFNrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRZd016QTNXaGNOTXpNeE1URXpNVFl3TXpBM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUorWXE1SFAvdlNHWWxtMkp2WnVHK0xkRDVBbENQWFRDR3R0Y1RxLzRjdUhEQzI4SlRmdVlVWWsKeXg2cURpMUptZnVoc1ZWcFBiMHR5dHFES3MyTG1jMEd3QU9qcDFnS0FWYkRmM2ZyWkNYYTduRS9wU0dLSmZaNQpLSEU5RHlqOGVmR051d1Y2dlJTdzkrdHBwZjZ1anRJWnc1ek5MRHpIRUpoajQyMDN6eFFHQ3ZBUlVVdDZWY0dYCnpRamg5czl6V2dRRGxSd2RmM1V0c2J2SThuTUh4djdRUCs3TUdZRm1ZTGRpbjhFQWlScnBDZEJkNVdjVmxjTVAKeG9CcndmbE13T2V4T0xLRDZDUElzRGw3ckd4cFpKU0x2NmsrT28vLzY2bW05V2VoUUZJR3NJZURTMUpuUGFQeQpPUmpmWGI4K0ZNckNtZ0N6Qzl4TktMRlRQdWZxeGI4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0TkRBME16UXlaamd0TW1Jek9DMDBPREkyTFdFMk9USXROMk15T1dSaU1tUTUKTVRJekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqcklRZWh3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQmZ2MU9WUEVRU0poZ3FuUmJNYmpHejNieDI0SVdsajYzay9tVFd4dFJnd3Q0RENmdm1VdUp5CmJzbTUwQ2ZXMjFNUTZ3aEdCSWYyTzZEbXhpSHlkQm81R3ZiTDR4RCtTR29jMkM0TFIrTE9UdlFXWERFQ2REZUUKRHI5Y1JOWEpxbFNybUFCcFNUczFYS3pVdGxRZ0lHY2tzL2F6QmIyYUlGVVNxSW50WlpaaFdsaHdpNGJQV2xGRQpxRnFzY0x1TFRZNWMzS3h0eDVqQzczQnBsNnRlQzI3NnRNYjJLQTRHZkFiN2hOUjc5cFF3d093c1ZkQ2tFbEVuCnN0S3Iwcld0bStOMjdvOStDdkYzQnVId20zNzUweW1qYkRnMWFob0FpL0VQMFBjcEkzT2pOa1JlelZTZklPU2sKSTZES1o5SkhXUlpmY1NOdklkcXcrZzZxZ3BmalY3NSsKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1845"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:03:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e960ae08-1334-4338-8e2b-b20c8c4ad74d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "113"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:02 GMT
+      - Thu, 16 Nov 2023 16:03:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82fc0f66-e0f0-4042-834f-3db4c3736d5f
+      - 3482491c-aeac-4eb7-bcb9-da53b161ebdf
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "113"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:02 GMT
+      - Thu, 16 Nov 2023 16:03:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c43217be-cbb2-490e-ab93-98b4902d067f
+      - 2c5aa255-dcd3-4ced-b41f-2027ccd5cf8f
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "113"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:02 GMT
+      - Thu, 16 Nov 2023 16:03:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20bd7850-995a-4e5a-9b64-8dbbc3384321
+      - 16352db1-7729-48e2-8e00-e6cd0144c529
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,85 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1203"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b22ae59d-3581-4f58-8d90-4b028136bbef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVRTlwRzhjdWRaTnhmQy9FRG9FWGVQRWlMWWI4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1URTFNQjRYCkRUSXpNVEV3TWpFNE5UQTFORm9YRFRNek1UQXpNREU0TlRBMU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRFMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXU5VllmRnNveXBESWtLekkvVXBwMHoxOFE4ZldxakdYTUpXYTlDRXJsTVJzMG5INEh0SWcKbExXNFpyd3lxbm1YZGhTZjhpNEJvMitaSjM0eUlmRktsUGdtcWFvYk1keCs4MlRoVFFNek9NUE96TFJzWTdoNApWdDJja2hsZ2RzTy9IOVg4Ti8yb1k5aGt5cklCZzAxRlk5dXFEZTMzaU9iTittTm50djcrSGU3RmZ1RGhGcThCClpPY0t0bGlEU3dYVEc4SEp6a29XTWRWVDBoSzhkUUpoWXlGamFERlpwdEQrYXpMcjB0L3A5amZYL05WZHZHREwKaVdsQmhIZVRSRXpKd1UyeWY3YkJud25oaU9jM0o0NVR5M1JPK2RieVRrZTFrRlMrSTdoSnIxNXJZY0NscDFMQQpGODZEVE1ZSzZRdWxlQ05sWnF1LzdLM1prbkRJNmpKTjF3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRXhOWUk4Y25jdE1HVTNaVGM0TldJdE5Ea3pNeTAwTnpJd0xUa3pNVGN0TkRBeE56SXkKTnpjeE9XVXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJMSllod1F6bjgxek1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFIbW1iOFgyc2x0RU1TU1dFU2FBYk54M1hWayszRXBaNGRSZVJmNHpWeWNiODNYUDZhCjB5aFErS1F5UURxL0M0QXNyUzZ2M2ZYeTk4VmhDdUFWMDJlMlEvSTB1eGVhWEdLVHdrd005R0dRR3czQVdIdHUKY3hseXltd043QmF6cjZSU1g0SndtUUdxajdsd3R2WElvUTNjeHV1WUFzMjRmbnJGZDJVY2E0MnBodUIxQWZQagpqeitORmxyNDZESmVLdXRIbmt5Q1ZsZ0hrNkE3Z0laQXFXL05sR2hDWXRTK21xYVovL0NCeGNVdkNJWlNmYnEyClBPQ3FYd0hib0RaSWllNmlhY1IrUEdmUGxTWTFVT1Y5MWE3Y2FGb1ZxTzN1b1BFeWZhVHp1Rm5pYkc0cVNhVjIKQWlyalJYMndUMVZWMzBMY1pTVGMzUGRxeFZwTnZoZlB5S1o4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1847"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6525194d-5b48-4e59-911b-4429dad8d06e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "113"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:03 GMT
+      - Thu, 16 Nov 2023 16:03:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cee4006-9e68-4b0c-b19d-55fe1bd3a733
+      - 14602010-f67d-41db-9ec3-e6b5338f9a26
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "113"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:03 GMT
+      - Thu, 16 Nov 2023 16:03:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97503e49-e25f-4575-8246-b6bb9f75d1e5
+      - 31082aa0-936e-4539-b59b-9045242f516f
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1170,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1249"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:03:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 439b394d-4410-4759-840f-e22098ac6ee5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQk16TG1saXgvMXVMR2Y4VU03UDgzY3pkbFNrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRZd016QTNXaGNOTXpNeE1URXpNVFl3TXpBM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUorWXE1SFAvdlNHWWxtMkp2WnVHK0xkRDVBbENQWFRDR3R0Y1RxLzRjdUhEQzI4SlRmdVlVWWsKeXg2cURpMUptZnVoc1ZWcFBiMHR5dHFES3MyTG1jMEd3QU9qcDFnS0FWYkRmM2ZyWkNYYTduRS9wU0dLSmZaNQpLSEU5RHlqOGVmR051d1Y2dlJTdzkrdHBwZjZ1anRJWnc1ek5MRHpIRUpoajQyMDN6eFFHQ3ZBUlVVdDZWY0dYCnpRamg5czl6V2dRRGxSd2RmM1V0c2J2SThuTUh4djdRUCs3TUdZRm1ZTGRpbjhFQWlScnBDZEJkNVdjVmxjTVAKeG9CcndmbE13T2V4T0xLRDZDUElzRGw3ckd4cFpKU0x2NmsrT28vLzY2bW05V2VoUUZJR3NJZURTMUpuUGFQeQpPUmpmWGI4K0ZNckNtZ0N6Qzl4TktMRlRQdWZxeGI4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0TkRBME16UXlaamd0TW1Jek9DMDBPREkyTFdFMk9USXROMk15T1dSaU1tUTUKTVRJekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqcklRZWh3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQmZ2MU9WUEVRU0poZ3FuUmJNYmpHejNieDI0SVdsajYzay9tVFd4dFJnd3Q0RENmdm1VdUp5CmJzbTUwQ2ZXMjFNUTZ3aEdCSWYyTzZEbXhpSHlkQm81R3ZiTDR4RCtTR29jMkM0TFIrTE9UdlFXWERFQ2REZUUKRHI5Y1JOWEpxbFNybUFCcFNUczFYS3pVdGxRZ0lHY2tzL2F6QmIyYUlGVVNxSW50WlpaaFdsaHdpNGJQV2xGRQpxRnFzY0x1TFRZNWMzS3h0eDVqQzczQnBsNnRlQzI3NnRNYjJLQTRHZkFiN2hOUjc5cFF3d093c1ZkQ2tFbEVuCnN0S3Iwcld0bStOMjdvOStDdkYzQnVId20zNzUweW1qYkRnMWFob0FpL0VQMFBjcEkzT2pOa1JlelZTZklPU2sKSTZES1o5SkhXUlpmY1NOdklkcXcrZzZxZ3BmalY3NSsKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1845"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:03:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a990d2bd-b961-4d12-8fe5-d5a018e87452
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "113"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:03 GMT
+      - Thu, 16 Nov 2023 16:03:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f1f887e-f119-4b69-8b65-7975bea5747d
+      - 27e131f6-66ac-4d69-afea-4d25088dee37
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,19 +1269,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "1203"
+      - "117"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:04 GMT
+      - Thu, 16 Nov 2023 16:03:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1355619-ff7f-4769-9ed7-d3c73df6895f
+      - 80882f8f-2524-4b1c-bd10-8c711b96440f
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,7 +1302,73 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2/databases/test-terraform
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/databases?name=test-terraform&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "117"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:03:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 553ed988-4179-4570-8ea9-0fe462942a70
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1249"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:03:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 56eb09f2-f39e-4723-a2dc-17120bf66536
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123/databases/test-terraform
     method: DELETE
   response:
     body: ""
@@ -1345,7 +1378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:04 GMT
+      - Thu, 16 Nov 2023 16:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f089320e-d37d-4264-b557-0be624aab2d5
+      - 99d96a54-e90b-4b67-9ac9-75ca1baa9398
     status: 204 No Content
     code: 204
     duration: ""
@@ -1366,19 +1399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:04 GMT
+      - Thu, 16 Nov 2023 16:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da5bf097-1705-4138-a53f-7314475993ae
+      - fb75f3fe-02ed-45ea-b76b-8deef5f2e45e
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,19 +1432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:04 GMT
+      - Thu, 16 Nov 2023 16:03:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bad658a-f3b8-412d-b2b0-3fec900bcf0a
+      - 54f759bd-0104-4002-883d-33a384400abc
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,19 +1465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1206"
+      - "1252"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:05 GMT
+      - Thu, 16 Nov 2023 16:03:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f68636c3-f62a-4d11-97be-3bb4dfabe02d
+      - 9721f157-8b0a-41b1-a74e-a8d926f31b27
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,19 +1498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:15.590460Z","retention":7},"created_at":"2023-11-02T18:50:15.590460Z","endpoint":{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867},"endpoints":[{"id":"e99646a0-bbfe-48cd-bcfd-b483819281be","ip":"51.159.205.115","load_balancer":{},"name":null,"port":7867}],"engine":"PostgreSQL-15","id":"0e7e785b-4933-4720-9317-4017227719e2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:35.772983Z","retention":7},"created_at":"2023-11-16T16:00:35.772983Z","endpoint":{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349},"endpoints":[{"id":"615a062a-4d0e-43ea-a950-c4377db21e0a","ip":"195.154.197.0","load_balancer":{},"name":null,"port":14349}],"engine":"PostgreSQL-15","id":"404342f8-2b38-4826-a692-7c29db2d9123","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1206"
+      - "1252"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:05 GMT
+      - Thu, 16 Nov 2023 16:03:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a937c0a-db78-496d-a8f2-6480c3a5df2b
+      - c1b4d543-ad8d-4f0f-a126-f452d3cc892b
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,10 +1531,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"0e7e785b-4933-4720-9317-4017227719e2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"404342f8-2b38-4826-a692-7c29db2d9123","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1510,7 +1543,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:35 GMT
+      - Thu, 16 Nov 2023 16:04:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1520,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e76acd11-aaea-44e5-8cd6-2349d43942d8
+      - 9bcff4e1-c719-48e3-8802-3e41869e4b6a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1531,10 +1564,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0e7e785b-4933-4720-9317-4017227719e2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/404342f8-2b38-4826-a692-7c29db2d9123
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"0e7e785b-4933-4720-9317-4017227719e2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"404342f8-2b38-4826-a692-7c29db2d9123","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1543,7 +1576,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:35 GMT
+      - Thu, 16 Nov 2023 16:04:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1553,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0afd2d4a-eb53-44f1-9114-9a03f5287335
+      - f88223b8-2c30-464e-a812-cc3e4783856f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-instance-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-instance-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:32 GMT
+      - Thu, 16 Nov 2023 15:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d7b48c3-380d-4f52-8c78-8030af5b58bd
+      - 76a9848a-e957-4766-ae28-d8679a6a52bd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"data-rdb-test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"data-rdb-test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "739"
+      - "766"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:43 GMT
+      - Thu, 16 Nov 2023 16:00:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 123ae0f0-ebbf-4873-8332-9ce8bce0459e
+      - fa07a4ba-0077-4ee4-b0f9-79cb13104c72
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "739"
+      - "766"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:43 GMT
+      - Thu, 16 Nov 2023 16:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 108faad0-accd-4c46-bf4d-5a0bbdd2d669
+      - 221d7222-a492-49e7-96d8-69aa3a4725c3
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "739"
+      - "766"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:13 GMT
+      - Thu, 16 Nov 2023 16:01:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af6854d2-448f-4d2e-883f-5ce01d6317b8
+      - 098da244-1fc5-4959-9516-4aa4fc3f4ed7
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "739"
+      - "766"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:43 GMT
+      - Thu, 16 Nov 2023 16:02:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2af8ce14-0572-4715-8269-ea037b774c25
+      - 447a0454-fc5d-42ef-b38d-caf96dcdf2c7
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "739"
+      - "766"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:13 GMT
+      - Thu, 16 Nov 2023 16:02:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4811541-9aff-44ee-9850-77bcebe946d9
+      - 4c051272-ceb5-4e11-9431-7ad6e69c11b5
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "739"
+      - "766"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:44 GMT
+      - Thu, 16 Nov 2023 16:03:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74b78798-5d30-4c8e-8c9c-444579ea1fae
+      - 2e075018-8a16-4099-8e38-2b5960e6c39a
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1212"
+      - "1041"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:14 GMT
+      - Thu, 16 Nov 2023 16:03:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee00230f-62c7-4c9d-8be2-317acb023e05
+      - b691e2ab-4306-4447-a41e-746241555d55
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1260"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2ea44e9b-c930-46bb-ab7c-88a72d847d14
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1212"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:14 GMT
+      - Thu, 16 Nov 2023 16:04:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05f3754d-0f6d-4b1a-ba99-d9ed39da4960
+      - 6f942915-e7b8-4c16-81bb-accfc353192d
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1212"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:14 GMT
+      - Thu, 16 Nov 2023 16:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc9cbc48-b0c1-4831-bc51-2523ec03e249
+      - 46fdc903-61f8-48d2-8549-7682d14ec55d
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTBYNVdidFcrR2JJUW94WWtRR1dxaGtCSjFBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXlORm9YRFRNek1URXhNekUyTURNeU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNBMWl1eEJYV3IxQmJYT3Y1bllhRXlYMElQaVZCWjN4MEM1a1pRbDVPdGlnM3lhZHdPcEEKMVpvRGp0V3IyeXhRN3V1QnhEazFuVmlLbEt6TlBjb2QrSDFrZUlpYlptalpXL01vQnVSd3p1ajROTlRHeW9jMQplMU01L0hUSm5FYTVtM3B5YTVWeEdkRGhRQTRKRGI0TGl0ekNNYzdyQU9ZTWJSdGNzQ2xDdHRqeGhJWmhPaGttClpVMlg5T25BUytBNVRGR1d3VGhuOFBFQ0dYRzd0ekNmdXAzVE00eWlXSmFFUFA0aE9UYU4vWThOVTZpaVRycEoKQ2lQczY5VXJWaHlrczIrTTJvRE82VHIyZnBTVU42TEhqVHlrd21IZWVGb1o3Um5mYnJYS3RrQ0d3aEVaS3o0QgozWGRHVGVEeHpmM2RkWi9Oa2p2aFFUZFRuc0ZNUTlaNit3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWmxORE5oTkdRdE5EbGpNUzAwTVRnd0xUZzNNVGt0TkRBd09ETmgKTW1NellXVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrOXlod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNPTGd2bHZGd1JROGI4NFNwTFp4cFRHWlRWK2VrelJpZExKT29UV1ZvaVlLMVFVRzNQCm1Jaklxam15aDg5N3N2TXFSN05lWndLaG44aFc1Tm4raG5uUXk4L0lySjFpZE8yaWFVQWlWTUx6TGdIUkZMNncKbVJYN1BxYjh5RVVDNDRTQ2x4OUY5RkJzdGpkVUtLYTlPeCt1Ulpva0lVU0ZsNmt5VWJ1dkQ5Z1JwNTUrOTlyOAoxSTRyT1Jna2NGbEdJa2cvVklrR2YyQ25KOTQxZ2RYWFZUOG9wNnZYN0hEQjRIMXI1UDJRbG50ZXJKKzM5cjltCmNwQlFRMWtTdjE3ZWFtampyYVR5eGRteDQvUEhsR1hvS28wdWNOcktjdjg0Mi8xWDk4aTF5cEFFNnMvaFM5WU4Kck1PWnVhUUxUZmhUVFRaVXpFbUVCdWx3YW91SVIrMGVqRDJ3Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:14 GMT
+      - Thu, 16 Nov 2023 16:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70ce0716-f987-4cd3-8407-507ce7636723
+      - 0f30c22a-f24b-48e1-ba36-48d79058406a
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1212"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:14 GMT
+      - Thu, 16 Nov 2023 16:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5403608a-1bc6-4675-99f2-c921757305fc
+      - fcadffe7-16dd-469f-b15c-4d32797ba8c5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTBYNVdidFcrR2JJUW94WWtRR1dxaGtCSjFBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXlORm9YRFRNek1URXhNekUyTURNeU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNBMWl1eEJYV3IxQmJYT3Y1bllhRXlYMElQaVZCWjN4MEM1a1pRbDVPdGlnM3lhZHdPcEEKMVpvRGp0V3IyeXhRN3V1QnhEazFuVmlLbEt6TlBjb2QrSDFrZUlpYlptalpXL01vQnVSd3p1ajROTlRHeW9jMQplMU01L0hUSm5FYTVtM3B5YTVWeEdkRGhRQTRKRGI0TGl0ekNNYzdyQU9ZTWJSdGNzQ2xDdHRqeGhJWmhPaGttClpVMlg5T25BUytBNVRGR1d3VGhuOFBFQ0dYRzd0ekNmdXAzVE00eWlXSmFFUFA0aE9UYU4vWThOVTZpaVRycEoKQ2lQczY5VXJWaHlrczIrTTJvRE82VHIyZnBTVU42TEhqVHlrd21IZWVGb1o3Um5mYnJYS3RrQ0d3aEVaS3o0QgozWGRHVGVEeHpmM2RkWi9Oa2p2aFFUZFRuc0ZNUTlaNit3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWmxORE5oTkdRdE5EbGpNUzAwTVRnd0xUZzNNVGt0TkRBd09ETmgKTW1NellXVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrOXlod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNPTGd2bHZGd1JROGI4NFNwTFp4cFRHWlRWK2VrelJpZExKT29UV1ZvaVlLMVFVRzNQCm1Jaklxam15aDg5N3N2TXFSN05lWndLaG44aFc1Tm4raG5uUXk4L0lySjFpZE8yaWFVQWlWTUx6TGdIUkZMNncKbVJYN1BxYjh5RVVDNDRTQ2x4OUY5RkJzdGpkVUtLYTlPeCt1Ulpva0lVU0ZsNmt5VWJ1dkQ5Z1JwNTUrOTlyOAoxSTRyT1Jna2NGbEdJa2cvVklrR2YyQ25KOTQxZ2RYWFZUOG9wNnZYN0hEQjRIMXI1UDJRbG50ZXJKKzM5cjltCmNwQlFRMWtTdjE3ZWFtampyYVR5eGRteDQvUEhsR1hvS28wdWNOcktjdjg0Mi8xWDk4aTF5cEFFNnMvaFM5WU4Kck1PWnVhUUxUZmhUVFRaVXpFbUVCdWx3YW91SVIrMGVqRDJ3Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1849"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df60d7ce-f18a-4677-ba7a-7d8ad615b7d0
     status: 200 OK
     code: 200
     duration: ""
@@ -709,16 +775,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1244"
+      - "1293"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:14 GMT
+      - Thu, 16 Nov 2023 16:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69c321bf-ddad-47fc-9edf-d5d80544e7b5
+      - ab5f32f3-652f-4ccb-9121-78421da8a893
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:14 GMT
+      - Thu, 16 Nov 2023 16:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 721a4009-fbf0-4a18-957f-e902e63bc0d2
+      - 6b824ac1-2fe2-4483-ae37-d2b7a2396e99
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTBYNVdidFcrR2JJUW94WWtRR1dxaGtCSjFBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXlORm9YRFRNek1URXhNekUyTURNeU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNBMWl1eEJYV3IxQmJYT3Y1bllhRXlYMElQaVZCWjN4MEM1a1pRbDVPdGlnM3lhZHdPcEEKMVpvRGp0V3IyeXhRN3V1QnhEazFuVmlLbEt6TlBjb2QrSDFrZUlpYlptalpXL01vQnVSd3p1ajROTlRHeW9jMQplMU01L0hUSm5FYTVtM3B5YTVWeEdkRGhRQTRKRGI0TGl0ekNNYzdyQU9ZTWJSdGNzQ2xDdHRqeGhJWmhPaGttClpVMlg5T25BUytBNVRGR1d3VGhuOFBFQ0dYRzd0ekNmdXAzVE00eWlXSmFFUFA0aE9UYU4vWThOVTZpaVRycEoKQ2lQczY5VXJWaHlrczIrTTJvRE82VHIyZnBTVU42TEhqVHlrd21IZWVGb1o3Um5mYnJYS3RrQ0d3aEVaS3o0QgozWGRHVGVEeHpmM2RkWi9Oa2p2aFFUZFRuc0ZNUTlaNit3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWmxORE5oTkdRdE5EbGpNUzAwTVRnd0xUZzNNVGt0TkRBd09ETmgKTW1NellXVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrOXlod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNPTGd2bHZGd1JROGI4NFNwTFp4cFRHWlRWK2VrelJpZExKT29UV1ZvaVlLMVFVRzNQCm1Jaklxam15aDg5N3N2TXFSN05lWndLaG44aFc1Tm4raG5uUXk4L0lySjFpZE8yaWFVQWlWTUx6TGdIUkZMNncKbVJYN1BxYjh5RVVDNDRTQ2x4OUY5RkJzdGpkVUtLYTlPeCt1Ulpva0lVU0ZsNmt5VWJ1dkQ5Z1JwNTUrOTlyOAoxSTRyT1Jna2NGbEdJa2cvVklrR2YyQ25KOTQxZ2RYWFZUOG9wNnZYN0hEQjRIMXI1UDJRbG50ZXJKKzM5cjltCmNwQlFRMWtTdjE3ZWFtampyYVR5eGRteDQvUEhsR1hvS28wdWNOcktjdjg0Mi8xWDk4aTF5cEFFNnMvaFM5WU4Kck1PWnVhUUxUZmhUVFRaVXpFbUVCdWx3YW91SVIrMGVqRDJ3Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1212"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:14 GMT
+      - Thu, 16 Nov 2023 16:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3d44bc9-a9d8-4796-b852-c3200504c03f
+      - 501e0080-b506-4f67-bc73-258aa9b010f2
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:14 GMT
+      - Thu, 16 Nov 2023 16:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0634089c-09ef-4b68-a2ce-aa51fe8463c6
+      - 5730226d-668e-4f6d-9643-24f352c9e059
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1212"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
+      - Thu, 16 Nov 2023 16:04:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,40 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 031fbef5-7060-4e64-b4ed-1a5e126e4a58
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1212"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6aef5e5d-c701-467b-9db1-acd3d025329f
+      - 7ea86646-c7ef-41d3-b63b-aff53b325579
     status: 200 OK
     code: 200
     duration: ""
@@ -907,16 +940,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1244"
+      - "1293"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
+      - Thu, 16 Nov 2023 16:04:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cad5df8-1ed9-4919-bb6e-2613bc588d71
+      - 9b86d64b-6481-4051-88b7-ca75c5cb9d59
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTBYNVdidFcrR2JJUW94WWtRR1dxaGtCSjFBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXlORm9YRFRNek1URXhNekUyTURNeU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNBMWl1eEJYV3IxQmJYT3Y1bllhRXlYMElQaVZCWjN4MEM1a1pRbDVPdGlnM3lhZHdPcEEKMVpvRGp0V3IyeXhRN3V1QnhEazFuVmlLbEt6TlBjb2QrSDFrZUlpYlptalpXL01vQnVSd3p1ajROTlRHeW9jMQplMU01L0hUSm5FYTVtM3B5YTVWeEdkRGhRQTRKRGI0TGl0ekNNYzdyQU9ZTWJSdGNzQ2xDdHRqeGhJWmhPaGttClpVMlg5T25BUytBNVRGR1d3VGhuOFBFQ0dYRzd0ekNmdXAzVE00eWlXSmFFUFA0aE9UYU4vWThOVTZpaVRycEoKQ2lQczY5VXJWaHlrczIrTTJvRE82VHIyZnBTVU42TEhqVHlrd21IZWVGb1o3Um5mYnJYS3RrQ0d3aEVaS3o0QgozWGRHVGVEeHpmM2RkWi9Oa2p2aFFUZFRuc0ZNUTlaNit3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWmxORE5oTkdRdE5EbGpNUzAwTVRnd0xUZzNNVGt0TkRBd09ETmgKTW1NellXVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrOXlod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNPTGd2bHZGd1JROGI4NFNwTFp4cFRHWlRWK2VrelJpZExKT29UV1ZvaVlLMVFVRzNQCm1Jaklxam15aDg5N3N2TXFSN05lWndLaG44aFc1Tm4raG5uUXk4L0lySjFpZE8yaWFVQWlWTUx6TGdIUkZMNncKbVJYN1BxYjh5RVVDNDRTQ2x4OUY5RkJzdGpkVUtLYTlPeCt1Ulpva0lVU0ZsNmt5VWJ1dkQ5Z1JwNTUrOTlyOAoxSTRyT1Jna2NGbEdJa2cvVklrR2YyQ25KOTQxZ2RYWFZUOG9wNnZYN0hEQjRIMXI1UDJRbG50ZXJKKzM5cjltCmNwQlFRMWtTdjE3ZWFtampyYVR5eGRteDQvUEhsR1hvS28wdWNOcktjdjg0Mi8xWDk4aTF5cEFFNnMvaFM5WU4Kck1PWnVhUUxUZmhUVFRaVXpFbUVCdWx3YW91SVIrMGVqRDJ3Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
+      - Thu, 16 Nov 2023 16:04:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 144aec37-1738-42d5-8e8c-d025ea5ce16d
+      - a0ff8490-7a33-4c79-a259-272a90c8faa6
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1212"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
+      - Thu, 16 Nov 2023 16:04:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5015b28a-07f0-4c81-835c-be3f5fdca524
+      - 9c15a434-3d9c-4598-b4a3-d927e15730ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTBYNVdidFcrR2JJUW94WWtRR1dxaGtCSjFBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXlORm9YRFRNek1URXhNekUyTURNeU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNBMWl1eEJYV3IxQmJYT3Y1bllhRXlYMElQaVZCWjN4MEM1a1pRbDVPdGlnM3lhZHdPcEEKMVpvRGp0V3IyeXhRN3V1QnhEazFuVmlLbEt6TlBjb2QrSDFrZUlpYlptalpXL01vQnVSd3p1ajROTlRHeW9jMQplMU01L0hUSm5FYTVtM3B5YTVWeEdkRGhRQTRKRGI0TGl0ekNNYzdyQU9ZTWJSdGNzQ2xDdHRqeGhJWmhPaGttClpVMlg5T25BUytBNVRGR1d3VGhuOFBFQ0dYRzd0ekNmdXAzVE00eWlXSmFFUFA0aE9UYU4vWThOVTZpaVRycEoKQ2lQczY5VXJWaHlrczIrTTJvRE82VHIyZnBTVU42TEhqVHlrd21IZWVGb1o3Um5mYnJYS3RrQ0d3aEVaS3o0QgozWGRHVGVEeHpmM2RkWi9Oa2p2aFFUZFRuc0ZNUTlaNit3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWmxORE5oTkdRdE5EbGpNUzAwTVRnd0xUZzNNVGt0TkRBd09ETmgKTW1NellXVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrOXlod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNPTGd2bHZGd1JROGI4NFNwTFp4cFRHWlRWK2VrelJpZExKT29UV1ZvaVlLMVFVRzNQCm1Jaklxam15aDg5N3N2TXFSN05lWndLaG44aFc1Tm4raG5uUXk4L0lySjFpZE8yaWFVQWlWTUx6TGdIUkZMNncKbVJYN1BxYjh5RVVDNDRTQ2x4OUY5RkJzdGpkVUtLYTlPeCt1Ulpva0lVU0ZsNmt5VWJ1dkQ5Z1JwNTUrOTlyOAoxSTRyT1Jna2NGbEdJa2cvVklrR2YyQ25KOTQxZ2RYWFZUOG9wNnZYN0hEQjRIMXI1UDJRbG50ZXJKKzM5cjltCmNwQlFRMWtTdjE3ZWFtampyYVR5eGRteDQvUEhsR1hvS28wdWNOcktjdjg0Mi8xWDk4aTF5cEFFNnMvaFM5WU4Kck1PWnVhUUxUZmhUVFRaVXpFbUVCdWx3YW91SVIrMGVqRDJ3Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
+      - Thu, 16 Nov 2023 16:04:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b963aaec-c452-4866-a0ff-4dc7eadc2e27
+      - 18c36acc-d594-464b-977e-1fbd4b778583
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1212"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
+      - Thu, 16 Nov 2023 16:04:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9163f2a2-e268-40c1-9958-253788a31490
+      - fcff81ca-2ace-44b0-8745-19d3099dc331
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTBYNVdidFcrR2JJUW94WWtRR1dxaGtCSjFBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXlORm9YRFRNek1URXhNekUyTURNeU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNBMWl1eEJYV3IxQmJYT3Y1bllhRXlYMElQaVZCWjN4MEM1a1pRbDVPdGlnM3lhZHdPcEEKMVpvRGp0V3IyeXhRN3V1QnhEazFuVmlLbEt6TlBjb2QrSDFrZUlpYlptalpXL01vQnVSd3p1ajROTlRHeW9jMQplMU01L0hUSm5FYTVtM3B5YTVWeEdkRGhRQTRKRGI0TGl0ekNNYzdyQU9ZTWJSdGNzQ2xDdHRqeGhJWmhPaGttClpVMlg5T25BUytBNVRGR1d3VGhuOFBFQ0dYRzd0ekNmdXAzVE00eWlXSmFFUFA0aE9UYU4vWThOVTZpaVRycEoKQ2lQczY5VXJWaHlrczIrTTJvRE82VHIyZnBTVU42TEhqVHlrd21IZWVGb1o3Um5mYnJYS3RrQ0d3aEVaS3o0QgozWGRHVGVEeHpmM2RkWi9Oa2p2aFFUZFRuc0ZNUTlaNit3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWmxORE5oTkdRdE5EbGpNUzAwTVRnd0xUZzNNVGt0TkRBd09ETmgKTW1NellXVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrOXlod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNPTGd2bHZGd1JROGI4NFNwTFp4cFRHWlRWK2VrelJpZExKT29UV1ZvaVlLMVFVRzNQCm1Jaklxam15aDg5N3N2TXFSN05lWndLaG44aFc1Tm4raG5uUXk4L0lySjFpZE8yaWFVQWlWTUx6TGdIUkZMNncKbVJYN1BxYjh5RVVDNDRTQ2x4OUY5RkJzdGpkVUtLYTlPeCt1Ulpva0lVU0ZsNmt5VWJ1dkQ5Z1JwNTUrOTlyOAoxSTRyT1Jna2NGbEdJa2cvVklrR2YyQ25KOTQxZ2RYWFZUOG9wNnZYN0hEQjRIMXI1UDJRbG50ZXJKKzM5cjltCmNwQlFRMWtTdjE3ZWFtampyYVR5eGRteDQvUEhsR1hvS28wdWNOcktjdjg0Mi8xWDk4aTF5cEFFNnMvaFM5WU4Kck1PWnVhUUxUZmhUVFRaVXpFbUVCdWx3YW91SVIrMGVqRDJ3Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:04:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,40 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0da8c841-4930-4761-abc7-635248e97757
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1212"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 696e6819-3470-431e-a9fd-b81e8d7877f6
+      - 52cbce3c-1a13-4e60-a2f7-4f6515417793
     status: 200 OK
     code: 200
     duration: ""
@@ -1138,16 +1138,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1244"
+      - "1293"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:04:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c692e147-0887-467c-abe0-2f451064e86c
+      - 2b23e593-2ff7-4bdc-9cb2-2d1abb09630b
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,19 +1168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:04:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4da73567-2424-43a8-a125-d103f22ce8e2
+      - 6b0ec79b-0d41-4efd-b8bf-8b62f0b526d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTBYNVdidFcrR2JJUW94WWtRR1dxaGtCSjFBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXlORm9YRFRNek1URXhNekUyTURNeU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNBMWl1eEJYV3IxQmJYT3Y1bllhRXlYMElQaVZCWjN4MEM1a1pRbDVPdGlnM3lhZHdPcEEKMVpvRGp0V3IyeXhRN3V1QnhEazFuVmlLbEt6TlBjb2QrSDFrZUlpYlptalpXL01vQnVSd3p1ajROTlRHeW9jMQplMU01L0hUSm5FYTVtM3B5YTVWeEdkRGhRQTRKRGI0TGl0ekNNYzdyQU9ZTWJSdGNzQ2xDdHRqeGhJWmhPaGttClpVMlg5T25BUytBNVRGR1d3VGhuOFBFQ0dYRzd0ekNmdXAzVE00eWlXSmFFUFA0aE9UYU4vWThOVTZpaVRycEoKQ2lQczY5VXJWaHlrczIrTTJvRE82VHIyZnBTVU42TEhqVHlrd21IZWVGb1o3Um5mYnJYS3RrQ0d3aEVaS3o0QgozWGRHVGVEeHpmM2RkWi9Oa2p2aFFUZFRuc0ZNUTlaNit3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWmxORE5oTkdRdE5EbGpNUzAwTVRnd0xUZzNNVGt0TkRBd09ETmgKTW1NellXVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrOXlod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNPTGd2bHZGd1JROGI4NFNwTFp4cFRHWlRWK2VrelJpZExKT29UV1ZvaVlLMVFVRzNQCm1Jaklxam15aDg5N3N2TXFSN05lWndLaG44aFc1Tm4raG5uUXk4L0lySjFpZE8yaWFVQWlWTUx6TGdIUkZMNncKbVJYN1BxYjh5RVVDNDRTQ2x4OUY5RkJzdGpkVUtLYTlPeCt1Ulpva0lVU0ZsNmt5VWJ1dkQ5Z1JwNTUrOTlyOAoxSTRyT1Jna2NGbEdJa2cvVklrR2YyQ25KOTQxZ2RYWFZUOG9wNnZYN0hEQjRIMXI1UDJRbG50ZXJKKzM5cjltCmNwQlFRMWtTdjE3ZWFtampyYVR5eGRteDQvUEhsR1hvS28wdWNOcktjdjg0Mi8xWDk4aTF5cEFFNnMvaFM5WU4Kck1PWnVhUUxUZmhUVFRaVXpFbUVCdWx3YW91SVIrMGVqRDJ3Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1212"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:04:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76bdf95e-d59e-4c3a-bd07-2f4f72b86f70
+      - a5886965-94ad-49e7-b0c4-3e3b49ce9f5a
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:04:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1256,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d035f577-5cff-4bc6-9c05-efaca8475262
+      - b93083a5-3332-4c07-b4b6-5b8771982411
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTBYNVdidFcrR2JJUW94WWtRR1dxaGtCSjFBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXlORm9YRFRNek1URXhNekUyTURNeU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNBMWl1eEJYV3IxQmJYT3Y1bllhRXlYMElQaVZCWjN4MEM1a1pRbDVPdGlnM3lhZHdPcEEKMVpvRGp0V3IyeXhRN3V1QnhEazFuVmlLbEt6TlBjb2QrSDFrZUlpYlptalpXL01vQnVSd3p1ajROTlRHeW9jMQplMU01L0hUSm5FYTVtM3B5YTVWeEdkRGhRQTRKRGI0TGl0ekNNYzdyQU9ZTWJSdGNzQ2xDdHRqeGhJWmhPaGttClpVMlg5T25BUytBNVRGR1d3VGhuOFBFQ0dYRzd0ekNmdXAzVE00eWlXSmFFUFA0aE9UYU4vWThOVTZpaVRycEoKQ2lQczY5VXJWaHlrczIrTTJvRE82VHIyZnBTVU42TEhqVHlrd21IZWVGb1o3Um5mYnJYS3RrQ0d3aEVaS3o0QgozWGRHVGVEeHpmM2RkWi9Oa2p2aFFUZFRuc0ZNUTlaNit3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWmxORE5oTkdRdE5EbGpNUzAwTVRnd0xUZzNNVGt0TkRBd09ETmgKTW1NellXVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrOXlod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNPTGd2bHZGd1JROGI4NFNwTFp4cFRHWlRWK2VrelJpZExKT29UV1ZvaVlLMVFVRzNQCm1Jaklxam15aDg5N3N2TXFSN05lWndLaG44aFc1Tm4raG5uUXk4L0lySjFpZE8yaWFVQWlWTUx6TGdIUkZMNncKbVJYN1BxYjh5RVVDNDRTQ2x4OUY5RkJzdGpkVUtLYTlPeCt1Ulpva0lVU0ZsNmt5VWJ1dkQ5Z1JwNTUrOTlyOAoxSTRyT1Jna2NGbEdJa2cvVklrR2YyQ25KOTQxZ2RYWFZUOG9wNnZYN0hEQjRIMXI1UDJRbG50ZXJKKzM5cjltCmNwQlFRMWtTdjE3ZWFtampyYVR5eGRteDQvUEhsR1hvS28wdWNOcktjdjg0Mi8xWDk4aTF5cEFFNnMvaFM5WU4Kck1PWnVhUUxUZmhUVFRaVXpFbUVCdWx3YW91SVIrMGVqRDJ3Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1849"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5adbe67a-4d6b-4d87-a6a9-9aec83f08964
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1260"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3f593242-cc52-4a27-8592-a4eeeb0401ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1270,16 +1336,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1244"
+      - "1293"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:04:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3b1b3d4-63b5-4825-a282-ed86068b671b
+      - 3481f8e1-a06e-4c75-896f-02903fc7af8e
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,19 +1366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTBYNVdidFcrR2JJUW94WWtRR1dxaGtCSjFBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXlORm9YRFRNek1URXhNekUyTURNeU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNBMWl1eEJYV3IxQmJYT3Y1bllhRXlYMElQaVZCWjN4MEM1a1pRbDVPdGlnM3lhZHdPcEEKMVpvRGp0V3IyeXhRN3V1QnhEazFuVmlLbEt6TlBjb2QrSDFrZUlpYlptalpXL01vQnVSd3p1ajROTlRHeW9jMQplMU01L0hUSm5FYTVtM3B5YTVWeEdkRGhRQTRKRGI0TGl0ekNNYzdyQU9ZTWJSdGNzQ2xDdHRqeGhJWmhPaGttClpVMlg5T25BUytBNVRGR1d3VGhuOFBFQ0dYRzd0ekNmdXAzVE00eWlXSmFFUFA0aE9UYU4vWThOVTZpaVRycEoKQ2lQczY5VXJWaHlrczIrTTJvRE82VHIyZnBTVU42TEhqVHlrd21IZWVGb1o3Um5mYnJYS3RrQ0d3aEVaS3o0QgozWGRHVGVEeHpmM2RkWi9Oa2p2aFFUZFRuc0ZNUTlaNit3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWmxORE5oTkdRdE5EbGpNUzAwTVRnd0xUZzNNVGt0TkRBd09ETmgKTW1NellXVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrOXlod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNPTGd2bHZGd1JROGI4NFNwTFp4cFRHWlRWK2VrelJpZExKT29UV1ZvaVlLMVFVRzNQCm1Jaklxam15aDg5N3N2TXFSN05lWndLaG44aFc1Tm4raG5uUXk4L0lySjFpZE8yaWFVQWlWTUx6TGdIUkZMNncKbVJYN1BxYjh5RVVDNDRTQ2x4OUY5RkJzdGpkVUtLYTlPeCt1Ulpva0lVU0ZsNmt5VWJ1dkQ5Z1JwNTUrOTlyOAoxSTRyT1Jna2NGbEdJa2cvVklrR2YyQ25KOTQxZ2RYWFZUOG9wNnZYN0hEQjRIMXI1UDJRbG50ZXJKKzM5cjltCmNwQlFRMWtTdjE3ZWFtampyYVR5eGRteDQvUEhsR1hvS28wdWNOcktjdjg0Mi8xWDk4aTF5cEFFNnMvaFM5WU4Kck1PWnVhUUxUZmhUVFRaVXpFbUVCdWx3YW91SVIrMGVqRDJ3Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1212"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:04:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af2099ba-e9d6-4c8c-a09e-c216503343c6
+      - 7d873ff3-6c41-4736-a76f-fa47350af97a
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,19 +1399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1212"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:04:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e564304-fc23-4860-9261-7c17143c1062
+      - 07a2f4e3-ee0a-4b34-a940-461cac820bf8
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,19 +1432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTBYNVdidFcrR2JJUW94WWtRR1dxaGtCSjFBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXlORm9YRFRNek1URXhNekUyTURNeU5Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNBMWl1eEJYV3IxQmJYT3Y1bllhRXlYMElQaVZCWjN4MEM1a1pRbDVPdGlnM3lhZHdPcEEKMVpvRGp0V3IyeXhRN3V1QnhEazFuVmlLbEt6TlBjb2QrSDFrZUlpYlptalpXL01vQnVSd3p1ajROTlRHeW9jMQplMU01L0hUSm5FYTVtM3B5YTVWeEdkRGhRQTRKRGI0TGl0ekNNYzdyQU9ZTWJSdGNzQ2xDdHRqeGhJWmhPaGttClpVMlg5T25BUytBNVRGR1d3VGhuOFBFQ0dYRzd0ekNmdXAzVE00eWlXSmFFUFA0aE9UYU4vWThOVTZpaVRycEoKQ2lQczY5VXJWaHlrczIrTTJvRE82VHIyZnBTVU42TEhqVHlrd21IZWVGb1o3Um5mYnJYS3RrQ0d3aEVaS3o0QgozWGRHVGVEeHpmM2RkWi9Oa2p2aFFUZFRuc0ZNUTlaNit3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFpXWmxORE5oTkdRdE5EbGpNUzAwTVRnd0xUZzNNVGt0TkRBd09ETmgKTW1NellXVmxMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrOXlod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNPTGd2bHZGd1JROGI4NFNwTFp4cFRHWlRWK2VrelJpZExKT29UV1ZvaVlLMVFVRzNQCm1Jaklxam15aDg5N3N2TXFSN05lWndLaG44aFc1Tm4raG5uUXk4L0lySjFpZE8yaWFVQWlWTUx6TGdIUkZMNncKbVJYN1BxYjh5RVVDNDRTQ2x4OUY5RkJzdGpkVUtLYTlPeCt1Ulpva0lVU0ZsNmt5VWJ1dkQ5Z1JwNTUrOTlyOAoxSTRyT1Jna2NGbEdJa2cvVklrR2YyQ25KOTQxZ2RYWFZUOG9wNnZYN0hEQjRIMXI1UDJRbG50ZXJKKzM5cjltCmNwQlFRMWtTdjE3ZWFtampyYVR5eGRteDQvUEhsR1hvS28wdWNOcktjdjg0Mi8xWDk4aTF5cEFFNnMvaFM5WU4Kck1PWnVhUUxUZmhUVFRaVXpFbUVCdWx3YW91SVIrMGVqRDJ3Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:04:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c132b900-4eb0-4651-a2c4-a1ce78d82776
+      - 07b85591-e9a1-4639-addb-c2cc08161d71
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,19 +1465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXZ6VzlCVjlNWFIwOVk4VldORVE4OHl0SUc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1URXhXaGNOTXpNeE1ETXdNVGcxTVRFeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtyREQrU1J1cVZSUVVpUXhScVNRa29NSmVmZkYzWDdTOVM2STJoNFFZUldNN1RQRGo3cTJCaVQKWjZKcFF4bU5XY1ZzcXNPZ3J5Y3dYMDBLbWhhQjJEeENkZU8rbWF0M0ptNlVOcEFYYkZzSnZ3R3R2TmF2OHorUwpaY2hhM1UzTitZYXp0Myt4MWhiam1OcHF5OXhqVHlYblliR0hvVE5qT1pyS3F1MHZZTnlydzBkMjFmRXhYRkh2CkgyQTN1Q3B2RDBUUVdnSnBoRnpCeVRraFNFY3V4Q21iZnNyclU2U3NLc0J2S1JsTTNjQzBSdEZkR1pJc2NDSSsKTE5ReVRUdFV3aXpMV1RIbklmYThzandxeks1bDROSUxITnNvY0UwdG5aUUtpbEp3MVR2T1QzckQrZDNzR3hiTwo2Si9CdWd3K0pOdXl6T2dpaXVhSkNIa1RYZ2xFUG1rQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0Tm1RNE56Qm1OR010TUdZMVl5MDBPVFEwTFRrMllqQXRNelprTXpreE5HRmkKWkROakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtWNWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lqRjBsSlNkb05CdWlscDYvNXEzZk1lZUd4cGtZTm5LWlJ4a3lJMENVVHB6ZUt4eW1jOS9qClYwL2RBRy9RTXlIckp4RjNXQ0E4aHdYQzd0QlR4TkZFV29VVFFjNkFIUy9wenRkLy9KdjJQbkFvRS9XajdXWVcKVWFpcklNaitjSnNMaW9KTVlnWVQ4dS9jTS9vWGpJOHcrNmFlTjI1Ylp6eVRQN1A2SFRlQ1FQOUlYaDdWdjY1aApyWTBXUWxuUEhwTlRENDNzWkRlUDRXK0xqNGNLQWpBNWFZakhZZ2FvbmNvQlY0SUQ4TDZ0d2lweE9Mem9WcjR2CnZLRUhtNm5WWHRKZW5EbEt4N3FNK21ybVEzQTlFNG5QTlZBeDJGNG5WTEFONGJtdlM0RU85WU1YeHlOT0V4QVUKL1BGTzlrcCtLTE5HN0ZRYnN5ZVdSYzhpUDB4K0V5Ti8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:17 GMT
+      - Thu, 16 Nov 2023 16:04:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3def92ed-456f-4f07-9d9b-32d8bdd5f5b3
+      - fe988658-69b9-4663-8242-7070cafc6e3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,52 +1498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1212"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3ab059d3-4ada-4ffa-a322-4eef4c257122
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1215"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:17 GMT
+      - Thu, 16 Nov 2023 16:04:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3b7d94b-caf1-4828-9a43-592d8999508e
+      - 63c0aec4-912a-486d-b0d1-38e9e36ab4bf
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,19 +1531,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:43.131553Z","retention":7},"created_at":"2023-11-02T18:50:43.131553Z","endpoint":{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519},"endpoints":[{"id":"e6b68c1c-156c-4c97-a5e0-9b180734d210","ip":"51.159.10.213","load_balancer":{},"name":null,"port":21519}],"engine":"PostgreSQL-15","id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:54.398026Z","retention":7},"created_at":"2023-11-16T16:00:54.398026Z","endpoint":{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344},"endpoints":[{"id":"6a7dede8-516b-46e0-92ae-ada8ab8200a8","ip":"51.159.113.173","load_balancer":{},"name":null,"port":21344}],"engine":"PostgreSQL-15","id":"efe43a4d-49c1-4180-8719-40083a2c3aee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1215"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:18 GMT
+      - Thu, 16 Nov 2023 16:04:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1520,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbbd34ca-21b5-4a71-a6a8-943bcdd28042
+      - be2d47b9-c3ab-4e6e-8cf7-11aa21b73e23
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,10 +1564,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"efe43a4d-49c1-4180-8719-40083a2c3aee","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1543,7 +1576,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:48 GMT
+      - Thu, 16 Nov 2023 16:04:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1553,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbe08f97-2e51-4cb9-8a29-b354fe976f6c
+      - d05e1854-00c6-4a1c-b7d1-e7d981f4cb06
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1564,10 +1597,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"efe43a4d-49c1-4180-8719-40083a2c3aee","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1576,7 +1609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:48 GMT
+      - Thu, 16 Nov 2023 16:04:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1586,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43c68981-c40c-45b6-94ee-e3048429cc5b
+      - db129675-08c6-4c02-abf7-20e8a362ef68
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1597,10 +1630,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"efe43a4d-49c1-4180-8719-40083a2c3aee","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1609,7 +1642,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:48 GMT
+      - Thu, 16 Nov 2023 16:04:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1619,7 +1652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af3507e5-e254-41d1-8012-5277c7ed3a9e
+      - 20b92d0a-1c39-48bf-8cc9-aa179a3b53e7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1630,10 +1663,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6d870f4c-0f5c-4944-96b0-36d3914abd3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efe43a4d-49c1-4180-8719-40083a2c3aee
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"6d870f4c-0f5c-4944-96b0-36d3914abd3c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"efe43a4d-49c1-4180-8719-40083a2c3aee","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1642,7 +1675,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:50 GMT
+      - Thu, 16 Nov 2023 16:04:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1652,7 +1685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3ec1565-2051-4eb1-9981-c49e8474780f
+      - fad5e507-c6e4-49f3-a60f-4a39e46797a4
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-privilege-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-privilege-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:32 GMT
+      - Thu, 16 Nov 2023 15:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc80d19f-2b05-4828-93dd-03da7d36902c
+      - bc1566bc-83a5-4d76-aeba-d1f252a579e4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-privilege","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-privilege","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 15:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20de9f06-bec3-4d2a-a40e-e8ff74a60dba
+      - f291f2d1-83f8-485a-9ffc-b198f91b3f82
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 15:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baa4ee0c-a3fa-46c3-9cb3-69f45b2ca4d6
+      - f7673c37-69b8-42c7-91b5-dc6df563608a
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:08 GMT
+      - Thu, 16 Nov 2023 15:56:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88fe1a9d-a3f4-4920-b0b4-6072672f6c42
+      - 8e484b25-53b3-4aa4-99c9-64ae61687b06
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:38 GMT
+      - Thu, 16 Nov 2023 15:57:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 244c99a4-7895-4c31-8610-91dd894eeac1
+      - 66641452-1f90-459e-8e86-704d2db88b44
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:08 GMT
+      - Thu, 16 Nov 2023 15:57:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5d5d53e-c52f-4024-b1bd-03a223ab0a21
+      - 83d9ad50-0c8b-49ec-b52c-25d1a43d3be6
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:38 GMT
+      - Thu, 16 Nov 2023 15:58:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2680bc39-6052-4e1c-bd7c-500a732e2942
+      - 7ef421ee-3007-423b-8e8b-da70e6a2a5bd
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "776"
+      - "805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:08 GMT
+      - Thu, 16 Nov 2023 15:58:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d2439c2-f3b0-48cb-9b40-1282ed4d4090
+      - dd834fd2-ee84-49cd-b70b-f803bbb21f1a
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:59:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 647b5174-e8c5-4f8c-803d-e03ca4ac091d
+      - fbb0f42e-a183-4c4c-9f98-fd472173e7d8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1080"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:59:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3da4f566-a394-470c-9e1b-e5c3a175b775
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1299"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9a5eb4c1-359b-4e36-b213-8a81c35d15ba
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:00:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f38eec2-694c-43f4-8c8a-0fbe86f036eb
+      - 0f169e99-889d-4cfb-9376-5677e5587e60
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:00:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4196021c-8712-4fc8-8c25-0b99f8b0cf02
+      - c07aea29-ce35-41ea-81d0-e6bb8c607bc6
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSElxYThtQ2Q1SVF5V3JsNHBmNDBjU1RGYVFFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBPVm9YRFRNek1URXhNekUxTlRrME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVONk9STVFtK2dCdVR4cmowZVNQYTdJNm53Ylc1RlBJZktVWFp1Ulkvb1RYM01QTC9heVIKT28xaUdpQWtHRDQvNUtvUFMrZGs0dmVCcEhoblJpQWdUL3cxOWo0WEtMc3I1N1Q4ZFNNeTQ4TDVaRVZFdnc0VgpnWmhKd0dyZFRDcUc0YWk1MTdHanRvbzczTE5kcVFncVpZTlY1RitmU09NcXY3VDIvd2pzUUd4Zkp1VEZYWjl4CkdTZVVPKzV4MDZBdHlvNmh4am9LT3hBRWVQQ3JORG1HWTVHY0swMitjYTlWRDhwVzcrQkxjWHlieS9QdUMrNTcKTVBPRERBUlJBQUplOTFWbmZqaHdpWitUbDZ3RUhxTEZ6c3E0aFhNT293LzZTM0tpNURPYTdEbndQa1Q0Rlh3dgpPNUMxakVwdkVDZUVYekxuSlVmUWNabE1PS0RNTmNuMzZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE16RTBZamRrWVRrdFlqRmlOeTAwWldSakxUazNPVFV0TkRZd01qYzQKTldRMU9HWTRMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE2czZvTEN1S2ZqVTFvVy93VU5ZVGJlZmJTQ3A1TUhVUnFxMWVOOFowWWMwZGhIL2VGCjdjdDE4RmdBWnpybEJxMmpDbzk5blB0RndWTE5FbEdXV0F1bE1OT0tvYXc5UzlXK3M1dTRXdVpZb0ZpOTNGTVIKR3JCTURLUzczRmlMZFp5NzdxNFhTZXFhUjV6bGF2L1ZQdHlLSnBCdXZ0alJSb1lDdVpQQllWMTBrd29rVFdGMQp5WnhXKzN1WHcxYlVCTDlUZjUvWTdPVUNMQStiTllxb3VaeDJvVzdFUG5ZSnpFVG9Nckl1aWtRM0t4Qk5WdE81CjFOL21CQjZpaXE3U1IwT1dYdERhalgxQ0sxeERTUHBEYzBXTDhhSDAyY2tyOGJtT1pNaGh2alRXcTU1Q2N6aSsKcTFKbmc4RDhQcS9nU0tJeGhnNXVPSFN1SUlZTEY3WTltK01vCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:00:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2387ae3c-ac81-4514-b42d-4b3e7b6911e4
+      - be7d79d9-a9d3-4322-9549-b8c99e236a1e
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:00:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 052c4813-5840-4f0e-aa09-30002cb20522
+      - 5d1a5cdc-8116-4442-b95d-05585765a5ed
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSElxYThtQ2Q1SVF5V3JsNHBmNDBjU1RGYVFFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBPVm9YRFRNek1URXhNekUxTlRrME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVONk9STVFtK2dCdVR4cmowZVNQYTdJNm53Ylc1RlBJZktVWFp1Ulkvb1RYM01QTC9heVIKT28xaUdpQWtHRDQvNUtvUFMrZGs0dmVCcEhoblJpQWdUL3cxOWo0WEtMc3I1N1Q4ZFNNeTQ4TDVaRVZFdnc0VgpnWmhKd0dyZFRDcUc0YWk1MTdHanRvbzczTE5kcVFncVpZTlY1RitmU09NcXY3VDIvd2pzUUd4Zkp1VEZYWjl4CkdTZVVPKzV4MDZBdHlvNmh4am9LT3hBRWVQQ3JORG1HWTVHY0swMitjYTlWRDhwVzcrQkxjWHlieS9QdUMrNTcKTVBPRERBUlJBQUplOTFWbmZqaHdpWitUbDZ3RUhxTEZ6c3E0aFhNT293LzZTM0tpNURPYTdEbndQa1Q0Rlh3dgpPNUMxakVwdkVDZUVYekxuSlVmUWNabE1PS0RNTmNuMzZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE16RTBZamRrWVRrdFlqRmlOeTAwWldSakxUazNPVFV0TkRZd01qYzQKTldRMU9HWTRMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE2czZvTEN1S2ZqVTFvVy93VU5ZVGJlZmJTQ3A1TUhVUnFxMWVOOFowWWMwZGhIL2VGCjdjdDE4RmdBWnpybEJxMmpDbzk5blB0RndWTE5FbEdXV0F1bE1OT0tvYXc5UzlXK3M1dTRXdVpZb0ZpOTNGTVIKR3JCTURLUzczRmlMZFp5NzdxNFhTZXFhUjV6bGF2L1ZQdHlLSnBCdXZ0alJSb1lDdVpQQllWMTBrd29rVFdGMQp5WnhXKzN1WHcxYlVCTDlUZjUvWTdPVUNMQStiTllxb3VaeDJvVzdFUG5ZSnpFVG9Nckl1aWtRM0t4Qk5WdE81CjFOL21CQjZpaXE3U1IwT1dYdERhalgxQ0sxeERTUHBEYzBXTDhhSDAyY2tyOGJtT1pNaGh2alRXcTU1Q2N6aSsKcTFKbmc4RDhQcS9nU0tJeGhnNXVPSFN1SUlZTEY3WTltK01vCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:00:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99cec5e1-c5e8-4d24-99ef-c02bf87e9496
+      - d42edb92-cefd-4763-846f-1a577f9d7b89
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 16:00:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 421e05fa-7ef3-43c3-b8c3-0a9550db4ae4
+      - 2e6ca526-537f-463e-8cbe-a549251a1ecd
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSElxYThtQ2Q1SVF5V3JsNHBmNDBjU1RGYVFFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBPVm9YRFRNek1URXhNekUxTlRrME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVONk9STVFtK2dCdVR4cmowZVNQYTdJNm53Ylc1RlBJZktVWFp1Ulkvb1RYM01QTC9heVIKT28xaUdpQWtHRDQvNUtvUFMrZGs0dmVCcEhoblJpQWdUL3cxOWo0WEtMc3I1N1Q4ZFNNeTQ4TDVaRVZFdnc0VgpnWmhKd0dyZFRDcUc0YWk1MTdHanRvbzczTE5kcVFncVpZTlY1RitmU09NcXY3VDIvd2pzUUd4Zkp1VEZYWjl4CkdTZVVPKzV4MDZBdHlvNmh4am9LT3hBRWVQQ3JORG1HWTVHY0swMitjYTlWRDhwVzcrQkxjWHlieS9QdUMrNTcKTVBPRERBUlJBQUplOTFWbmZqaHdpWitUbDZ3RUhxTEZ6c3E0aFhNT293LzZTM0tpNURPYTdEbndQa1Q0Rlh3dgpPNUMxakVwdkVDZUVYekxuSlVmUWNabE1PS0RNTmNuMzZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE16RTBZamRrWVRrdFlqRmlOeTAwWldSakxUazNPVFV0TkRZd01qYzQKTldRMU9HWTRMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE2czZvTEN1S2ZqVTFvVy93VU5ZVGJlZmJTQ3A1TUhVUnFxMWVOOFowWWMwZGhIL2VGCjdjdDE4RmdBWnpybEJxMmpDbzk5blB0RndWTE5FbEdXV0F1bE1OT0tvYXc5UzlXK3M1dTRXdVpZb0ZpOTNGTVIKR3JCTURLUzczRmlMZFp5NzdxNFhTZXFhUjV6bGF2L1ZQdHlLSnBCdXZ0alJSb1lDdVpQQllWMTBrd29rVFdGMQp5WnhXKzN1WHcxYlVCTDlUZjUvWTdPVUNMQStiTllxb3VaeDJvVzdFUG5ZSnpFVG9Nckl1aWtRM0t4Qk5WdE81CjFOL21CQjZpaXE3U1IwT1dYdERhalgxQ0sxeERTUHBEYzBXTDhhSDAyY2tyOGJtT1pNaGh2alRXcTU1Q2N6aSsKcTFKbmc4RDhQcS9nU0tJeGhnNXVPSFN1SUlZTEY3WTltK01vCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 16:00:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d18e89f5-67f8-451b-aa73-735a77d22e0c
+      - 5333d35d-25fc-4e2e-8037-d569dfb93324
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
+      - Thu, 16 Nov 2023 16:00:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 103bd751-f2b9-4165-9e5a-957606d1ba10
+      - 0466f97f-03c9-4ccd-a671-35c215a0fc6d
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
     headers:
       Content-Length:
-      - "49"
+      - "52"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
+      - Thu, 16 Nov 2023 16:00:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6497d74b-28a9-47ed-aad2-82adf04103c6
+      - 5a4ed2fe-aa24-4a77-a900-c6f6b7890354
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
+      - Thu, 16 Nov 2023 16:00:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48a84a43-c084-41a0-a07c-1b5b8b85e980
+      - 9d576380-6f22-4d53-91c8-a4db54806557
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
+      - Thu, 16 Nov 2023 16:00:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 775366ad-244b-40a5-8228-db73514205df
+      - 5148c802-bbc8-4e4b-9ce1-1c69c8ae3b31
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:43 GMT
+      - Thu, 16 Nov 2023 16:00:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecb62343-e1b1-49ef-b18b-60e9d6ae1563
+      - 74db581a-4773-412c-9e3f-00e2f6aa1595
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSElxYThtQ2Q1SVF5V3JsNHBmNDBjU1RGYVFFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBPVm9YRFRNek1URXhNekUxTlRrME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVONk9STVFtK2dCdVR4cmowZVNQYTdJNm53Ylc1RlBJZktVWFp1Ulkvb1RYM01QTC9heVIKT28xaUdpQWtHRDQvNUtvUFMrZGs0dmVCcEhoblJpQWdUL3cxOWo0WEtMc3I1N1Q4ZFNNeTQ4TDVaRVZFdnc0VgpnWmhKd0dyZFRDcUc0YWk1MTdHanRvbzczTE5kcVFncVpZTlY1RitmU09NcXY3VDIvd2pzUUd4Zkp1VEZYWjl4CkdTZVVPKzV4MDZBdHlvNmh4am9LT3hBRWVQQ3JORG1HWTVHY0swMitjYTlWRDhwVzcrQkxjWHlieS9QdUMrNTcKTVBPRERBUlJBQUplOTFWbmZqaHdpWitUbDZ3RUhxTEZ6c3E0aFhNT293LzZTM0tpNURPYTdEbndQa1Q0Rlh3dgpPNUMxakVwdkVDZUVYekxuSlVmUWNabE1PS0RNTmNuMzZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE16RTBZamRrWVRrdFlqRmlOeTAwWldSakxUazNPVFV0TkRZd01qYzQKTldRMU9HWTRMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE2czZvTEN1S2ZqVTFvVy93VU5ZVGJlZmJTQ3A1TUhVUnFxMWVOOFowWWMwZGhIL2VGCjdjdDE4RmdBWnpybEJxMmpDbzk5blB0RndWTE5FbEdXV0F1bE1OT0tvYXc5UzlXK3M1dTRXdVpZb0ZpOTNGTVIKR3JCTURLUzczRmlMZFp5NzdxNFhTZXFhUjV6bGF2L1ZQdHlLSnBCdXZ0alJSb1lDdVpQQllWMTBrd29rVFdGMQp5WnhXKzN1WHcxYlVCTDlUZjUvWTdPVUNMQStiTllxb3VaeDJvVzdFUG5ZSnpFVG9Nckl1aWtRM0t4Qk5WdE81CjFOL21CQjZpaXE3U1IwT1dYdERhalgxQ0sxeERTUHBEYzBXTDhhSDAyY2tyOGJtT1pNaGh2alRXcTU1Q2N6aSsKcTFKbmc4RDhQcS9nU0tJeGhnNXVPSFN1SUlZTEY3WTltK01vCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:43 GMT
+      - Thu, 16 Nov 2023 16:00:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cbc4032-0c5d-4e17-b499-e9fa6f72b283
+      - f4a59d52-edfa-4495-adcf-db16dc332e97
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:43 GMT
+      - Thu, 16 Nov 2023 16:00:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3880fbe9-02cf-4a13-9a8c-6cc88c5d01be
+      - 1cfcd16f-6267-4f39-bc79-c2568ea7cf2d
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:43 GMT
+      - Thu, 16 Nov 2023 16:00:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa75e92d-8242-40d1-a042-c294af4a8bc6
+      - 63415c5f-eb4e-49df-8ee2-32abf55449a4
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSElxYThtQ2Q1SVF5V3JsNHBmNDBjU1RGYVFFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBPVm9YRFRNek1URXhNekUxTlRrME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVONk9STVFtK2dCdVR4cmowZVNQYTdJNm53Ylc1RlBJZktVWFp1Ulkvb1RYM01QTC9heVIKT28xaUdpQWtHRDQvNUtvUFMrZGs0dmVCcEhoblJpQWdUL3cxOWo0WEtMc3I1N1Q4ZFNNeTQ4TDVaRVZFdnc0VgpnWmhKd0dyZFRDcUc0YWk1MTdHanRvbzczTE5kcVFncVpZTlY1RitmU09NcXY3VDIvd2pzUUd4Zkp1VEZYWjl4CkdTZVVPKzV4MDZBdHlvNmh4am9LT3hBRWVQQ3JORG1HWTVHY0swMitjYTlWRDhwVzcrQkxjWHlieS9QdUMrNTcKTVBPRERBUlJBQUplOTFWbmZqaHdpWitUbDZ3RUhxTEZ6c3E0aFhNT293LzZTM0tpNURPYTdEbndQa1Q0Rlh3dgpPNUMxakVwdkVDZUVYekxuSlVmUWNabE1PS0RNTmNuMzZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE16RTBZamRrWVRrdFlqRmlOeTAwWldSakxUazNPVFV0TkRZd01qYzQKTldRMU9HWTRMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE2czZvTEN1S2ZqVTFvVy93VU5ZVGJlZmJTQ3A1TUhVUnFxMWVOOFowWWMwZGhIL2VGCjdjdDE4RmdBWnpybEJxMmpDbzk5blB0RndWTE5FbEdXV0F1bE1OT0tvYXc5UzlXK3M1dTRXdVpZb0ZpOTNGTVIKR3JCTURLUzczRmlMZFp5NzdxNFhTZXFhUjV6bGF2L1ZQdHlLSnBCdXZ0alJSb1lDdVpQQllWMTBrd29rVFdGMQp5WnhXKzN1WHcxYlVCTDlUZjUvWTdPVUNMQStiTllxb3VaeDJvVzdFUG5ZSnpFVG9Nckl1aWtRM0t4Qk5WdE81CjFOL21CQjZpaXE3U1IwT1dYdERhalgxQ0sxeERTUHBEYzBXTDhhSDAyY2tyOGJtT1pNaGh2alRXcTU1Q2N6aSsKcTFKbmc4RDhQcS9nU0tJeGhnNXVPSFN1SUlZTEY3WTltK01vCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:43 GMT
+      - Thu, 16 Nov 2023 16:00:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8caf14aa-fd55-4080-bff7-9933b9ff4818
+      - 3f66ea85-3c58-4d81-90c8-53d8925ca44a
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1203,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:44 GMT
+      - Thu, 16 Nov 2023 16:00:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 953662e6-411b-45c6-bf04-c57454885a62
+      - f8660f02-729b-4dc1-86c8-5b219e23a2de
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1236,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:44 GMT
+      - Thu, 16 Nov 2023 16:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec0ef2a8-90a2-477d-8f80-0cd7fbfbe469
+      - 96f7aa4a-97d0-4bf2-ad1d-331ab9386e6e
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,19 +1271,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"foo"}'
     headers:
       Content-Length:
-      - "31"
+      - "32"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:44 GMT
+      - Thu, 16 Nov 2023 16:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1227,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 052b851c-f736-4f41-b559-d546ce39775a
+      - 3f01ee8c-1d15-4868-a450-b6f8f2821cec
     status: 200 OK
     code: 200
     duration: ""
@@ -1238,19 +1304,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:44 GMT
+      - Thu, 16 Nov 2023 16:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69971be0-3be2-491a-a4b2-3b7caae1d79e
+      - 871f27fb-daf6-43cb-98fb-babe67de0806
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,184 +1337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:49:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 35508168-3428-4ea0-8f2f-f6ea9a4e5ed5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1249"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:49:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 218f011a-c911-439c-a6c7-a36bcb83209c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1843"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:49:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 13ee0704-7215-4081-a97d-7ae86269bce7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "102"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:49:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f1e02a51-7b15-47eb-ac4b-963afc2cd24c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1249"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:49:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 223c87f1-2de0-4e06-9011-cf28ff73318c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:52 GMT
+      - Thu, 16 Nov 2023 16:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b963dc8-1ee4-4d1d-85d7-22212f8cf0e5
+      - c8b32827-30a9-4677-aaaa-bec15f94d29a
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,19 +1370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:52 GMT
+      - Thu, 16 Nov 2023 16:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a37f46c-ce73-4be0-91af-f153e12e2629
+      - 9d6e0987-9315-4859-aaa7-0b74ce81d23c
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,19 +1403,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSElxYThtQ2Q1SVF5V3JsNHBmNDBjU1RGYVFFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBPVm9YRFRNek1URXhNekUxTlRrME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVONk9STVFtK2dCdVR4cmowZVNQYTdJNm53Ylc1RlBJZktVWFp1Ulkvb1RYM01QTC9heVIKT28xaUdpQWtHRDQvNUtvUFMrZGs0dmVCcEhoblJpQWdUL3cxOWo0WEtMc3I1N1Q4ZFNNeTQ4TDVaRVZFdnc0VgpnWmhKd0dyZFRDcUc0YWk1MTdHanRvbzczTE5kcVFncVpZTlY1RitmU09NcXY3VDIvd2pzUUd4Zkp1VEZYWjl4CkdTZVVPKzV4MDZBdHlvNmh4am9LT3hBRWVQQ3JORG1HWTVHY0swMitjYTlWRDhwVzcrQkxjWHlieS9QdUMrNTcKTVBPRERBUlJBQUplOTFWbmZqaHdpWitUbDZ3RUhxTEZ6c3E0aFhNT293LzZTM0tpNURPYTdEbndQa1Q0Rlh3dgpPNUMxakVwdkVDZUVYekxuSlVmUWNabE1PS0RNTmNuMzZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE16RTBZamRrWVRrdFlqRmlOeTAwWldSakxUazNPVFV0TkRZd01qYzQKTldRMU9HWTRMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE2czZvTEN1S2ZqVTFvVy93VU5ZVGJlZmJTQ3A1TUhVUnFxMWVOOFowWWMwZGhIL2VGCjdjdDE4RmdBWnpybEJxMmpDbzk5blB0RndWTE5FbEdXV0F1bE1OT0tvYXc5UzlXK3M1dTRXdVpZb0ZpOTNGTVIKR3JCTURLUzczRmlMZFp5NzdxNFhTZXFhUjV6bGF2L1ZQdHlLSnBCdXZ0alJSb1lDdVpQQllWMTBrd29rVFdGMQp5WnhXKzN1WHcxYlVCTDlUZjUvWTdPVUNMQStiTllxb3VaeDJvVzdFUG5ZSnpFVG9Nckl1aWtRM0t4Qk5WdE81CjFOL21CQjZpaXE3U1IwT1dYdERhalgxQ0sxeERTUHBEYzBXTDhhSDAyY2tyOGJtT1pNaGh2alRXcTU1Q2N6aSsKcTFKbmc4RDhQcS9nU0tJeGhnNXVPSFN1SUlZTEY3WTltK01vCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:53 GMT
+      - Thu, 16 Nov 2023 16:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1524,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d9bdc91-204a-478f-824b-4511073a4e89
+      - 005ab645-e07b-4b49-afbb-0bcf29bb82ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,19 +1436,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:53 GMT
+      - Thu, 16 Nov 2023 16:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1557,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7462b0f2-6427-4b82-890c-8f9d93687e85
+      - fc250f68-41e3-43c8-987c-1ee2707ba70b
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,19 +1469,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:53 GMT
+      - Thu, 16 Nov 2023 16:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1590,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac1896aa-279d-4e31-af3a-b591f103f17f
+      - f8cd4cfa-6b53-4645-b119-47c728fa2696
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,19 +1502,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:53 GMT
+      - Thu, 16 Nov 2023 16:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5950dee4-d36c-46e3-8d73-dcf87dbe03a5
+      - aa283d16-ecb9-4d01-8c52-47137617fce1
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,19 +1535,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:54 GMT
+      - Thu, 16 Nov 2023 16:00:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1557,172 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee8220f3-1566-4816-b8ae-8efeaa44941f
+      - 20ec18dc-d917-4ce7-a8b8-d50043e259b3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSElxYThtQ2Q1SVF5V3JsNHBmNDBjU1RGYVFFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBPVm9YRFRNek1URXhNekUxTlRrME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVONk9STVFtK2dCdVR4cmowZVNQYTdJNm53Ylc1RlBJZktVWFp1Ulkvb1RYM01QTC9heVIKT28xaUdpQWtHRDQvNUtvUFMrZGs0dmVCcEhoblJpQWdUL3cxOWo0WEtMc3I1N1Q4ZFNNeTQ4TDVaRVZFdnc0VgpnWmhKd0dyZFRDcUc0YWk1MTdHanRvbzczTE5kcVFncVpZTlY1RitmU09NcXY3VDIvd2pzUUd4Zkp1VEZYWjl4CkdTZVVPKzV4MDZBdHlvNmh4am9LT3hBRWVQQ3JORG1HWTVHY0swMitjYTlWRDhwVzcrQkxjWHlieS9QdUMrNTcKTVBPRERBUlJBQUplOTFWbmZqaHdpWitUbDZ3RUhxTEZ6c3E0aFhNT293LzZTM0tpNURPYTdEbndQa1Q0Rlh3dgpPNUMxakVwdkVDZUVYekxuSlVmUWNabE1PS0RNTmNuMzZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE16RTBZamRrWVRrdFlqRmlOeTAwWldSakxUazNPVFV0TkRZd01qYzQKTldRMU9HWTRMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE2czZvTEN1S2ZqVTFvVy93VU5ZVGJlZmJTQ3A1TUhVUnFxMWVOOFowWWMwZGhIL2VGCjdjdDE4RmdBWnpybEJxMmpDbzk5blB0RndWTE5FbEdXV0F1bE1OT0tvYXc5UzlXK3M1dTRXdVpZb0ZpOTNGTVIKR3JCTURLUzczRmlMZFp5NzdxNFhTZXFhUjV6bGF2L1ZQdHlLSnBCdXZ0alJSb1lDdVpQQllWMTBrd29rVFdGMQp5WnhXKzN1WHcxYlVCTDlUZjUvWTdPVUNMQStiTllxb3VaeDJvVzdFUG5ZSnpFVG9Nckl1aWtRM0t4Qk5WdE81CjFOL21CQjZpaXE3U1IwT1dYdERhalgxQ0sxeERTUHBEYzBXTDhhSDAyY2tyOGJtT1pNaGh2alRXcTU1Q2N6aSsKcTFKbmc4RDhQcS9nU0tJeGhnNXVPSFN1SUlZTEY3WTltK01vCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1849"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 468ed46e-6f2d-4d5a-b77e-2e3f17163191
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/databases?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "106"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c4c53d22-c71b-40f9-a8b4-5f43463ab81c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1299"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85863ad3-79be-4b38-ad49-9c17b1683a88
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "61"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b70133c6-763c-493d-aa38-2b5c8a84cef0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1299"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cd0fbca7-63e6-4e9e-8016-cc12dbb60042
     status: 200 OK
     code: 200
     duration: ""
@@ -1669,19 +1735,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"all","user_name":"foo"}'
     headers:
       Content-Length:
-      - "60"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:54 GMT
+      - Thu, 16 Nov 2023 16:00:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1691,7 +1757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b60b03e5-25a6-4169-a10b-a68163c6f4e3
+      - 7a16270b-5e29-410e-be54-87d55a820b3d
     status: 200 OK
     code: 200
     duration: ""
@@ -1702,19 +1768,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:54 GMT
+      - Thu, 16 Nov 2023 16:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1724,7 +1790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1eafcce-6ca6-4bda-9b07-3793126ada42
+      - 403c8890-4e9d-4bc3-9b1b-eb909b2f1c04
     status: 200 OK
     code: 200
     duration: ""
@@ -1735,19 +1801,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:54 GMT
+      - Thu, 16 Nov 2023 16:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1757,7 +1823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0defcfd7-c5fd-462e-96ca-50e9055e546b
+      - a634eaa7-2cb2-449c-8722-09d7bf9ffb2f
     status: 200 OK
     code: 200
     duration: ""
@@ -1768,19 +1834,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:54 GMT
+      - Thu, 16 Nov 2023 16:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1790,7 +1856,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9e13a1d-5964-45ff-9daa-20b05a7b61f0
+      - af7a5531-d921-46e0-b57a-4f305cd5ad08
     status: 200 OK
     code: 200
     duration: ""
@@ -1801,19 +1867,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "93"
+      - "96"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:55 GMT
+      - Thu, 16 Nov 2023 16:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1823,7 +1889,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9392a0fa-9f2e-44ff-a3fa-4d784fcdb3fa
+      - 7346ede4-7d11-4a71-a23a-14efacb6b1e2
     status: 200 OK
     code: 200
     duration: ""
@@ -1834,19 +1900,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:02 GMT
+      - Thu, 16 Nov 2023 16:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1856,7 +1922,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a64afa8f-5254-4fcd-9aa5-4430dd1a37b1
+      - d9003319-1209-4174-88ba-7a138a70b01c
     status: 200 OK
     code: 200
     duration: ""
@@ -1867,19 +1933,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSElxYThtQ2Q1SVF5V3JsNHBmNDBjU1RGYVFFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBPVm9YRFRNek1URXhNekUxTlRrME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVONk9STVFtK2dCdVR4cmowZVNQYTdJNm53Ylc1RlBJZktVWFp1Ulkvb1RYM01QTC9heVIKT28xaUdpQWtHRDQvNUtvUFMrZGs0dmVCcEhoblJpQWdUL3cxOWo0WEtMc3I1N1Q4ZFNNeTQ4TDVaRVZFdnc0VgpnWmhKd0dyZFRDcUc0YWk1MTdHanRvbzczTE5kcVFncVpZTlY1RitmU09NcXY3VDIvd2pzUUd4Zkp1VEZYWjl4CkdTZVVPKzV4MDZBdHlvNmh4am9LT3hBRWVQQ3JORG1HWTVHY0swMitjYTlWRDhwVzcrQkxjWHlieS9QdUMrNTcKTVBPRERBUlJBQUplOTFWbmZqaHdpWitUbDZ3RUhxTEZ6c3E0aFhNT293LzZTM0tpNURPYTdEbndQa1Q0Rlh3dgpPNUMxakVwdkVDZUVYekxuSlVmUWNabE1PS0RNTmNuMzZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE16RTBZamRrWVRrdFlqRmlOeTAwWldSakxUazNPVFV0TkRZd01qYzQKTldRMU9HWTRMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE2czZvTEN1S2ZqVTFvVy93VU5ZVGJlZmJTQ3A1TUhVUnFxMWVOOFowWWMwZGhIL2VGCjdjdDE4RmdBWnpybEJxMmpDbzk5blB0RndWTE5FbEdXV0F1bE1OT0tvYXc5UzlXK3M1dTRXdVpZb0ZpOTNGTVIKR3JCTURLUzczRmlMZFp5NzdxNFhTZXFhUjV6bGF2L1ZQdHlLSnBCdXZ0alJSb1lDdVpQQllWMTBrd29rVFdGMQp5WnhXKzN1WHcxYlVCTDlUZjUvWTdPVUNMQStiTllxb3VaeDJvVzdFUG5ZSnpFVG9Nckl1aWtRM0t4Qk5WdE81CjFOL21CQjZpaXE3U1IwT1dYdERhalgxQ0sxeERTUHBEYzBXTDhhSDAyY2tyOGJtT1pNaGh2alRXcTU1Q2N6aSsKcTFKbmc4RDhQcS9nU0tJeGhnNXVPSFN1SUlZTEY3WTltK01vCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:02 GMT
+      - Thu, 16 Nov 2023 16:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1889,7 +1955,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 047109d0-2f75-41a3-89d1-4f2852751452
+      - 00cfe99a-aafd-4d8d-bb67-f1d45e190059
     status: 200 OK
     code: 200
     duration: ""
@@ -1900,19 +1966,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:02 GMT
+      - Thu, 16 Nov 2023 16:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1922,7 +1988,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 803c634a-0917-4503-83d8-43360820af5d
+      - 51e1afe8-4946-41ed-b504-66043b8a40bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1933,19 +1999,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:02 GMT
+      - Thu, 16 Nov 2023 16:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1955,7 +2021,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24974366-e934-46fc-80e7-7b028b6e7333
+      - 16770971-633a-4f8c-a36c-7808261e1f1f
     status: 200 OK
     code: 200
     duration: ""
@@ -1966,85 +2032,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b428f2e4-1dd8-433e-b4d6-bfde2c97f035
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1249"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d4d7eac9-5077-43e8-8c3b-d2796ec12851
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:03 GMT
+      - Thu, 16 Nov 2023 16:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2054,7 +2054,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f150469f-e335-40d0-bf8b-51de33467a26
+      - de346fb9-9ed3-4108-9997-5737aefa25b4
     status: 200 OK
     code: 200
     duration: ""
@@ -2065,19 +2065,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1299"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 36d17ba2-e282-4b28-9a3c-cecfab796c2a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "61"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c8bf0b14-4e5c-46c0-a788-71a7014e8345
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "93"
+      - "96"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:03 GMT
+      - Thu, 16 Nov 2023 16:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2087,7 +2153,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c789adc7-4886-42dc-92c8-32036f17b24f
+      - 983ecb7a-04d4-4d44-a49c-962fb40796ce
     status: 200 OK
     code: 200
     duration: ""
@@ -2098,19 +2164,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:04 GMT
+      - Thu, 16 Nov 2023 16:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2120,7 +2186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68ff2f95-3944-4a1e-95ef-a5b16990219b
+      - b4d00b1e-aa82-410d-b1ba-ca5b1f5c87c6
     status: 200 OK
     code: 200
     duration: ""
@@ -2131,19 +2197,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSElxYThtQ2Q1SVF5V3JsNHBmNDBjU1RGYVFFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBPVm9YRFRNek1URXhNekUxTlRrME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVONk9STVFtK2dCdVR4cmowZVNQYTdJNm53Ylc1RlBJZktVWFp1Ulkvb1RYM01QTC9heVIKT28xaUdpQWtHRDQvNUtvUFMrZGs0dmVCcEhoblJpQWdUL3cxOWo0WEtMc3I1N1Q4ZFNNeTQ4TDVaRVZFdnc0VgpnWmhKd0dyZFRDcUc0YWk1MTdHanRvbzczTE5kcVFncVpZTlY1RitmU09NcXY3VDIvd2pzUUd4Zkp1VEZYWjl4CkdTZVVPKzV4MDZBdHlvNmh4am9LT3hBRWVQQ3JORG1HWTVHY0swMitjYTlWRDhwVzcrQkxjWHlieS9QdUMrNTcKTVBPRERBUlJBQUplOTFWbmZqaHdpWitUbDZ3RUhxTEZ6c3E0aFhNT293LzZTM0tpNURPYTdEbndQa1Q0Rlh3dgpPNUMxakVwdkVDZUVYekxuSlVmUWNabE1PS0RNTmNuMzZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE16RTBZamRrWVRrdFlqRmlOeTAwWldSakxUazNPVFV0TkRZd01qYzQKTldRMU9HWTRMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE2czZvTEN1S2ZqVTFvVy93VU5ZVGJlZmJTQ3A1TUhVUnFxMWVOOFowWWMwZGhIL2VGCjdjdDE4RmdBWnpybEJxMmpDbzk5blB0RndWTE5FbEdXV0F1bE1OT0tvYXc5UzlXK3M1dTRXdVpZb0ZpOTNGTVIKR3JCTURLUzczRmlMZFp5NzdxNFhTZXFhUjV6bGF2L1ZQdHlLSnBCdXZ0alJSb1lDdVpQQllWMTBrd29rVFdGMQp5WnhXKzN1WHcxYlVCTDlUZjUvWTdPVUNMQStiTllxb3VaeDJvVzdFUG5ZSnpFVG9Nckl1aWtRM0t4Qk5WdE81CjFOL21CQjZpaXE3U1IwT1dYdERhalgxQ0sxeERTUHBEYzBXTDhhSDAyY2tyOGJtT1pNaGh2alRXcTU1Q2N6aSsKcTFKbmc4RDhQcS9nU0tJeGhnNXVPSFN1SUlZTEY3WTltK01vCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:04 GMT
+      - Thu, 16 Nov 2023 16:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2153,7 +2219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8063f116-debf-411b-9ab0-98726a219d4a
+      - 45308b39-b920-4672-93ed-26740669dc46
     status: 200 OK
     code: 200
     duration: ""
@@ -2164,19 +2230,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:04 GMT
+      - Thu, 16 Nov 2023 16:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2186,7 +2252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7273bb0-e715-4995-bbfc-5292759f5e52
+      - 4370ac86-ea63-44c0-9eef-8a0e17890eeb
     status: 200 OK
     code: 200
     duration: ""
@@ -2197,19 +2263,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:04 GMT
+      - Thu, 16 Nov 2023 16:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2219,7 +2285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f748ef4-0ebc-4a58-b8f0-d7abd01575a9
+      - 8990cf1d-b016-46a3-b698-24ad549073a1
     status: 200 OK
     code: 200
     duration: ""
@@ -2230,118 +2296,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fba4b080-4069-4742-a79b-5161213bd164
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1249"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 18470a76-4ace-4dfb-8a73-e8736244a038
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1249"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8717a2fc-0fa3-4d1f-9c97-f0b61b27de92
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:04 GMT
+      - Thu, 16 Nov 2023 16:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2351,7 +2318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b1ba518-344b-47ee-b784-75f53d887f5e
+      - 3947855e-fdb1-4b41-b22f-2ce09b466691
     status: 200 OK
     code: 200
     duration: ""
@@ -2362,19 +2329,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1299"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6e47d19a-11f0-4b44-a2e9-5b1f253bc512
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1299"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 983f01d5-f21b-4411-ba93-3e5870a2f323
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:04 GMT
+      - Thu, 16 Nov 2023 16:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2384,7 +2417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25904353-d491-4ff4-a430-c90d1a98875c
+      - e9f6bbf7-7ec2-4901-b0db-231516040364
     status: 200 OK
     code: 200
     duration: ""
@@ -2395,19 +2428,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "61"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4e60ee40-a50f-42f7-8a4d-2f8efc7700bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "93"
+      - "96"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:05 GMT
+      - Thu, 16 Nov 2023 16:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2417,7 +2483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a87c95a3-54e2-4210-b8e9-b6ce8dcef767
+      - f48ba828-2395-40a2-bf57-cf9f145a81af
     status: 200 OK
     code: 200
     duration: ""
@@ -2428,19 +2494,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "93"
+      - "96"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:05 GMT
+      - Thu, 16 Nov 2023 16:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2450,7 +2516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0a4eda5-5526-4ad5-a397-f6ffeae9612f
+      - 2c13c46a-ef50-460d-a5ba-7888a666b826
     status: 200 OK
     code: 200
     duration: ""
@@ -2461,19 +2527,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:05 GMT
+      - Thu, 16 Nov 2023 16:00:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2483,7 +2549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5f0d9e9-641d-4605-910b-b935a964eab9
+      - cc647257-398f-47a0-a946-48c8cacf1374
     status: 200 OK
     code: 200
     duration: ""
@@ -2494,19 +2560,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:05 GMT
+      - Thu, 16 Nov 2023 16:00:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2516,7 +2582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 289fefc7-36a5-492e-bd50-7bf82b849ec4
+      - c2ea2885-e2b7-46f1-8c0b-2f6fa627117f
     status: 200 OK
     code: 200
     duration: ""
@@ -2527,19 +2593,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "93"
+      - "96"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:06 GMT
+      - Thu, 16 Nov 2023 16:00:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2549,7 +2615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b122eeed-aee0-4e82-83d8-7ea934920265
+      - 1e88b8a6-b9ea-4b7d-a793-d1499cd28043
     status: 200 OK
     code: 200
     duration: ""
@@ -2560,19 +2626,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:06 GMT
+      - Thu, 16 Nov 2023 16:00:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2582,7 +2648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19ace607-160d-4279-b202-d9c8c7d45015
+      - 6898adbc-0b9c-43ef-8dfd-b4d6a47c0771
     status: 200 OK
     code: 200
     duration: ""
@@ -2593,19 +2659,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:06 GMT
+      - Thu, 16 Nov 2023 16:00:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2615,7 +2681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf1bef2a-d634-4ac2-b2f5-5cbd2b4ce352
+      - d516ce31-2a47-46d7-ae88-4a90d23b9834
     status: 200 OK
     code: 200
     duration: ""
@@ -2626,19 +2692,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:06 GMT
+      - Thu, 16 Nov 2023 16:00:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2648,7 +2714,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40f03bb3-6881-4f3c-ad36-69fb86eff057
+      - 78945958-fcd1-443b-a55f-a6306f344047
     status: 200 OK
     code: 200
     duration: ""
@@ -2659,19 +2725,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "93"
+      - "96"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:07 GMT
+      - Thu, 16 Nov 2023 16:00:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2681,7 +2747,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a69265b5-1e00-4d59-9710-1728760feab2
+      - ca2eb799-ded5-4e25-a0ef-c5945b1f418a
     status: 200 OK
     code: 200
     duration: ""
@@ -2692,19 +2758,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:07 GMT
+      - Thu, 16 Nov 2023 16:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2714,7 +2780,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8756540-b0c3-47d5-9138-45ca295ecf53
+      - 81279b50-afed-4a15-a948-d61d20f0dd11
     status: 200 OK
     code: 200
     duration: ""
@@ -2725,19 +2791,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSElxYThtQ2Q1SVF5V3JsNHBmNDBjU1RGYVFFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBPVm9YRFRNek1URXhNekUxTlRrME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVONk9STVFtK2dCdVR4cmowZVNQYTdJNm53Ylc1RlBJZktVWFp1Ulkvb1RYM01QTC9heVIKT28xaUdpQWtHRDQvNUtvUFMrZGs0dmVCcEhoblJpQWdUL3cxOWo0WEtMc3I1N1Q4ZFNNeTQ4TDVaRVZFdnc0VgpnWmhKd0dyZFRDcUc0YWk1MTdHanRvbzczTE5kcVFncVpZTlY1RitmU09NcXY3VDIvd2pzUUd4Zkp1VEZYWjl4CkdTZVVPKzV4MDZBdHlvNmh4am9LT3hBRWVQQ3JORG1HWTVHY0swMitjYTlWRDhwVzcrQkxjWHlieS9QdUMrNTcKTVBPRERBUlJBQUplOTFWbmZqaHdpWitUbDZ3RUhxTEZ6c3E0aFhNT293LzZTM0tpNURPYTdEbndQa1Q0Rlh3dgpPNUMxakVwdkVDZUVYekxuSlVmUWNabE1PS0RNTmNuMzZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE16RTBZamRrWVRrdFlqRmlOeTAwWldSakxUazNPVFV0TkRZd01qYzQKTldRMU9HWTRMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE2czZvTEN1S2ZqVTFvVy93VU5ZVGJlZmJTQ3A1TUhVUnFxMWVOOFowWWMwZGhIL2VGCjdjdDE4RmdBWnpybEJxMmpDbzk5blB0RndWTE5FbEdXV0F1bE1OT0tvYXc5UzlXK3M1dTRXdVpZb0ZpOTNGTVIKR3JCTURLUzczRmlMZFp5NzdxNFhTZXFhUjV6bGF2L1ZQdHlLSnBCdXZ0alJSb1lDdVpQQllWMTBrd29rVFdGMQp5WnhXKzN1WHcxYlVCTDlUZjUvWTdPVUNMQStiTllxb3VaeDJvVzdFUG5ZSnpFVG9Nckl1aWtRM0t4Qk5WdE81CjFOL21CQjZpaXE3U1IwT1dYdERhalgxQ0sxeERTUHBEYzBXTDhhSDAyY2tyOGJtT1pNaGh2alRXcTU1Q2N6aSsKcTFKbmc4RDhQcS9nU0tJeGhnNXVPSFN1SUlZTEY3WTltK01vCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:07 GMT
+      - Thu, 16 Nov 2023 16:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2747,7 +2813,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 301bce45-44fb-4185-9e44-973ff0bf250b
+      - bd6648be-8747-4f3f-b082-da53b6cf259d
     status: 200 OK
     code: 200
     duration: ""
@@ -2758,19 +2824,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:07 GMT
+      - Thu, 16 Nov 2023 16:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2780,7 +2846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c2b9581-3d0d-4eb7-a7e1-8a7ca1daefbe
+      - 35c39ba0-0b1e-4d72-b2f4-461639fb019d
     status: 200 OK
     code: 200
     duration: ""
@@ -2791,19 +2857,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:07 GMT
+      - Thu, 16 Nov 2023 16:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2813,7 +2879,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b657519-a393-482c-a8c3-88bdd30a9049
+      - 1870eb75-047c-4e34-ae82-e809f5f3ac3a
     status: 200 OK
     code: 200
     duration: ""
@@ -2824,118 +2890,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9aa0dabe-ace0-412f-8bbf-428870f06f4b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1249"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3ce194c0-0fcd-4549-aa1d-2f267e3fdd0e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1249"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a5767f68-529f-436c-bd40-c80c3f5eb504
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:08 GMT
+      - Thu, 16 Nov 2023 16:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2945,7 +2912,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f6861ce-d559-4f88-a06e-1851dc9dd131
+      - 72de6459-5446-40ee-ba13-e524d5566763
     status: 200 OK
     code: 200
     duration: ""
@@ -2956,19 +2923,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1299"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ff332131-3b9f-435f-af2a-cd93456edf77
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1299"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cacecb4d-b069-4605-ace6-909710bd6677
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:08 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2978,7 +3011,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd12b31a-f778-4966-920f-087080ecdcbd
+      - 57a3b081-a682-461e-8be8-437b83268d9a
     status: 200 OK
     code: 200
     duration: ""
@@ -2989,19 +3022,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "61"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d9ca5345-be5e-4634-935a-ee8d54527c71
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "93"
+      - "96"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:08 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3011,7 +3077,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 997ea0ab-38a7-43fb-bef4-363b3d85c74c
+      - 23da4af4-ce2b-49cb-aa2f-5d23bc2e2df8
     status: 200 OK
     code: 200
     duration: ""
@@ -3022,19 +3088,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "93"
+      - "96"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:08 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3044,7 +3110,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 848b5878-91af-46bb-81e4-a9799be39f8c
+      - 2d1d835b-7b14-4ad4-bb25-d6575990677a
     status: 200 OK
     code: 200
     duration: ""
@@ -3055,19 +3121,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3077,7 +3143,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e66e5f57-85ca-45f7-a554-6fd21b1a7f2c
+      - 605675dd-4311-4dc6-bf8c-3e70a6746447
     status: 200 OK
     code: 200
     duration: ""
@@ -3088,19 +3154,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3110,7 +3176,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cabdbfe4-0391-4403-9aff-b3494de9a483
+      - aa005120-a2ed-4dd3-be81-16302b7a615f
     status: 200 OK
     code: 200
     duration: ""
@@ -3121,19 +3187,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "93"
+      - "96"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
+      - Thu, 16 Nov 2023 16:00:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3143,7 +3209,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6215ac89-8a74-4dd0-b348-85d6370c734b
+      - 4fb8a767-dd4f-4353-b68c-6664db87e6dc
     status: 200 OK
     code: 200
     duration: ""
@@ -3154,19 +3220,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
     headers:
       Content-Length:
-      - "1249"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
+      - Thu, 16 Nov 2023 16:00:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3176,7 +3242,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58c5dc45-4cc3-4ba2-bbdf-c7e60ad5d1d8
+      - afda8408-acd5-40df-b99b-7968b612f933
     status: 200 OK
     code: 200
     duration: ""
@@ -3187,19 +3253,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
+      - Thu, 16 Nov 2023 16:00:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3209,7 +3275,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8d6c64e-9ddc-4e59-ada4-078a37ba4e94
+      - cacf3e68-6b66-44eb-a3bf-7816a26ea24d
     status: 200 OK
     code: 200
     duration: ""
@@ -3220,19 +3286,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
+      - Thu, 16 Nov 2023 16:00:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3242,7 +3308,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 014f7afd-e892-454e-addb-d8e7f8903d02
+      - 6df95b15-4989-499d-9f40-b25ef7ff3a2f
     status: 200 OK
     code: 200
     duration: ""
@@ -3253,19 +3319,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
+      - Thu, 16 Nov 2023 16:00:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3275,7 +3341,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fe3c77a-6f41-4749-a085-e450eaa66ac4
+      - a25368e7-cc76-4763-ad1a-4a5f311be401
     status: 200 OK
     code: 200
     duration: ""
@@ -3286,85 +3352,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3def8308-f0a2-4bcc-a262-df09662c2bfb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "102"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 96eae8d1-d7c4-407b-a089-8c47713bc6b5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
+      - Thu, 16 Nov 2023 16:00:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3374,7 +3374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4aa57ef2-2ae3-4db2-8c78-60169c4f8b4c
+      - edd295d7-2223-48ad-936e-ec0900b93c93
     status: 200 OK
     code: 200
     duration: ""
@@ -3385,19 +3385,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
     headers:
       Content-Length:
-      - "93"
+      - "96"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:10 GMT
+      - Thu, 16 Nov 2023 16:00:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3407,7 +3407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0856befe-f176-4197-b2b1-018fb65d6b54
+      - c1824daf-3878-45ef-a31a-19a2642ccf0a
     status: 200 OK
     code: 200
     duration: ""
@@ -3418,52 +3418,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1249"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 248a6598-09e4-4125-ab63-530ad6386e54
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:10 GMT
+      - Thu, 16 Nov 2023 16:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3473,7 +3440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3b9998e-5814-4fa6-8449-dd9fefb8de1d
+      - b40253e1-52b9-43b5-b6d9-9fb647b03ca1
     status: 200 OK
     code: 200
     duration: ""
@@ -3484,19 +3451,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/certificate
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSElxYThtQ2Q1SVF5V3JsNHBmNDBjU1RGYVFFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBPVm9YRFRNek1URXhNekUxTlRrME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVONk9STVFtK2dCdVR4cmowZVNQYTdJNm53Ylc1RlBJZktVWFp1Ulkvb1RYM01QTC9heVIKT28xaUdpQWtHRDQvNUtvUFMrZGs0dmVCcEhoblJpQWdUL3cxOWo0WEtMc3I1N1Q4ZFNNeTQ4TDVaRVZFdnc0VgpnWmhKd0dyZFRDcUc0YWk1MTdHanRvbzczTE5kcVFncVpZTlY1RitmU09NcXY3VDIvd2pzUUd4Zkp1VEZYWjl4CkdTZVVPKzV4MDZBdHlvNmh4am9LT3hBRWVQQ3JORG1HWTVHY0swMitjYTlWRDhwVzcrQkxjWHlieS9QdUMrNTcKTVBPRERBUlJBQUplOTFWbmZqaHdpWitUbDZ3RUhxTEZ6c3E0aFhNT293LzZTM0tpNURPYTdEbndQa1Q0Rlh3dgpPNUMxakVwdkVDZUVYekxuSlVmUWNabE1PS0RNTmNuMzZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE16RTBZamRrWVRrdFlqRmlOeTAwWldSakxUazNPVFV0TkRZd01qYzQKTldRMU9HWTRMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE2czZvTEN1S2ZqVTFvVy93VU5ZVGJlZmJTQ3A1TUhVUnFxMWVOOFowWWMwZGhIL2VGCjdjdDE4RmdBWnpybEJxMmpDbzk5blB0RndWTE5FbEdXV0F1bE1OT0tvYXc5UzlXK3M1dTRXdVpZb0ZpOTNGTVIKR3JCTURLUzczRmlMZFp5NzdxNFhTZXFhUjV6bGF2L1ZQdHlLSnBCdXZ0alJSb1lDdVpQQllWMTBrd29rVFdGMQp5WnhXKzN1WHcxYlVCTDlUZjUvWTdPVUNMQStiTllxb3VaeDJvVzdFUG5ZSnpFVG9Nckl1aWtRM0t4Qk5WdE81CjFOL21CQjZpaXE3U1IwT1dYdERhalgxQ0sxeERTUHBEYzBXTDhhSDAyY2tyOGJtT1pNaGh2alRXcTU1Q2N6aSsKcTFKbmc4RDhQcS9nU0tJeGhnNXVPSFN1SUlZTEY3WTltK01vCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "59"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:10 GMT
+      - Thu, 16 Nov 2023 16:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3506,7 +3473,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5208305a-0344-46be-a5ee-480ac517270d
+      - 6a991d0d-311f-42c3-848c-651714f7195e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1299"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:01:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 950549ad-783f-481d-95a6-a11d39941430
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "61"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:01:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fa933cc1-af3b-4ce0-8be0-cad1ebc723d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "61"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:01:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a1038718-e692-4f37-9dc2-ceb2ebda26d4
     status: 200 OK
     code: 200
     duration: ""
@@ -3519,19 +3585,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"foo"}'
     headers:
       Content-Length:
-      - "61"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 16:01:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3541,7 +3607,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d587e0a-9a00-4bde-94e9-89c84c31a715
+      - 1f183189-2d64-4917-9582-35f21d0645b7
     status: 200 OK
     code: 200
     duration: ""
@@ -3552,19 +3618,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 16:01:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3574,7 +3640,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc58aae7-4326-4fa4-925a-2775b5447f28
+      - ad3fabf8-2e6e-4593-888b-6ae95caaa23a
     status: 200 OK
     code: 200
     duration: ""
@@ -3585,19 +3651,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3607,7 +3673,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbd04148-5931-453a-9775-e7d2c2217cd3
+      - 6cf952c9-29eb-4170-9d0d-fe028cca3e39
     status: 200 OK
     code: 200
     duration: ""
@@ -3618,19 +3684,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3640,7 +3706,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3ce4354-6985-4f3f-8ae5-248b557acf78
+      - a3bf94c9-06cb-4278-9ce2-df06fc1560f3
     status: 200 OK
     code: 200
     duration: ""
@@ -3651,7 +3717,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/users/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/users/foo
     method: DELETE
   response:
     body: ""
@@ -3661,7 +3727,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3671,7 +3737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd04e034-0535-4af9-a7b2-c1c8ef96be41
+      - d5319b39-3c20-483a-b2db-ddb823d53ebe
     status: 204 No Content
     code: 204
     duration: ""
@@ -3682,7 +3748,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/databases/foo
     method: DELETE
   response:
     body: ""
@@ -3692,7 +3758,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3702,7 +3768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7202c3e0-a9db-4699-931f-0375b069b869
+      - 4d0de764-c67c-4216-a024-5f79a2d8c0c5
     status: 204 No Content
     code: 204
     duration: ""
@@ -3713,19 +3779,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:12 GMT
+      - Thu, 16 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3735,7 +3801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8d96e93-bcf9-44f3-82f5-2c41fc69f950
+      - 40ea02c2-5f6b-4222-9d7d-6a0623b70018
     status: 200 OK
     code: 200
     duration: ""
@@ -3746,19 +3812,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:12 GMT
+      - Thu, 16 Nov 2023 16:01:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3768,7 +3834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30b8e107-226f-42dd-ad3e-f40d8d798077
+      - fd797bd8-0220-494b-8cef-4e3dcd6cdba1
     status: 200 OK
     code: 200
     duration: ""
@@ -3779,19 +3845,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmI1Mm9aTTY0VGxSVHNrbmwvSHpMZllCQkhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXhXaGNOTXpNeE1ETXdNVGcwTnpJeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1YcTBJQUV1bHljZXRjeWxIN01mbjRoVHhEdURQTGIrNFQzbUNqU3VReEorYVl2WUV2am9qYnIKR0dNN1pOVzhmS2dlcGpXc0E3MVE2blJXaTNTakphUHA4MTh3Wll3WFZwTHBkdjZod0JsMnhCNXoxTDB0N3FnbgphM2JKcDU5V1dXb2x2enY4RnVTR1MyVVFETGc2OG11bWlBcnhkTUFLeTZjeW1MVFF6KzU5QjlxNy83MU80VURGCk82VFhRVzNhb2hVZ1BSVjM4TmJDNml2UnhxN0lBZ3FSV3YyMnp0cUxMNHVCOWZrd0c1NnB5QXBrRjlxRldIb0sKREhDV3FWRzIzMzFRSURuTERKanE5ZWRpNWJVbzJSZE9lSVQ3aUpSUERpV1dKN2ZsZWtsSmNodEdwVGorNVZIYwpYNm16eGloeFVWRXpXYVlHNFZMWEY0SUVkYitKTElNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WWpSaE1ETTNZbVF0TVdKa09TMDBNMkU0TFdGbFptUXRObVpsT0dRd04yTXoKTXpnNExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckxMUmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1lGSWl1ZUNHTXFwd1QzQmpRN3VnZDM1NkpaTVhGZ0tCOEZ2aG0rS1c4QjIzRy9tTk5vNTgrCnBGRlhPeXJUanB4WjBSbUtjR3crV0NHZ29LV0Q2a3BVWDREV2ZtQ3JCRTJPUFVJNFVoUHRiTU92NFkvSWlKMGgKTENzK2JkRWV1Y1k4bFpvcmxvMCsremp6Wmg4dnNyVC9OUVZ0R1pHM1RkcVFmVFNGWFhveUVaeWNIY1A3YWR1RAprNDlKT2JrNmNFd3d1bnNvU3IzR2NFbjc1Z0dScElaenBmRG5tdVZEM0tXQ0w3ZGJEa084WkdUd2xjTHc0ZkVOCmdUSm9zc1RPNHBjYWk0aDVNbzFCeUthdExpZnBaR3dLVFQyWm9zSUlEODk5OUhjbUYzY1lMQWN4ZHZCbEt0c0sKM2dxejVnQnRCdDFmQ1VMV3ZlNGYrNS8xY2prQ2p3TmQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSElxYThtQ2Q1SVF5V3JsNHBmNDBjU1RGYVFFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBPVm9YRFRNek1URXhNekUxTlRrME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVONk9STVFtK2dCdVR4cmowZVNQYTdJNm53Ylc1RlBJZktVWFp1Ulkvb1RYM01QTC9heVIKT28xaUdpQWtHRDQvNUtvUFMrZGs0dmVCcEhoblJpQWdUL3cxOWo0WEtMc3I1N1Q4ZFNNeTQ4TDVaRVZFdnc0VgpnWmhKd0dyZFRDcUc0YWk1MTdHanRvbzczTE5kcVFncVpZTlY1RitmU09NcXY3VDIvd2pzUUd4Zkp1VEZYWjl4CkdTZVVPKzV4MDZBdHlvNmh4am9LT3hBRWVQQ3JORG1HWTVHY0swMitjYTlWRDhwVzcrQkxjWHlieS9QdUMrNTcKTVBPRERBUlJBQUplOTFWbmZqaHdpWitUbDZ3RUhxTEZ6c3E0aFhNT293LzZTM0tpNURPYTdEbndQa1Q0Rlh3dgpPNUMxakVwdkVDZUVYekxuSlVmUWNabE1PS0RNTmNuMzZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE16RTBZamRrWVRrdFlqRmlOeTAwWldSakxUazNPVFV0TkRZd01qYzQKTldRMU9HWTRMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE2czZvTEN1S2ZqVTFvVy93VU5ZVGJlZmJTQ3A1TUhVUnFxMWVOOFowWWMwZGhIL2VGCjdjdDE4RmdBWnpybEJxMmpDbzk5blB0RndWTE5FbEdXV0F1bE1OT0tvYXc5UzlXK3M1dTRXdVpZb0ZpOTNGTVIKR3JCTURLUzczRmlMZFp5NzdxNFhTZXFhUjV6bGF2L1ZQdHlLSnBCdXZ0alJSb1lDdVpQQllWMTBrd29rVFdGMQp5WnhXKzN1WHcxYlVCTDlUZjUvWTdPVUNMQStiTllxb3VaeDJvVzdFUG5ZSnpFVG9Nckl1aWtRM0t4Qk5WdE81CjFOL21CQjZpaXE3U1IwT1dYdERhalgxQ0sxeERTUHBEYzBXTDhhSDAyY2tyOGJtT1pNaGh2alRXcTU1Q2N6aSsKcTFKbmc4RDhQcS9nU0tJeGhnNXVPSFN1SUlZTEY3WTltK01vCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:12 GMT
+      - Thu, 16 Nov 2023 16:01:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3801,7 +3867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d312b972-dfdb-4ce5-9bb7-d64b90e5ea0c
+      - 19b234ad-953a-458b-ad79-5b880ed5efc2
     status: 200 OK
     code: 200
     duration: ""
@@ -3812,19 +3878,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1249"
+      - "1299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:13 GMT
+      - Thu, 16 Nov 2023 16:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3834,7 +3900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5923aa19-66cc-4dac-9476-e8756d876873
+      - ee1f5381-e916-47a7-a5b3-2825aeee3721
     status: 200 OK
     code: 200
     duration: ""
@@ -3845,19 +3911,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1252"
+      - "1302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:13 GMT
+      - Thu, 16 Nov 2023 16:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3867,7 +3933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae9c0204-c999-4019-a15f-575333972af1
+      - cd80af0f-b211-4d31-a5b0-f50677578cd3
     status: 200 OK
     code: 200
     duration: ""
@@ -3878,19 +3944,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.864169Z","retention":7},"created_at":"2023-11-02T18:46:37.864169Z","endpoint":{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230},"endpoints":[{"id":"abaa4ba3-4ae8-4d39-952f-7c7cf25add34","ip":"51.159.26.223","load_balancer":{},"name":null,"port":28230}],"engine":"PostgreSQL-15","id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:23.309476Z","retention":7},"created_at":"2023-11-16T15:56:23.309476Z","endpoint":{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738},"endpoints":[{"id":"824bf7bb-05df-4638-8106-f159e1587a08","ip":"51.159.113.173","load_balancer":{},"name":null,"port":13738}],"engine":"PostgreSQL-15","id":"314b7da9-b1b7-4edc-9795-4602785d58f8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1252"
+      - "1302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:13 GMT
+      - Thu, 16 Nov 2023 16:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3900,7 +3966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 884ec637-9576-42c8-92c6-63ba1ffdb656
+      - cf77decf-a98b-491f-b853-b14c3249ca83
     status: 200 OK
     code: 200
     duration: ""
@@ -3911,10 +3977,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"314b7da9-b1b7-4edc-9795-4602785d58f8","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3923,7 +3989,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:43 GMT
+      - Thu, 16 Nov 2023 16:01:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3933,7 +3999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cadd788c-0089-4fb3-b654-cefbcf50dfd2
+      - 4622858c-e9ac-4b37-8782-b82578651af0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3944,10 +4010,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b4a037bd-1bd9-43a8-aefd-6fe8d07c3388
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/314b7da9-b1b7-4edc-9795-4602785d58f8
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"b4a037bd-1bd9-43a8-aefd-6fe8d07c3388","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"314b7da9-b1b7-4edc-9795-4602785d58f8","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3956,7 +4022,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:43 GMT
+      - Thu, 16 Nov 2023 16:01:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3966,7 +4032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc871571-81ee-4012-8c3b-d0aa9383d0a3
+      - 80c9ce0a-d1db-4e0f-9d8d-9d7c7bcf4712
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-acl-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-acl-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:32 GMT
+      - Thu, 16 Nov 2023 15:52:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,9 +328,46 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea80fedc-ca63-4be4-9d25-e625a094b3f5
+      - 1681adeb-2942-4592-a210-ed6a398934cc
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: '{"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
+    method: POST
+  response:
+    body: '{"ip":{"address":"51.158.79.120","id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "306"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:24 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/78d361b7-6c7d-44f0-9176-ad85c1726d1b
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d4dea39e-a4a2-4522-aaf3-55d3ea0c4127
+    status: 201 Created
+    code: 201
     duration: ""
 - request:
     body: '{"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
@@ -353,7 +390,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:45 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Location:
       - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/d3970f1f-ac85-4434-904d-760f78fef8f8
       Server:
@@ -365,49 +402,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3f748ec-efda-4ff0-a574-d6056b5a514c
+      - 023bc344-c761-4949-ac75-4a65f38e4438
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
-    method: POST
-  response:
-    body: '{"ip":{"address":"163.172.144.233","id":"fc60dd87-2665-43fb-82f7-37416e799532","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "308"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:45 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fc60dd87-2665-43fb-82f7-37416e799532
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 792c68a6-d11d-4596-b71a-63a2a4038932
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"rdb-acl-basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"rdb-acl-basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -418,16 +418,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "729"
+      - "756"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:45 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -437,40 +437,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d96b5bc-7509-4878-881d-a4c447794f49
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fc60dd87-2665-43fb-82f7-37416e799532
-    method: GET
-  response:
-    body: '{"ip":{"address":"163.172.144.233","id":"fc60dd87-2665-43fb-82f7-37416e799532","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "308"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:50:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b9a6d71e-36cd-4b17-a351-37e843a1e867
+      - 09d31f72-d6c7-4454-9ba9-9991794c98f7
     status: 200 OK
     code: 200
     duration: ""
@@ -493,7 +460,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:45 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -503,7 +470,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a271c92-8e03-46a1-97c5-75a0e6df4ea6
+      - 61cb508c-4f1c-45f3-a875-780ba48cc028
     status: 200 OK
     code: 200
     duration: ""
@@ -514,19 +481,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/78d361b7-6c7d-44f0-9176-ad85c1726d1b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ip":{"address":"51.158.79.120","id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "729"
+      - "306"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:45 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -536,7 +503,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7924cb6-42bd-49da-854c-e09abdcbafbb
+      - 3197d6b9-91c3-486e-b282-d97d00775ea1
     status: 200 OK
     code: 200
     duration: ""
@@ -547,19 +514,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "729"
+      - "756"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:15 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -569,7 +536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46c87017-620b-4cba-add6-35a28a44d90c
+      - 9ddd49ec-cdd0-4362-bc77-b76ec6da51f8
     status: 200 OK
     code: 200
     duration: ""
@@ -580,19 +547,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "729"
+      - "756"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:46 GMT
+      - Thu, 16 Nov 2023 16:00:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -602,7 +569,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fbb53cd-72fb-41e9-b15b-1bcb2996f191
+      - f558fcbc-3e1a-4f38-8a88-c5e3ec46db65
     status: 200 OK
     code: 200
     duration: ""
@@ -613,19 +580,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "729"
+      - "756"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:16 GMT
+      - Thu, 16 Nov 2023 16:01:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -635,7 +602,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c42c15b6-1335-4122-b382-7c2c3de22e33
+      - 86432b47-8d15-4569-9e14-b056a2558ea3
     status: 200 OK
     code: 200
     duration: ""
@@ -646,19 +613,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "729"
+      - "756"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:48 GMT
+      - Thu, 16 Nov 2023 16:01:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -668,7 +635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb455c10-91a5-48df-a385-769d4ab68906
+      - 081e7bed-1d99-4af6-ad0d-8f4f8a22bb53
     status: 200 OK
     code: 200
     duration: ""
@@ -679,19 +646,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "756"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:18 GMT
+      - Thu, 16 Nov 2023 16:02:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -701,7 +668,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b68306f6-9818-4f8c-b261-776e7b173284
+      - da6eae4f-218c-4aa9-95d4-66299bae4f51
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "756"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:02:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1dd9d019-8cd8-42f3-af9a-f180a8b836ab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1031"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:03:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 525a9567-67a0-488d-94ac-b3cbaef04d66
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1248"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ec0211bc-71ba-4b58-afe1-1bddc345320e
     status: 200 OK
     code: 200
     duration: ""
@@ -714,19 +780,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:19 GMT
+      - Thu, 16 Nov 2023 16:04:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -736,7 +802,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dac930cb-3b7e-41dd-b2fa-84f8b1342a98
+      - 1104f0ad-3b00-47ca-9af7-45a9a5704594
     status: 200 OK
     code: 200
     duration: ""
@@ -747,19 +813,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:19 GMT
+      - Thu, 16 Nov 2023 16:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -769,7 +835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfc41364-6e06-4cbc-97d7-15245875d456
+      - 0e43f5c8-8942-4601-adae-5e4e279175a7
     status: 200 OK
     code: 200
     duration: ""
@@ -780,19 +846,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSXJkRVErd0NnYXRHVlhlbEQ5ek53WTNQd213d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXpObG9YRFRNek1URXhNekUyTURNek5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXJzcm9vTFpGb3VIUkNOc0lTYTFuQnBqUWRreXJteStMNUc3QWR1N3J4cHV5dGJLMXRhZDQKNGVBTTRRZU9TRHIzSHlmNks2L0MrbkJNRmVLSlNJWkVJbWhSd21JVkdXdnVnRzd5ZVc4WXVubTYrQi9MNE0wTwpFd2pXRGp1Sm4zRVlyT203eHI3QzhPVHBPQ2JaMVVONFZqT1pXM1E0WCtDU1gwU29IOUtXS1RjcDRCUFlCMlNCCjJ1NXM3RzZEdm40N0VIendGMU5tekt3b2VyZ2lkd3U5UXBOZnEvZ1VuZm9kVTVwSE95bHRmUmc4bHBoMHVpYmIKeTUwR3VkZUJ3UVI0QTYxVmxqMWFvSVYxQ1NsamxSbDVhZlFtUTJiUzJEeW5INVoyY2FTam9WNlcwYmdIRFBrRQp2WFpRM2YyRVVuakFiSklSanE2R3BCNkNXZHVhYmsrbSt3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE5HTmtNMlJtWTJFdE4yVmlPQzAwWldabExXSXpNelF0WW1ZNU4yWm0KT1RVM05qVmlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uMFBod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ2cWFzR09kRWRqKzNLN0JIN1pRSllFMHpkTmkwOER1RlNnNmd6OTdpUngwMFlnZ3Z3Ci9EcFc3QTltajl1bVF4cXYycXVsRGRrVml4LzI4NFRITnR1N0p5WjRSWTR1ZG1UVW5iMVpJZHlGNnQwTzVHK3kKR09rNlo3UkJYRG9jQ2NxZHNjV1BDNjVnWk95cnpuMnd4NWxFamJsVTErZHF5cDdUdlNYcTdzNmhWaVNIMnl1UQozNEpDNllRR2VNcVAvait0c3pLeDJIdTlLeW5hVnVIL0lWMlNqWUtrQWo5VmtUa2EzakJRUkN3WnN1aFltYithClNDR0FMbGdia3loU3RUYW1VRm1HdkFmREh6NnZmYStFc3pzWTJNUUVCdXc0aEwyQ21WaXFlZkxOUS83blNoak4KRGF1Q3F3cHNpUzJjSkw2M25rcHQzSW9hcFN2K0FKZHpYS2l5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:19 GMT
+      - Thu, 16 Nov 2023 16:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -802,7 +868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 368a741a-7fa3-4578-84ef-5c5ead9d56a6
+      - b8587035-6ebc-4f40-bc3b-632e751b8447
     status: 200 OK
     code: 200
     duration: ""
@@ -813,19 +879,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:19 GMT
+      - Thu, 16 Nov 2023 16:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -835,12 +901,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36ac40ae-5195-4c9f-8f07-37c35861d183
+      - df4b71ab-e064-48b5-8da3-60d53da965a6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"rules":[{"ip":"51.15.211.1/32","description":""},{"ip":"163.172.144.233/32","description":""}]}'
+    body: '{"rules":[{"ip":"51.15.211.1/32","description":""},{"ip":"51.158.79.120/32","description":""}]}'
     form: {}
     headers:
       Content-Type:
@@ -848,20 +914,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
     method: PUT
   response:
-    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.211.1/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"IP
-      allowed","direction":"inbound","ip":"163.172.144.233/32","port":12508,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.211.1/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"IP
+      allowed","direction":"inbound","ip":"51.158.79.120/32","port":1047,"protocol":"tcp"}]}'
     headers:
       Content-Length:
-      - "255"
+      - "262"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:19 GMT
+      - Thu, 16 Nov 2023 16:04:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -871,7 +937,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b06ca8fd-dacd-4e63-b89d-f3a923a43e38
+      - e7c10513-3f29-4920-b097-35f959dfddb9
     status: 200 OK
     code: 200
     duration: ""
@@ -882,19 +948,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1208"
+      - "1254"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:19 GMT
+      - Thu, 16 Nov 2023 16:04:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -904,7 +970,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f24e09b4-aa9f-4db4-9bde-82ea222c2c16
+      - 44670cef-f1ab-445d-800c-f7d4cddf9b2b
     status: 200 OK
     code: 200
     duration: ""
@@ -915,19 +981,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:50 GMT
+      - Thu, 16 Nov 2023 16:04:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -937,7 +1003,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72ec5352-fc98-4e8a-9209-5522263a36b9
+      - 5d5d8c9b-27ff-460c-aa26-ac3a0951e9cb
     status: 200 OK
     code: 200
     duration: ""
@@ -948,20 +1014,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.211.1/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"IP
-      allowed","direction":"inbound","ip":"163.172.144.233/32","port":12508,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.211.1/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"IP
+      allowed","direction":"inbound","ip":"51.158.79.120/32","port":1047,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "271"
+      - "279"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:50 GMT
+      - Thu, 16 Nov 2023 16:04:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -971,239 +1037,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee22d843-1be3-4920-9967-a79495d0cd76
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/d3970f1f-ac85-4434-904d-760f78fef8f8
-    method: GET
-  response:
-    body: '{"ip":{"address":"51.15.211.1","id":"d3970f1f-ac85-4434-904d-760f78fef8f8","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "304"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 64e1f654-f6b0-4ccf-8019-8d88db39b83e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fc60dd87-2665-43fb-82f7-37416e799532
-    method: GET
-  response:
-    body: '{"ip":{"address":"163.172.144.233","id":"fc60dd87-2665-43fb-82f7-37416e799532","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "308"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cff1c464-a645-41b5-84f2-88aba31aab81
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1202"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b6c564e4-a5d4-4c7d-9e53-28211073dadb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1843"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fadf38a5-7698-4dc2-b0cf-6a40d620f946
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1202"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0f1dde11-9d57-49cc-86a0-fb3626d23ba2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
-    method: GET
-  response:
-    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.211.1/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"IP
-      allowed","direction":"inbound","ip":"163.172.144.233/32","port":12508,"protocol":"tcp"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "271"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4ddc9a4c-c2fb-49f0-a57c-d78303b79ce9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fc60dd87-2665-43fb-82f7-37416e799532
-    method: GET
-  response:
-    body: '{"ip":{"address":"163.172.144.233","id":"fc60dd87-2665-43fb-82f7-37416e799532","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "308"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 038b0472-aabd-4dce-8e93-35a71867096d
+      - dea9e189-77e5-42f9-ac49-a7bfe394ffa9
     status: 200 OK
     code: 200
     duration: ""
@@ -1226,7 +1060,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:52 GMT
+      - Thu, 16 Nov 2023 16:04:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1236,7 +1070,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 728dc8bb-2068-42bc-9885-0e122bd284b5
+      - 84cb4962-3620-47a4-b179-36ed94754f12
     status: 200 OK
     code: 200
     duration: ""
@@ -1247,19 +1081,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/78d361b7-6c7d-44f0-9176-ad85c1726d1b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ip":{"address":"51.158.79.120","id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "306"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:52 GMT
+      - Thu, 16 Nov 2023 16:04:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1269,7 +1103,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c972eea8-5d5e-4606-b8f3-68c80a3b92df
+      - 253f9aff-adde-4667-a63d-e3cb40b6d270
     status: 200 OK
     code: 200
     duration: ""
@@ -1280,19 +1114,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:52 GMT
+      - Thu, 16 Nov 2023 16:04:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1302,7 +1136,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b685e5b-5827-48a8-a240-92254e780cc8
+      - 0402bfab-6c17-47c3-9125-2492a91e923d
     status: 200 OK
     code: 200
     duration: ""
@@ -1313,19 +1147,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSXJkRVErd0NnYXRHVlhlbEQ5ek53WTNQd213d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXpObG9YRFRNek1URXhNekUyTURNek5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXJzcm9vTFpGb3VIUkNOc0lTYTFuQnBqUWRreXJteStMNUc3QWR1N3J4cHV5dGJLMXRhZDQKNGVBTTRRZU9TRHIzSHlmNks2L0MrbkJNRmVLSlNJWkVJbWhSd21JVkdXdnVnRzd5ZVc4WXVubTYrQi9MNE0wTwpFd2pXRGp1Sm4zRVlyT203eHI3QzhPVHBPQ2JaMVVONFZqT1pXM1E0WCtDU1gwU29IOUtXS1RjcDRCUFlCMlNCCjJ1NXM3RzZEdm40N0VIendGMU5tekt3b2VyZ2lkd3U5UXBOZnEvZ1VuZm9kVTVwSE95bHRmUmc4bHBoMHVpYmIKeTUwR3VkZUJ3UVI0QTYxVmxqMWFvSVYxQ1NsamxSbDVhZlFtUTJiUzJEeW5INVoyY2FTam9WNlcwYmdIRFBrRQp2WFpRM2YyRVVuakFiSklSanE2R3BCNkNXZHVhYmsrbSt3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE5HTmtNMlJtWTJFdE4yVmlPQzAwWldabExXSXpNelF0WW1ZNU4yWm0KT1RVM05qVmlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uMFBod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ2cWFzR09kRWRqKzNLN0JIN1pRSllFMHpkTmkwOER1RlNnNmd6OTdpUngwMFlnZ3Z3Ci9EcFc3QTltajl1bVF4cXYycXVsRGRrVml4LzI4NFRITnR1N0p5WjRSWTR1ZG1UVW5iMVpJZHlGNnQwTzVHK3kKR09rNlo3UkJYRG9jQ2NxZHNjV1BDNjVnWk95cnpuMnd4NWxFamJsVTErZHF5cDdUdlNYcTdzNmhWaVNIMnl1UQozNEpDNllRR2VNcVAvait0c3pLeDJIdTlLeW5hVnVIL0lWMlNqWUtrQWo5VmtUa2EzakJRUkN3WnN1aFltYithClNDR0FMbGdia3loU3RUYW1VRm1HdkFmREh6NnZmYStFc3pzWTJNUUVCdXc0aEwyQ21WaXFlZkxOUS83blNoak4KRGF1Q3F3cHNpUzJjSkw2M25rcHQzSW9hcFN2K0FKZHpYS2l5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1202"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:52 GMT
+      - Thu, 16 Nov 2023 16:04:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1335,7 +1169,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2f4df26-d4d9-497d-85a7-68337821db7d
+      - fcdb3275-3fa0-416a-ac3b-525db5c52b28
     status: 200 OK
     code: 200
     duration: ""
@@ -1346,20 +1180,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.211.1/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"IP
-      allowed","direction":"inbound","ip":"163.172.144.233/32","port":12508,"protocol":"tcp"}],"total_count":2}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "271"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:52 GMT
+      - Thu, 16 Nov 2023 16:04:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1369,7 +1202,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 942ec956-ba86-4aeb-b239-c39ea5880807
+      - e222c72d-91a0-4e31-91a9-7eb09704a5ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1380,15 +1213,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fc60dd87-2665-43fb-82f7-37416e799532
-    method: DELETE
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
+    method: GET
   response:
-    body: ""
+    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.211.1/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"IP
+      allowed","direction":"inbound","ip":"51.158.79.120/32","port":1047,"protocol":"tcp"}],"total_count":2}'
     headers:
+      Content-Length:
+      - "279"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:53 GMT
+      - Thu, 16 Nov 2023 16:04:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1398,9 +1236,208 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0a22a20-4ea1-442f-b373-fc6f9e3a510c
-    status: 204 No Content
-    code: 204
+      - 67035c5f-4d90-46a6-946a-bd720829b41b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/d3970f1f-ac85-4434-904d-760f78fef8f8
+    method: GET
+  response:
+    body: '{"ip":{"address":"51.15.211.1","id":"d3970f1f-ac85-4434-904d-760f78fef8f8","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "304"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a0f20a17-833d-4674-9277-8784edcf767d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/78d361b7-6c7d-44f0-9176-ad85c1726d1b
+    method: GET
+  response:
+    body: '{"ip":{"address":"51.158.79.120","id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "306"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fdce0a68-9d9f-4918-abaa-913d7f9e42a7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1248"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c79327bf-e793-4bec-9209-478811266789
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSXJkRVErd0NnYXRHVlhlbEQ5ek53WTNQd213d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXpObG9YRFRNek1URXhNekUyTURNek5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXJzcm9vTFpGb3VIUkNOc0lTYTFuQnBqUWRreXJteStMNUc3QWR1N3J4cHV5dGJLMXRhZDQKNGVBTTRRZU9TRHIzSHlmNks2L0MrbkJNRmVLSlNJWkVJbWhSd21JVkdXdnVnRzd5ZVc4WXVubTYrQi9MNE0wTwpFd2pXRGp1Sm4zRVlyT203eHI3QzhPVHBPQ2JaMVVONFZqT1pXM1E0WCtDU1gwU29IOUtXS1RjcDRCUFlCMlNCCjJ1NXM3RzZEdm40N0VIendGMU5tekt3b2VyZ2lkd3U5UXBOZnEvZ1VuZm9kVTVwSE95bHRmUmc4bHBoMHVpYmIKeTUwR3VkZUJ3UVI0QTYxVmxqMWFvSVYxQ1NsamxSbDVhZlFtUTJiUzJEeW5INVoyY2FTam9WNlcwYmdIRFBrRQp2WFpRM2YyRVVuakFiSklSanE2R3BCNkNXZHVhYmsrbSt3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE5HTmtNMlJtWTJFdE4yVmlPQzAwWldabExXSXpNelF0WW1ZNU4yWm0KT1RVM05qVmlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uMFBod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ2cWFzR09kRWRqKzNLN0JIN1pRSllFMHpkTmkwOER1RlNnNmd6OTdpUngwMFlnZ3Z3Ci9EcFc3QTltajl1bVF4cXYycXVsRGRrVml4LzI4NFRITnR1N0p5WjRSWTR1ZG1UVW5iMVpJZHlGNnQwTzVHK3kKR09rNlo3UkJYRG9jQ2NxZHNjV1BDNjVnWk95cnpuMnd4NWxFamJsVTErZHF5cDdUdlNYcTdzNmhWaVNIMnl1UQozNEpDNllRR2VNcVAvait0c3pLeDJIdTlLeW5hVnVIL0lWMlNqWUtrQWo5VmtUa2EzakJRUkN3WnN1aFltYithClNDR0FMbGdia3loU3RUYW1VRm1HdkFmREh6NnZmYStFc3pzWTJNUUVCdXc0aEwyQ21WaXFlZkxOUS83blNoak4KRGF1Q3F3cHNpUzJjSkw2M25rcHQzSW9hcFN2K0FKZHpYS2l5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1849"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 837bbffc-e965-4d2e-a76f-9533e13f30a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1248"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 307b6475-ac69-4b74-8471-69080f576fe6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.211.1/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"IP
+      allowed","direction":"inbound","ip":"51.158.79.120/32","port":1047,"protocol":"tcp"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "279"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e0ee2f70-d5b8-4fac-9079-a73cfeb99803
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -1417,7 +1454,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 02 Nov 2023 18:53:53 GMT
+      - Thu, 16 Nov 2023 16:04:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1427,7 +1464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c88cc12d-7691-4177-9fdb-6ea21ea2f964
+      - 710bcf04-dff2-48bd-8ad1-cacb6c1147fe
     status: 204 No Content
     code: 204
     duration: ""
@@ -1438,19 +1475,15 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
-    method: GET
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/78d361b7-6c7d-44f0-9176-ad85c1726d1b
+    method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: ""
     headers:
-      Content-Length:
-      - "1202"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:53 GMT
+      - Thu, 16 Nov 2023 16:04:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1460,7 +1493,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd00fd25-a629-4ac3-86c2-348d97189d4d
+      - 3a4a135a-17ed-4e3e-898e-8de7ca400cb0
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1248"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6a860deb-8b46-49cb-94f1-72f6678bd744
     status: 200 OK
     code: 200
     duration: ""
@@ -1471,19 +1537,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:53 GMT
+      - Thu, 16 Nov 2023 16:04:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1493,7 +1559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8106e1fe-40cc-4189-99cd-915ffaa06b22
+      - fb2a0711-18d7-4ddd-9ad4-378dab32bd59
     status: 200 OK
     code: 200
     duration: ""
@@ -1506,19 +1572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
     method: PUT
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":12508,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":1047,"protocol":"tcp"}]}'
     headers:
       Content-Length:
-      - "229"
+      - "238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:54 GMT
+      - Thu, 16 Nov 2023 16:04:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1528,7 +1594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df7cec48-47fc-475c-b090-f7cd89eb19f7
+      - a9cd1b46-d842-4b8b-86f6-14d28eb53eda
     status: 200 OK
     code: 200
     duration: ""
@@ -1539,19 +1605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1208"
+      - "1254"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:54 GMT
+      - Thu, 16 Nov 2023 16:04:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1561,7 +1627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 040a9029-c6af-4e50-9ec2-adc3bcc958d3
+      - bb445afa-600c-4299-8cc5-bee502bb3cb3
     status: 200 OK
     code: 200
     duration: ""
@@ -1572,19 +1638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:24 GMT
+      - Thu, 16 Nov 2023 16:05:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1594,7 +1660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d018268a-3436-426c-8ef9-58006b21f21c
+      - 1db22d15-552c-4e2e-a41e-6ead3ef81ffa
     status: 200 OK
     code: 200
     duration: ""
@@ -1605,19 +1671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":12508,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":1047,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:24 GMT
+      - Thu, 16 Nov 2023 16:05:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1627,7 +1693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33692369-36b6-46d0-b3d1-cf461a142b20
+      - 1d79b96a-720e-473a-aaef-c4e041ad3c24
     status: 200 OK
     code: 200
     duration: ""
@@ -1638,19 +1704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:25 GMT
+      - Thu, 16 Nov 2023 16:05:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1660,7 +1726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6858c37f-5abd-4c2d-92b7-f10f28317acf
+      - 5d53fd75-23b5-4875-a30d-547e24c45ac0
     status: 200 OK
     code: 200
     duration: ""
@@ -1671,19 +1737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSXJkRVErd0NnYXRHVlhlbEQ5ek53WTNQd213d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXpObG9YRFRNek1URXhNekUyTURNek5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXJzcm9vTFpGb3VIUkNOc0lTYTFuQnBqUWRreXJteStMNUc3QWR1N3J4cHV5dGJLMXRhZDQKNGVBTTRRZU9TRHIzSHlmNks2L0MrbkJNRmVLSlNJWkVJbWhSd21JVkdXdnVnRzd5ZVc4WXVubTYrQi9MNE0wTwpFd2pXRGp1Sm4zRVlyT203eHI3QzhPVHBPQ2JaMVVONFZqT1pXM1E0WCtDU1gwU29IOUtXS1RjcDRCUFlCMlNCCjJ1NXM3RzZEdm40N0VIendGMU5tekt3b2VyZ2lkd3U5UXBOZnEvZ1VuZm9kVTVwSE95bHRmUmc4bHBoMHVpYmIKeTUwR3VkZUJ3UVI0QTYxVmxqMWFvSVYxQ1NsamxSbDVhZlFtUTJiUzJEeW5INVoyY2FTam9WNlcwYmdIRFBrRQp2WFpRM2YyRVVuakFiSklSanE2R3BCNkNXZHVhYmsrbSt3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE5HTmtNMlJtWTJFdE4yVmlPQzAwWldabExXSXpNelF0WW1ZNU4yWm0KT1RVM05qVmlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uMFBod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ2cWFzR09kRWRqKzNLN0JIN1pRSllFMHpkTmkwOER1RlNnNmd6OTdpUngwMFlnZ3Z3Ci9EcFc3QTltajl1bVF4cXYycXVsRGRrVml4LzI4NFRITnR1N0p5WjRSWTR1ZG1UVW5iMVpJZHlGNnQwTzVHK3kKR09rNlo3UkJYRG9jQ2NxZHNjV1BDNjVnWk95cnpuMnd4NWxFamJsVTErZHF5cDdUdlNYcTdzNmhWaVNIMnl1UQozNEpDNllRR2VNcVAvait0c3pLeDJIdTlLeW5hVnVIL0lWMlNqWUtrQWo5VmtUa2EzakJRUkN3WnN1aFltYithClNDR0FMbGdia3loU3RUYW1VRm1HdkFmREh6NnZmYStFc3pzWTJNUUVCdXc0aEwyQ21WaXFlZkxOUS83blNoak4KRGF1Q3F3cHNpUzJjSkw2M25rcHQzSW9hcFN2K0FKZHpYS2l5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:25 GMT
+      - Thu, 16 Nov 2023 16:05:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1693,7 +1759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 817695ef-a5aa-489a-a83a-222deca14906
+      - 446d3c77-e0a9-40a9-9662-a6c012211199
     status: 200 OK
     code: 200
     duration: ""
@@ -1704,19 +1770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:25 GMT
+      - Thu, 16 Nov 2023 16:05:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1726,7 +1792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ac28beb-37d9-4c17-a167-95a00a8d5269
+      - f3748603-22a3-46a0-8d43-13cd8e764877
     status: 200 OK
     code: 200
     duration: ""
@@ -1737,19 +1803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":12508,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":1047,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:25 GMT
+      - Thu, 16 Nov 2023 16:05:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1759,7 +1825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e954cfe-3ae6-4d43-bdb5-ecd8c03f8e12
+      - 05931c76-e8ba-448d-827f-499665cc3979
     status: 200 OK
     code: 200
     duration: ""
@@ -1770,19 +1836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:25 GMT
+      - Thu, 16 Nov 2023 16:05:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1792,7 +1858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffdad242-5310-486c-9969-b02cce5ff87a
+      - b4547597-1713-472d-bf81-0e9ccbe45e97
     status: 200 OK
     code: 200
     duration: ""
@@ -1803,19 +1869,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSXJkRVErd0NnYXRHVlhlbEQ5ek53WTNQd213d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXpObG9YRFRNek1URXhNekUyTURNek5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXJzcm9vTFpGb3VIUkNOc0lTYTFuQnBqUWRreXJteStMNUc3QWR1N3J4cHV5dGJLMXRhZDQKNGVBTTRRZU9TRHIzSHlmNks2L0MrbkJNRmVLSlNJWkVJbWhSd21JVkdXdnVnRzd5ZVc4WXVubTYrQi9MNE0wTwpFd2pXRGp1Sm4zRVlyT203eHI3QzhPVHBPQ2JaMVVONFZqT1pXM1E0WCtDU1gwU29IOUtXS1RjcDRCUFlCMlNCCjJ1NXM3RzZEdm40N0VIendGMU5tekt3b2VyZ2lkd3U5UXBOZnEvZ1VuZm9kVTVwSE95bHRmUmc4bHBoMHVpYmIKeTUwR3VkZUJ3UVI0QTYxVmxqMWFvSVYxQ1NsamxSbDVhZlFtUTJiUzJEeW5INVoyY2FTam9WNlcwYmdIRFBrRQp2WFpRM2YyRVVuakFiSklSanE2R3BCNkNXZHVhYmsrbSt3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE5HTmtNMlJtWTJFdE4yVmlPQzAwWldabExXSXpNelF0WW1ZNU4yWm0KT1RVM05qVmlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uMFBod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ2cWFzR09kRWRqKzNLN0JIN1pRSllFMHpkTmkwOER1RlNnNmd6OTdpUngwMFlnZ3Z3Ci9EcFc3QTltajl1bVF4cXYycXVsRGRrVml4LzI4NFRITnR1N0p5WjRSWTR1ZG1UVW5iMVpJZHlGNnQwTzVHK3kKR09rNlo3UkJYRG9jQ2NxZHNjV1BDNjVnWk95cnpuMnd4NWxFamJsVTErZHF5cDdUdlNYcTdzNmhWaVNIMnl1UQozNEpDNllRR2VNcVAvait0c3pLeDJIdTlLeW5hVnVIL0lWMlNqWUtrQWo5VmtUa2EzakJRUkN3WnN1aFltYithClNDR0FMbGdia3loU3RUYW1VRm1HdkFmREh6NnZmYStFc3pzWTJNUUVCdXc0aEwyQ21WaXFlZkxOUS83blNoak4KRGF1Q3F3cHNpUzJjSkw2M25rcHQzSW9hcFN2K0FKZHpYS2l5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:25 GMT
+      - Thu, 16 Nov 2023 16:05:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1825,7 +1891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfbba1af-591f-41fa-8783-b7b852c8e03b
+      - 38731793-96b3-4cf1-a821-3970c3e3a5ea
     status: 200 OK
     code: 200
     duration: ""
@@ -1836,19 +1902,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:26 GMT
+      - Thu, 16 Nov 2023 16:05:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1858,7 +1924,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb574219-578d-4df1-9f05-8943cf2cc590
+      - 63780927-e581-4c9f-947d-d855b13d7b4e
     status: 200 OK
     code: 200
     duration: ""
@@ -1869,19 +1935,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":12508,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":1047,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:26 GMT
+      - Thu, 16 Nov 2023 16:05:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1891,7 +1957,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b797c581-edc9-4728-ab24-b164aa4de2fc
+      - 7fc66228-ab58-45bc-b5f4-8b15b81e76b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1902,19 +1968,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:26 GMT
+      - Thu, 16 Nov 2023 16:05:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1924,7 +1990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37cc853b-f393-4593-bb88-b0bb4753c5c0
+      - fb16b59f-d5b1-41d9-989d-aebd1394e2d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1935,19 +2001,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:26 GMT
+      - Thu, 16 Nov 2023 16:05:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1957,7 +2023,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16c020d7-630f-4fae-9f88-e286c6c83dcb
+      - a4b6cf4c-2340-4e0c-bf90-f1a3b84808f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1970,19 +2036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
     method: PUT
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12508,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":1047,"protocol":"tcp"}]}'
     headers:
       Content-Length:
-      - "229"
+      - "238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:27 GMT
+      - Thu, 16 Nov 2023 16:05:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1992,7 +2058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2109977-ce44-406e-aa4b-a582c82236a9
+      - 38198e02-9302-4d26-b40b-e000b7bfd30e
     status: 200 OK
     code: 200
     duration: ""
@@ -2003,19 +2069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1208"
+      - "1254"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:27 GMT
+      - Thu, 16 Nov 2023 16:05:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2025,7 +2091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c490da5-0794-458e-9b2d-5ae646830584
+      - 07a46cbb-44c3-4321-bf15-b8960b4f0730
     status: 200 OK
     code: 200
     duration: ""
@@ -2036,19 +2102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:58 GMT
+      - Thu, 16 Nov 2023 16:05:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2058,7 +2124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04209fa0-36c3-431e-bbb8-aa80f6d7e2cf
+      - 042bf273-dd25-47a7-be4c-e7a4d4589cb1
     status: 200 OK
     code: 200
     duration: ""
@@ -2069,19 +2135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12508,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":1047,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:59 GMT
+      - Thu, 16 Nov 2023 16:05:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2091,7 +2157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71dffb83-dff1-44bf-8522-23e1414b4bc1
+      - 0fb07c78-3d11-4e36-a228-fbbb80c2e66a
     status: 200 OK
     code: 200
     duration: ""
@@ -2102,19 +2168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:00 GMT
+      - Thu, 16 Nov 2023 16:05:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2124,7 +2190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad9be827-b97f-4339-b7f3-56c6b64f8198
+      - 49dc4f81-38c2-4456-bc57-02b5b85ce305
     status: 200 OK
     code: 200
     duration: ""
@@ -2135,19 +2201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSXJkRVErd0NnYXRHVlhlbEQ5ek53WTNQd213d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXpObG9YRFRNek1URXhNekUyTURNek5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXJzcm9vTFpGb3VIUkNOc0lTYTFuQnBqUWRreXJteStMNUc3QWR1N3J4cHV5dGJLMXRhZDQKNGVBTTRRZU9TRHIzSHlmNks2L0MrbkJNRmVLSlNJWkVJbWhSd21JVkdXdnVnRzd5ZVc4WXVubTYrQi9MNE0wTwpFd2pXRGp1Sm4zRVlyT203eHI3QzhPVHBPQ2JaMVVONFZqT1pXM1E0WCtDU1gwU29IOUtXS1RjcDRCUFlCMlNCCjJ1NXM3RzZEdm40N0VIendGMU5tekt3b2VyZ2lkd3U5UXBOZnEvZ1VuZm9kVTVwSE95bHRmUmc4bHBoMHVpYmIKeTUwR3VkZUJ3UVI0QTYxVmxqMWFvSVYxQ1NsamxSbDVhZlFtUTJiUzJEeW5INVoyY2FTam9WNlcwYmdIRFBrRQp2WFpRM2YyRVVuakFiSklSanE2R3BCNkNXZHVhYmsrbSt3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE5HTmtNMlJtWTJFdE4yVmlPQzAwWldabExXSXpNelF0WW1ZNU4yWm0KT1RVM05qVmlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uMFBod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ2cWFzR09kRWRqKzNLN0JIN1pRSllFMHpkTmkwOER1RlNnNmd6OTdpUngwMFlnZ3Z3Ci9EcFc3QTltajl1bVF4cXYycXVsRGRrVml4LzI4NFRITnR1N0p5WjRSWTR1ZG1UVW5iMVpJZHlGNnQwTzVHK3kKR09rNlo3UkJYRG9jQ2NxZHNjV1BDNjVnWk95cnpuMnd4NWxFamJsVTErZHF5cDdUdlNYcTdzNmhWaVNIMnl1UQozNEpDNllRR2VNcVAvait0c3pLeDJIdTlLeW5hVnVIL0lWMlNqWUtrQWo5VmtUa2EzakJRUkN3WnN1aFltYithClNDR0FMbGdia3loU3RUYW1VRm1HdkFmREh6NnZmYStFc3pzWTJNUUVCdXc0aEwyQ21WaXFlZkxOUS83blNoak4KRGF1Q3F3cHNpUzJjSkw2M25rcHQzSW9hcFN2K0FKZHpYS2l5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:00 GMT
+      - Thu, 16 Nov 2023 16:05:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2157,7 +2223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d873090-4a91-4ff3-9f71-3735acc0825e
+      - 9f3651df-79ef-44c6-b370-eccaa1b3c0ee
     status: 200 OK
     code: 200
     duration: ""
@@ -2168,19 +2234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:01 GMT
+      - Thu, 16 Nov 2023 16:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2190,7 +2256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17de0ad6-044d-4749-9ecd-2c66c902e60c
+      - b66f0b7b-a2be-433b-a182-a30cbe0789e1
     status: 200 OK
     code: 200
     duration: ""
@@ -2201,19 +2267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12508,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":1047,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:01 GMT
+      - Thu, 16 Nov 2023 16:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2223,7 +2289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad69da7c-2122-483e-ba0c-c99e52fdd668
+      - 7a1ace83-8155-4d07-bfec-011978f6f01a
     status: 200 OK
     code: 200
     duration: ""
@@ -2234,19 +2300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:01 GMT
+      - Thu, 16 Nov 2023 16:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2256,7 +2322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df17901c-c569-43f9-a946-5d27c1bd199d
+      - 986350e8-9ec3-4644-95cc-2d4cfe502aaa
     status: 200 OK
     code: 200
     duration: ""
@@ -2267,19 +2333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:01 GMT
+      - Thu, 16 Nov 2023 16:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2289,7 +2355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a17fd04-903e-46d8-b2da-64871f9b9e1c
+      - 49a06236-d509-4d11-bc1c-b9890bd5e6d5
     status: 200 OK
     code: 200
     duration: ""
@@ -2300,19 +2366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":1047,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1843"
+      - "255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:01 GMT
+      - Thu, 16 Nov 2023 16:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2322,7 +2388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7c53e0f-6c41-48dd-af47-0ba5ae5e203c
+      - ed87e6bd-1da8-4bc3-bcef-6b030e5d066f
     status: 200 OK
     code: 200
     duration: ""
@@ -2333,19 +2399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/certificate
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12508,"protocol":"tcp"}],"total_count":2}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSXJkRVErd0NnYXRHVlhlbEQ5ek53WTNQd213d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXpObG9YRFRNek1URXhNekUyTURNek5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXJzcm9vTFpGb3VIUkNOc0lTYTFuQnBqUWRreXJteStMNUc3QWR1N3J4cHV5dGJLMXRhZDQKNGVBTTRRZU9TRHIzSHlmNks2L0MrbkJNRmVLSlNJWkVJbWhSd21JVkdXdnVnRzd5ZVc4WXVubTYrQi9MNE0wTwpFd2pXRGp1Sm4zRVlyT203eHI3QzhPVHBPQ2JaMVVONFZqT1pXM1E0WCtDU1gwU29IOUtXS1RjcDRCUFlCMlNCCjJ1NXM3RzZEdm40N0VIendGMU5tekt3b2VyZ2lkd3U5UXBOZnEvZ1VuZm9kVTVwSE95bHRmUmc4bHBoMHVpYmIKeTUwR3VkZUJ3UVI0QTYxVmxqMWFvSVYxQ1NsamxSbDVhZlFtUTJiUzJEeW5INVoyY2FTam9WNlcwYmdIRFBrRQp2WFpRM2YyRVVuakFiSklSanE2R3BCNkNXZHVhYmsrbSt3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE5HTmtNMlJtWTJFdE4yVmlPQzAwWldabExXSXpNelF0WW1ZNU4yWm0KT1RVM05qVmlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uMFBod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ2cWFzR09kRWRqKzNLN0JIN1pRSllFMHpkTmkwOER1RlNnNmd6OTdpUngwMFlnZ3Z3Ci9EcFc3QTltajl1bVF4cXYycXVsRGRrVml4LzI4NFRITnR1N0p5WjRSWTR1ZG1UVW5iMVpJZHlGNnQwTzVHK3kKR09rNlo3UkJYRG9jQ2NxZHNjV1BDNjVnWk95cnpuMnd4NWxFamJsVTErZHF5cDdUdlNYcTdzNmhWaVNIMnl1UQozNEpDNllRR2VNcVAvait0c3pLeDJIdTlLeW5hVnVIL0lWMlNqWUtrQWo5VmtUa2EzakJRUkN3WnN1aFltYithClNDR0FMbGdia3loU3RUYW1VRm1HdkFmREh6NnZmYStFc3pzWTJNUUVCdXc0aEwyQ21WaXFlZkxOUS83blNoak4KRGF1Q3F3cHNpUzJjSkw2M25rcHQzSW9hcFN2K0FKZHpYS2l5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "245"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:01 GMT
+      - Thu, 16 Nov 2023 16:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2355,7 +2421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 042e679d-d610-4865-bfa6-f00785f3dbd5
+      - e9d4c6ca-e390-4cc1-9029-1823f4013cb5
     status: 200 OK
     code: 200
     duration: ""
@@ -2366,19 +2432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:02 GMT
+      - Thu, 16 Nov 2023 16:05:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2388,7 +2454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 609462ae-402f-4716-9776-614d54ba33ba
+      - 05b0b276-ce4f-4683-8c66-01061bdeed80
     status: 200 OK
     code: 200
     duration: ""
@@ -2401,19 +2467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/acls
     method: DELETE
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12508,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12508,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":1047,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":1047,"protocol":"tcp"}]}'
     headers:
       Content-Length:
-      - "229"
+      - "238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:02 GMT
+      - Thu, 16 Nov 2023 16:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2423,7 +2489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5f25734-e6e8-4bdd-a3d6-c32bdaf81635
+      - 3e92acd3-56fb-4e20-ad4f-9857865c5d90
     status: 200 OK
     code: 200
     duration: ""
@@ -2434,19 +2500,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1208"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:02 GMT
+      - Thu, 16 Nov 2023 16:05:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2456,7 +2522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81fa4ef3-7de9-49e2-8820-d0ec33441801
+      - f074cafe-3cbe-4cb9-9a67-4ce008e8b23c
     status: 200 OK
     code: 200
     duration: ""
@@ -2467,19 +2533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:32 GMT
+      - Thu, 16 Nov 2023 16:05:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2489,7 +2555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a106911-bd95-48e5-97cf-a24bee019f6c
+      - db4c45b1-a339-410b-843c-d6e26fdcef1c
     status: 200 OK
     code: 200
     duration: ""
@@ -2500,19 +2566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSXJkRVErd0NnYXRHVlhlbEQ5ek53WTNQd213d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1ETXpObG9YRFRNek1URXhNekUyTURNek5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXJzcm9vTFpGb3VIUkNOc0lTYTFuQnBqUWRreXJteStMNUc3QWR1N3J4cHV5dGJLMXRhZDQKNGVBTTRRZU9TRHIzSHlmNks2L0MrbkJNRmVLSlNJWkVJbWhSd21JVkdXdnVnRzd5ZVc4WXVubTYrQi9MNE0wTwpFd2pXRGp1Sm4zRVlyT203eHI3QzhPVHBPQ2JaMVVONFZqT1pXM1E0WCtDU1gwU29IOUtXS1RjcDRCUFlCMlNCCjJ1NXM3RzZEdm40N0VIendGMU5tekt3b2VyZ2lkd3U5UXBOZnEvZ1VuZm9kVTVwSE95bHRmUmc4bHBoMHVpYmIKeTUwR3VkZUJ3UVI0QTYxVmxqMWFvSVYxQ1NsamxSbDVhZlFtUTJiUzJEeW5INVoyY2FTam9WNlcwYmdIRFBrRQp2WFpRM2YyRVVuakFiSklSanE2R3BCNkNXZHVhYmsrbSt3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE5HTmtNMlJtWTJFdE4yVmlPQzAwWldabExXSXpNelF0WW1ZNU4yWm0KT1RVM05qVmlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uMFBod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ2cWFzR09kRWRqKzNLN0JIN1pRSllFMHpkTmkwOER1RlNnNmd6OTdpUngwMFlnZ3Z3Ci9EcFc3QTltajl1bVF4cXYycXVsRGRrVml4LzI4NFRITnR1N0p5WjRSWTR1ZG1UVW5iMVpJZHlGNnQwTzVHK3kKR09rNlo3UkJYRG9jQ2NxZHNjV1BDNjVnWk95cnpuMnd4NWxFamJsVTErZHF5cDdUdlNYcTdzNmhWaVNIMnl1UQozNEpDNllRR2VNcVAvait0c3pLeDJIdTlLeW5hVnVIL0lWMlNqWUtrQWo5VmtUa2EzakJRUkN3WnN1aFltYithClNDR0FMbGdia3loU3RUYW1VRm1HdkFmREh6NnZmYStFc3pzWTJNUUVCdXc0aEwyQ21WaXFlZkxOUS83blNoak4KRGF1Q3F3cHNpUzJjSkw2M25rcHQzSW9hcFN2K0FKZHpYS2l5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1202"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:33 GMT
+      - Thu, 16 Nov 2023 16:05:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2522,7 +2588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 725f1001-5113-406c-ba0c-ad1136cde138
+      - 9922a806-b23d-4ceb-b57e-1f5d21c23e90
     status: 200 OK
     code: 200
     duration: ""
@@ -2533,19 +2599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTThENFNmN2ttY1BEb3duK3IvUTdvOEl3Ukt3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU1USXpXaGNOTXpNeE1ETXdNVGcxTVRJeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpldCtiRWRWUWMrWDhoOUNXTTVmSDdDRFhKVlpHMDdlK3FsazF3RGlObmpBWHNZV3lpd3V1TG4KeEY0QzlNekFMT3Q4emh6aGZGbHFwUlhYckVMOFlMVktDengyTUt4U2ZVbWE1b2RDbTA4M2Y2M2F1U210VWlvSAp2bkRha240OVM0VU5yWWYraDZLNWNPM2w1c211OG1CUVhmbXhjeU9jQTlOUWx2ZTRZYWhmVnJDcElaZ2tPSTBaCmN0cjQ3M2tEMmNaN3hKMDUzVWZMVTMrbVdUWTc4NlJJcFJvdnRON1lNVnNDSWM2Y3dDS1kvb1RnQ3J1VWExZ1cKdllmRjdHclVQMlVDa1h6OWplSno3Nm92Ujh6MEw4YnBiTDIwWU54cmhZYlhMQUFLd3hnbEtPYlF1VEtkcmE4SwowdWUxWnpXK0FiR2NvKzRUem4yOTkzMTFqN3VFMG44Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0Tm1Vell6QXlNekl0WkRZeFpDMDBNbVJrTFRrNFpqWXRaR0kzTVdGbU1qUmkKTVdKa0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm5jeWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQXRYY2JhVkxzNVE3TytmK25XVkIyaTdkU1lPb1NBUXpHS0l0cFZWenpwMTdyem04c1ltQThDCmcwZ2hHZm5SS2pTTVZ2YnlEWVcweGMrNTdPNEp1Rm9SMGI0Y1FYZkNLUFFPT0cwOWFBTXg0U25WRlpIbjZpZU8KRE9xeUwybElpS3hXbWJnWCtRRkVKZlRMTXcvRnVnYXlwclZ4a3dMTm9YNjVURTdlRVRieHBsSHVLckl5dHd3Tgo5bFRkekRNdExwUDFkYnZaOHNlK2NFdHN1elFNbGtjMytnTjdNcU1zaUhEanNLRDlnOE1SQUdwRkdwSDIycVJoCnhMVyttdkVkdWdPMHhrSU9GVjg2VEgwakFkNGJFOGdVcmNlRE10NUs3bzBRcUlsd05BWE80c2piUm1DVS9rWWUKb2tYV28ySjdLYnNiM05NbXQzRVplcUlseU91T2ZnVisKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:33 GMT
+      - Thu, 16 Nov 2023 16:05:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2555,7 +2621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d1ab7db-2e38-43c1-ab14-8892cdc4336c
+      - 6e610328-68cb-4e0d-ba39-63069944cf4f
     status: 200 OK
     code: 200
     duration: ""
@@ -2566,52 +2632,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1202"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:55:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ba66f74-49dc-4580-82cb-f983861ad752
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1251"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:34 GMT
+      - Thu, 16 Nov 2023 16:05:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2621,7 +2654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 704b73f2-b308-41df-be02-c3153166d801
+      - 4eb59261-da57-472a-af3c-7b124e96c8c3
     status: 200 OK
     code: 200
     duration: ""
@@ -2632,19 +2665,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:44.893813Z","retention":7},"created_at":"2023-11-02T18:50:44.893813Z","endpoint":{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508},"endpoints":[{"id":"b9be8bf8-5536-4ac2-97ee-825d0af3cfcf","ip":"51.159.26.223","load_balancer":{},"name":null,"port":12508}],"engine":"PostgreSQL-15","id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:00:23.905384Z","retention":7},"created_at":"2023-11-16T16:00:23.905384Z","endpoint":{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047},"endpoints":[{"id":"ca7e02b6-8ff0-4137-9b30-e6973268402f","ip":"51.159.113.173","load_balancer":{},"name":null,"port":1047}],"engine":"PostgreSQL-15","id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1251"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:34 GMT
+      - Thu, 16 Nov 2023 16:05:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2654,7 +2687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27c53568-94ce-4073-bd57-5d67dcc95780
+      - 2613dd26-533e-472a-be0e-c55ec83fa272
     status: 200 OK
     code: 200
     duration: ""
@@ -2665,10 +2698,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2677,7 +2710,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:04 GMT
+      - Thu, 16 Nov 2023 16:06:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2687,7 +2720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c44be64-dcfe-45c7-a566-b4b2edaf4c9c
+      - d6cf715c-b04f-47ed-9f37-0122096560b0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2698,10 +2731,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6e3c0232-d61d-42dd-98f6-db71af24b1bd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4cd3dfca-7eb8-4efe-b334-bf97ff95765b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"6e3c0232-d61d-42dd-98f6-db71af24b1bd","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"4cd3dfca-7eb8-4efe-b334-bf97ff95765b","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2710,7 +2743,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:04 GMT
+      - Thu, 16 Nov 2023 16:06:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2720,7 +2753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce2d2e90-3d80-4320-a5d6-a08d5b52e6a5
+      - 3c377f3f-5603-4dde-95cf-82f8ef49955e
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-database-backup-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-database-backup-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:32 GMT
+      - Thu, 16 Nov 2023 15:52:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a87f3d98-da0c-455d-9404-f78489c92383
+      - 3c71ff60-79b0-4e3f-979e-ecf15e9817a2
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbDatabaseBackup_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbDatabaseBackup_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "781"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 15:57:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9cc70ab5-4fc1-4664-80af-df41967492f1
+      - 6f33d7a6-6def-4a07-a721-a3869341e4ea
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "781"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 15:57:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49fdc126-8f31-499d-b622-bfc943c3545d
+      - 9449053a-7b28-4a45-bc7a-3235b3fc5626
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "781"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:08 GMT
+      - Thu, 16 Nov 2023 15:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00f35f06-c2c8-4128-b523-3d8d5bc1e76c
+      - 3c9212d7-594a-409e-8161-ad0475170446
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "781"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:38 GMT
+      - Thu, 16 Nov 2023 15:58:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 398e3321-1f01-4517-afb2-070c69f6449f
+      - 7d40b746-be14-478c-8e39-10938021999e
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "781"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:09 GMT
+      - Thu, 16 Nov 2023 15:58:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f816d2a3-96e6-4ac5-8753-2c8c1eb8c30a
+      - b6a8a68d-21d9-462c-a4c8-94fc24770b56
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "781"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:39 GMT
+      - Thu, 16 Nov 2023 15:59:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8b44685-5a8d-454b-a408-33494075f141
+      - e1ca7805-197c-468d-95f3-d81b3cb922bb
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "781"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:09 GMT
+      - Thu, 16 Nov 2023 15:59:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b84442be-83ac-484b-8719-e0d1b7c20f00
+      - ec7df2f5-06a5-4853-9bf1-98ddd2f8ad5e
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15b305c7-24dd-4b7f-b9d2-e99a8f1d7aab
+      - 14772bea-6dbf-4fb5-b680-865e543c5458
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:00:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8690db69-af50-4b82-9990-bb717f2066b6
+      - 450d994a-4c99-4f3e-a173-9c79f9b81f49
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:00:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d689901f-069a-46c0-be8f-8e9d1b5ca341
+      - d2afa497-112a-4afb-a896-6b94a0100390
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUXo1eXBPU3ZyNUwyU0ZKWkxLaFlaV2U2QWxRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56TXdXaGNOTXpNeE1ETXdNVGcwTnpNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxTbDAwWTVrVGlyQTBsdGIzU3pUQ2NNZEgvMWJFd29VdmM4cmRxdXU5UUhERlQxQXNEOEZmU1UKQmprSzdnRXBjU0RMcXcvT00ySGtKVUVrYUhWQ3EvRi9DeXNPY2doQjhYMkRkNGZ6V3VwWmUxclBORHVIdDI1WQpkL0FHMmRLSFdTRW8xd2RwY3NaTnY2T2NZMUhwNHRUM0x0UklleStXeDBCUzRjWlBIZWFML3IzRnZ4WUdlUHZJClUzNTc4L1NSdWRaZ1NBM2ZqUjJLS3B1LzlrcitzRERrdkJ4MG5ReGdSVEdWUS9yaVVPQmZxSld4dms5MnlPYUMKZlFNVWFFV0Z6c2FiTmFzbzZGY2ZWbEUrNTZJQ0tHZ1lzUDdJYldWcFFJQy9lUWFaY1N5WUxoVkVCRnV1bnlyLwpkWHJqM3NQbGhlTnFpNWtMMTZlb2ZPeGY1YngvUHVVQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WldaaFpEUm1PRFF0WmpReFlTMDBNelV5TFRrd05tSXROR1UyTldVeVptUXgKTmpNeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVFEbGM2eEhFNzdsbmU0SEpkSVY1TmsreXVLZG9ldVRvbXozZVVwMnA0eWlBNDJ0dGcyN0JxCkN0QldEMnJqN1BCVEQ3bnJueWdubDVuYXBuU0hhNjFjT3MxSGI5MWRzYnM0aU1rTHAzZ1A0SDZiendQaWZGNVAKeWRjT0xoVCtSbzd6aUpuTEx5ckVNNUw2cFV3ZlI2TGRVMTYyRmUvK1RVREJ1b3QrRHZmS0w4dVgwZXJQTkhmWApibms2dlFLcHNDdGlqT0lwTGhNekxENEk2aERiRDNOZXhFVHBJMHVBVmV3dm9IdUN0M3lXZE5OaHZleFJoTDdiCk1xWTBmVHQwcXorVHRBUnFqYnlHbUVqemFVRHFwb1NoMnl6ajdvVC80bUJrb0dSQ0ZIMjE4ZXhVYmNCUkhBZ2EKbEdadGcwYW1EdjhONEpSUVhJQVMvNlBobExNbWdEQmIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVY1ZlWkdQL3QxeEs1TGgrWFlGdUUrS3JRNmpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRZd01EQXpXaGNOTXpNeE1URXpNVFl3TURBeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1oYWNMWDd3T3JwNGNBTWZ6bW9Qb2xrUGMyR1FEaEhOUGd2SWhLeEZmbTFZT1plbE9pYVVzSGcKSTRIejNlN3prVGNJQ2Z6azFLcm1sbDVmV3FDa1llQVBwNnU5L0huREw4YnhkTzZTVjVUNEZ6K2ptbXpnbDFFSApzdVBGWHR6anZwaVJFZWw3aVdmRXdVbXRCTlJ2eUdabzdwUklzNjZMTGxFNUk3ZHVMZnhXbk1BSm9WdEdLa2NKClRTZjY1YWsxWXhTS1cwMWZmVjJORjRYUlV2bHE1UHJqb0tEU2hCWHRWTUVNMFJBU3p4dHdrWnRyWTN1ajgxQXcKMkM1Wlp2SWJOTXU2eVRyRnFFbWRtdlVoY2hGQThyRkxEWFIrZ0gwUHhwbS9GOEYzdHJORXgzRXB6OFl1OHY5egpZeEpVc0owZ0NMbkZoSEZVS0k5Q21YS0lqeTdFQzM4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0T0RNd09EQXhOMll0WmpRd1l5MDBZMlkwTFRneU5qQXROVEJpWTJKbFpETmgKWWpobExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtyK2h3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQTdIbjZJUnNGYVFSSnZINlFiZkRYMnFKR2w0M2FKMk9YMThDZk5ra0xTRDRvMVdjY3JocEpqCmI0YzdRQlRoNVQwNWF0N1F5ZEF5WU0wVFJWdmxmTDlZWlNIOG5UdDkxYXpCR2NFZ2J0OVlJVm5wSXBmaHRlSmQKOUovYlRFSG9XdFI0VHpFQ004cnRYTFplcnZjR1BybURXTmtNRXYvUmNtdEsrSHdYV0F6dWdQS0dOQ3czaDNSRApsTTI2S0lsa0RMdUxNQmgrOWxYUjQ5eENMcEhvc3lJK0FucElWTit0a25IaTJtR3JMN0laRkx3bDNqUC9WZENiCmVKc1N4ODhEcWZzZ1R0Tk1SWnhZa2x5clR6NTZNbzdpRjJLSWZLc2FuSEUzNlE2dVpyOTZ2YytOOXVzSFZvYmsKR1duM1JLeE5wWERwL1JFalJrYWw0TWx2REpJYjNsQk4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:00:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eacef93f-c99e-45f5-8e73-7262924541f9
+      - 99db3a10-63c8-4313-a746-d1080fe6307f
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:00:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bd9d04a-fee4-42b5-8592-16f0b533fdcc
+      - 733981f7-9fc3-4d5d-810e-92b1f40027e7
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
     headers:
       Content-Length:
-      - "49"
+      - "52"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a76399e-3329-4295-850c-4258ce536c79
+      - 49ca4e95-56f8-49cd-be20-949d4f8fc6b7
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d988888b-1cc7-4e9d-87f9-85a6ccb441fd
+      - bb12de6f-2228-4969-b044-2ae26a9d44af
     status: 200 OK
     code: 200
     duration: ""
@@ -807,52 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "102"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2000c061-44d7-4438-962f-aebce5674c84
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 907ce36a-a07e-4425-b490-ffe7796a98ed
+      - 7badf3e7-834a-4035-88cc-90fa80532bfc
     status: 200 OK
     code: 200
     duration: ""
@@ -873,85 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1227"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b1f2203b-81d3-4c6d-85e8-c47bf62b393e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUXo1eXBPU3ZyNUwyU0ZKWkxLaFlaV2U2QWxRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56TXdXaGNOTXpNeE1ETXdNVGcwTnpNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxTbDAwWTVrVGlyQTBsdGIzU3pUQ2NNZEgvMWJFd29VdmM4cmRxdXU5UUhERlQxQXNEOEZmU1UKQmprSzdnRXBjU0RMcXcvT00ySGtKVUVrYUhWQ3EvRi9DeXNPY2doQjhYMkRkNGZ6V3VwWmUxclBORHVIdDI1WQpkL0FHMmRLSFdTRW8xd2RwY3NaTnY2T2NZMUhwNHRUM0x0UklleStXeDBCUzRjWlBIZWFML3IzRnZ4WUdlUHZJClUzNTc4L1NSdWRaZ1NBM2ZqUjJLS3B1LzlrcitzRERrdkJ4MG5ReGdSVEdWUS9yaVVPQmZxSld4dms5MnlPYUMKZlFNVWFFV0Z6c2FiTmFzbzZGY2ZWbEUrNTZJQ0tHZ1lzUDdJYldWcFFJQy9lUWFaY1N5WUxoVkVCRnV1bnlyLwpkWHJqM3NQbGhlTnFpNWtMMTZlb2ZPeGY1YngvUHVVQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WldaaFpEUm1PRFF0WmpReFlTMDBNelV5TFRrd05tSXROR1UyTldVeVptUXgKTmpNeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVFEbGM2eEhFNzdsbmU0SEpkSVY1TmsreXVLZG9ldVRvbXozZVVwMnA0eWlBNDJ0dGcyN0JxCkN0QldEMnJqN1BCVEQ3bnJueWdubDVuYXBuU0hhNjFjT3MxSGI5MWRzYnM0aU1rTHAzZ1A0SDZiendQaWZGNVAKeWRjT0xoVCtSbzd6aUpuTEx5ckVNNUw2cFV3ZlI2TGRVMTYyRmUvK1RVREJ1b3QrRHZmS0w4dVgwZXJQTkhmWApibms2dlFLcHNDdGlqT0lwTGhNekxENEk2aERiRDNOZXhFVHBJMHVBVmV3dm9IdUN0M3lXZE5OaHZleFJoTDdiCk1xWTBmVHQwcXorVHRBUnFqYnlHbUVqemFVRHFwb1NoMnl6ajdvVC80bUJrb0dSQ0ZIMjE4ZXhVYmNCUkhBZ2EKbEdadGcwYW1EdjhONEpSUVhJQVMvNlBobExNbWdEQmIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1843"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ad70bf99-a761-459e-aa5e-01d26f4f9f46
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ebaa686-9f1c-4d51-ba18-f614b6cc927f
+      - 06614f16-1ccd-4e34-a3c5-cc737d1ba813
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:42 GMT
+      - Thu, 16 Nov 2023 16:00:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa6860ca-4959-4b9a-aac4-81f14b41b409
+      - 916ecaab-08e4-480b-8d67-13e3a190e733
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUXo1eXBPU3ZyNUwyU0ZKWkxLaFlaV2U2QWxRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56TXdXaGNOTXpNeE1ETXdNVGcwTnpNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxTbDAwWTVrVGlyQTBsdGIzU3pUQ2NNZEgvMWJFd29VdmM4cmRxdXU5UUhERlQxQXNEOEZmU1UKQmprSzdnRXBjU0RMcXcvT00ySGtKVUVrYUhWQ3EvRi9DeXNPY2doQjhYMkRkNGZ6V3VwWmUxclBORHVIdDI1WQpkL0FHMmRLSFdTRW8xd2RwY3NaTnY2T2NZMUhwNHRUM0x0UklleStXeDBCUzRjWlBIZWFML3IzRnZ4WUdlUHZJClUzNTc4L1NSdWRaZ1NBM2ZqUjJLS3B1LzlrcitzRERrdkJ4MG5ReGdSVEdWUS9yaVVPQmZxSld4dms5MnlPYUMKZlFNVWFFV0Z6c2FiTmFzbzZGY2ZWbEUrNTZJQ0tHZ1lzUDdJYldWcFFJQy9lUWFaY1N5WUxoVkVCRnV1bnlyLwpkWHJqM3NQbGhlTnFpNWtMMTZlb2ZPeGY1YngvUHVVQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WldaaFpEUm1PRFF0WmpReFlTMDBNelV5TFRrd05tSXROR1UyTldVeVptUXgKTmpNeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVFEbGM2eEhFNzdsbmU0SEpkSVY1TmsreXVLZG9ldVRvbXozZVVwMnA0eWlBNDJ0dGcyN0JxCkN0QldEMnJqN1BCVEQ3bnJueWdubDVuYXBuU0hhNjFjT3MxSGI5MWRzYnM0aU1rTHAzZ1A0SDZiendQaWZGNVAKeWRjT0xoVCtSbzd6aUpuTEx5ckVNNUw2cFV3ZlI2TGRVMTYyRmUvK1RVREJ1b3QrRHZmS0w4dVgwZXJQTkhmWApibms2dlFLcHNDdGlqT0lwTGhNekxENEk2aERiRDNOZXhFVHBJMHVBVmV3dm9IdUN0M3lXZE5OaHZleFJoTDdiCk1xWTBmVHQwcXorVHRBUnFqYnlHbUVqemFVRHFwb1NoMnl6ajdvVC80bUJrb0dSQ0ZIMjE4ZXhVYmNCUkhBZ2EKbEdadGcwYW1EdjhONEpSUVhJQVMvNlBobExNbWdEQmIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVY1ZlWkdQL3QxeEs1TGgrWFlGdUUrS3JRNmpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRZd01EQXpXaGNOTXpNeE1URXpNVFl3TURBeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1oYWNMWDd3T3JwNGNBTWZ6bW9Qb2xrUGMyR1FEaEhOUGd2SWhLeEZmbTFZT1plbE9pYVVzSGcKSTRIejNlN3prVGNJQ2Z6azFLcm1sbDVmV3FDa1llQVBwNnU5L0huREw4YnhkTzZTVjVUNEZ6K2ptbXpnbDFFSApzdVBGWHR6anZwaVJFZWw3aVdmRXdVbXRCTlJ2eUdabzdwUklzNjZMTGxFNUk3ZHVMZnhXbk1BSm9WdEdLa2NKClRTZjY1YWsxWXhTS1cwMWZmVjJORjRYUlV2bHE1UHJqb0tEU2hCWHRWTUVNMFJBU3p4dHdrWnRyWTN1ajgxQXcKMkM1Wlp2SWJOTXU2eVRyRnFFbWRtdlVoY2hGQThyRkxEWFIrZ0gwUHhwbS9GOEYzdHJORXgzRXB6OFl1OHY5egpZeEpVc0owZ0NMbkZoSEZVS0k5Q21YS0lqeTdFQzM4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0T0RNd09EQXhOMll0WmpRd1l5MDBZMlkwTFRneU5qQXROVEJpWTJKbFpETmgKWWpobExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtyK2h3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQTdIbjZJUnNGYVFSSnZINlFiZkRYMnFKR2w0M2FKMk9YMThDZk5ra0xTRDRvMVdjY3JocEpqCmI0YzdRQlRoNVQwNWF0N1F5ZEF5WU0wVFJWdmxmTDlZWlNIOG5UdDkxYXpCR2NFZ2J0OVlJVm5wSXBmaHRlSmQKOUovYlRFSG9XdFI0VHpFQ004cnRYTFplcnZjR1BybURXTmtNRXYvUmNtdEsrSHdYV0F6dWdQS0dOQ3czaDNSRApsTTI2S0lsa0RMdUxNQmgrOWxYUjQ5eENMcEhvc3lJK0FucElWTit0a25IaTJtR3JMN0laRkx3bDNqUC9WZENiCmVKc1N4ODhEcWZzZ1R0Tk1SWnhZa2x5clR6NTZNbzdpRjJLSWZLc2FuSEUzNlE2dVpyOTZ2YytOOXVzSFZvYmsKR1duM1JLeE5wWERwL1JFalJrYWw0TWx2REpJYjNsQk4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:42 GMT
+      - Thu, 16 Nov 2023 16:00:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69075c70-f842-48fc-9892-b530b458eb68
+      - d2be93c6-669a-411e-9289-446a73787382
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:43 GMT
+      - Thu, 16 Nov 2023 16:00:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,12 +961,111 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df520579-37e4-4584-9e32-02fc9605b551
+      - 1767ba18-0502-429f-bc53-9d89f461b211
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","database_name":"foo","name":"test_backup"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1273"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a9f547de-af60-4814-bcaa-bdd2ce581d7e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVY1ZlWkdQL3QxeEs1TGgrWFlGdUUrS3JRNmpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRZd01EQXpXaGNOTXpNeE1URXpNVFl3TURBeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1oYWNMWDd3T3JwNGNBTWZ6bW9Qb2xrUGMyR1FEaEhOUGd2SWhLeEZmbTFZT1plbE9pYVVzSGcKSTRIejNlN3prVGNJQ2Z6azFLcm1sbDVmV3FDa1llQVBwNnU5L0huREw4YnhkTzZTVjVUNEZ6K2ptbXpnbDFFSApzdVBGWHR6anZwaVJFZWw3aVdmRXdVbXRCTlJ2eUdabzdwUklzNjZMTGxFNUk3ZHVMZnhXbk1BSm9WdEdLa2NKClRTZjY1YWsxWXhTS1cwMWZmVjJORjRYUlV2bHE1UHJqb0tEU2hCWHRWTUVNMFJBU3p4dHdrWnRyWTN1ajgxQXcKMkM1Wlp2SWJOTXU2eVRyRnFFbWRtdlVoY2hGQThyRkxEWFIrZ0gwUHhwbS9GOEYzdHJORXgzRXB6OFl1OHY5egpZeEpVc0owZ0NMbkZoSEZVS0k5Q21YS0lqeTdFQzM4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0T0RNd09EQXhOMll0WmpRd1l5MDBZMlkwTFRneU5qQXROVEJpWTJKbFpETmgKWWpobExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtyK2h3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQTdIbjZJUnNGYVFSSnZINlFiZkRYMnFKR2w0M2FKMk9YMThDZk5ra0xTRDRvMVdjY3JocEpqCmI0YzdRQlRoNVQwNWF0N1F5ZEF5WU0wVFJWdmxmTDlZWlNIOG5UdDkxYXpCR2NFZ2J0OVlJVm5wSXBmaHRlSmQKOUovYlRFSG9XdFI0VHpFQ004cnRYTFplcnZjR1BybURXTmtNRXYvUmNtdEsrSHdYV0F6dWdQS0dOQ3czaDNSRApsTTI2S0lsa0RMdUxNQmgrOWxYUjQ5eENMcEhvc3lJK0FucElWTit0a25IaTJtR3JMN0laRkx3bDNqUC9WZENiCmVKc1N4ODhEcWZzZ1R0Tk1SWnhZa2x5clR6NTZNbzdpRjJLSWZLc2FuSEUzNlE2dVpyOTZ2YytOOXVzSFZvYmsKR1duM1JLeE5wWERwL1JFalJrYWw0TWx2REpJYjNsQk4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1845"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ab0ca5f7-657f-49d4-b142-138849b2e44e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e/databases?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "106"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99208d78-02c9-4958-94eb-5d5eaaa55eed
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","database_name":"foo","name":"test_backup"}'
     form: {}
     headers:
       Content-Type:
@@ -1076,16 +1076,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups
     method: POST
   response:
-    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-11-16T16:00:27.153222Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4a4cc7aa-d5ba-4098-a5c8-58e535e65999","instance_id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
-      - "398"
+      - "411"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:44 GMT
+      - Thu, 16 Nov 2023 16:00:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1095,7 +1095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4508e43-9b33-4f97-8af2-6ffcf807a251
+      - 029446a8-fdeb-4b06-8073-ac1c54a13159
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,19 +1106,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4a4cc7aa-d5ba-4098-a5c8-58e535e65999
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-11-16T16:00:27.153222Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4a4cc7aa-d5ba-4098-a5c8-58e535e65999","instance_id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
-      - "398"
+      - "411"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:44 GMT
+      - Thu, 16 Nov 2023 16:00:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1128,7 +1128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bd4866d-0182-43f1-9c97-0bfb5d8f8fb5
+      - b29feb68-9481-4e59-b4e8-91bc140d76ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1139,19 +1139,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4a4cc7aa-d5ba-4098-a5c8-58e535e65999
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-02T18:49:46.021270Z"}'
+    body: '{"created_at":"2023-11-16T16:00:27.153222Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4a4cc7aa-d5ba-4098-a5c8-58e535e65999","instance_id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-16T16:00:28.896788Z"}'
     headers:
       Content-Length:
-      - "420"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 16:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1161,7 +1161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b7e2ec4-c032-4d13-acaa-cb3f9b8ea8c5
+      - 2df6436a-8196-4b1d-948f-9f36464478f1
     status: 200 OK
     code: 200
     duration: ""
@@ -1172,19 +1172,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4a4cc7aa-d5ba-4098-a5c8-58e535e65999
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-02T18:49:46.021270Z"}'
+    body: '{"created_at":"2023-11-16T16:00:27.153222Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4a4cc7aa-d5ba-4098-a5c8-58e535e65999","instance_id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-16T16:00:28.896788Z"}'
     headers:
       Content-Length:
-      - "420"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 16:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1194,7 +1194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc55b9a4-2224-4e6d-bb78-106da8ee476f
+      - e9e1dbcb-1a35-4e1c-8d73-98c0353da2d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,19 +1205,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4a4cc7aa-d5ba-4098-a5c8-58e535e65999
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-02T18:49:46.021270Z"}'
+    body: '{"created_at":"2023-11-16T16:00:27.153222Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4a4cc7aa-d5ba-4098-a5c8-58e535e65999","instance_id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-16T16:00:28.896788Z"}'
     headers:
       Content-Length:
-      - "420"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 16:01:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1227,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4edaaa61-fd42-4f6a-ae39-03f838cd779a
+      - a6e0cf1c-79fd-43da-9967-ce535fe8bb8a
     status: 200 OK
     code: 200
     duration: ""
@@ -1238,19 +1238,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:15 GMT
+      - Thu, 16 Nov 2023 16:01:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7a49a99-1ad9-4b2f-b26f-022ac67e5898
+      - 2eeb908c-8a69-4c66-a499-3072266d7c13
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,19 +1271,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUXo1eXBPU3ZyNUwyU0ZKWkxLaFlaV2U2QWxRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56TXdXaGNOTXpNeE1ETXdNVGcwTnpNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxTbDAwWTVrVGlyQTBsdGIzU3pUQ2NNZEgvMWJFd29VdmM4cmRxdXU5UUhERlQxQXNEOEZmU1UKQmprSzdnRXBjU0RMcXcvT00ySGtKVUVrYUhWQ3EvRi9DeXNPY2doQjhYMkRkNGZ6V3VwWmUxclBORHVIdDI1WQpkL0FHMmRLSFdTRW8xd2RwY3NaTnY2T2NZMUhwNHRUM0x0UklleStXeDBCUzRjWlBIZWFML3IzRnZ4WUdlUHZJClUzNTc4L1NSdWRaZ1NBM2ZqUjJLS3B1LzlrcitzRERrdkJ4MG5ReGdSVEdWUS9yaVVPQmZxSld4dms5MnlPYUMKZlFNVWFFV0Z6c2FiTmFzbzZGY2ZWbEUrNTZJQ0tHZ1lzUDdJYldWcFFJQy9lUWFaY1N5WUxoVkVCRnV1bnlyLwpkWHJqM3NQbGhlTnFpNWtMMTZlb2ZPeGY1YngvUHVVQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WldaaFpEUm1PRFF0WmpReFlTMDBNelV5TFRrd05tSXROR1UyTldVeVptUXgKTmpNeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVFEbGM2eEhFNzdsbmU0SEpkSVY1TmsreXVLZG9ldVRvbXozZVVwMnA0eWlBNDJ0dGcyN0JxCkN0QldEMnJqN1BCVEQ3bnJueWdubDVuYXBuU0hhNjFjT3MxSGI5MWRzYnM0aU1rTHAzZ1A0SDZiendQaWZGNVAKeWRjT0xoVCtSbzd6aUpuTEx5ckVNNUw2cFV3ZlI2TGRVMTYyRmUvK1RVREJ1b3QrRHZmS0w4dVgwZXJQTkhmWApibms2dlFLcHNDdGlqT0lwTGhNekxENEk2aERiRDNOZXhFVHBJMHVBVmV3dm9IdUN0M3lXZE5OaHZleFJoTDdiCk1xWTBmVHQwcXorVHRBUnFqYnlHbUVqemFVRHFwb1NoMnl6ajdvVC80bUJrb0dSQ0ZIMjE4ZXhVYmNCUkhBZ2EKbEdadGcwYW1EdjhONEpSUVhJQVMvNlBobExNbWdEQmIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVY1ZlWkdQL3QxeEs1TGgrWFlGdUUrS3JRNmpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRZd01EQXpXaGNOTXpNeE1URXpNVFl3TURBeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1oYWNMWDd3T3JwNGNBTWZ6bW9Qb2xrUGMyR1FEaEhOUGd2SWhLeEZmbTFZT1plbE9pYVVzSGcKSTRIejNlN3prVGNJQ2Z6azFLcm1sbDVmV3FDa1llQVBwNnU5L0huREw4YnhkTzZTVjVUNEZ6K2ptbXpnbDFFSApzdVBGWHR6anZwaVJFZWw3aVdmRXdVbXRCTlJ2eUdabzdwUklzNjZMTGxFNUk3ZHVMZnhXbk1BSm9WdEdLa2NKClRTZjY1YWsxWXhTS1cwMWZmVjJORjRYUlV2bHE1UHJqb0tEU2hCWHRWTUVNMFJBU3p4dHdrWnRyWTN1ajgxQXcKMkM1Wlp2SWJOTXU2eVRyRnFFbWRtdlVoY2hGQThyRkxEWFIrZ0gwUHhwbS9GOEYzdHJORXgzRXB6OFl1OHY5egpZeEpVc0owZ0NMbkZoSEZVS0k5Q21YS0lqeTdFQzM4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0T0RNd09EQXhOMll0WmpRd1l5MDBZMlkwTFRneU5qQXROVEJpWTJKbFpETmgKWWpobExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtyK2h3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQTdIbjZJUnNGYVFSSnZINlFiZkRYMnFKR2w0M2FKMk9YMThDZk5ra0xTRDRvMVdjY3JocEpqCmI0YzdRQlRoNVQwNWF0N1F5ZEF5WU0wVFJWdmxmTDlZWlNIOG5UdDkxYXpCR2NFZ2J0OVlJVm5wSXBmaHRlSmQKOUovYlRFSG9XdFI0VHpFQ004cnRYTFplcnZjR1BybURXTmtNRXYvUmNtdEsrSHdYV0F6dWdQS0dOQ3czaDNSRApsTTI2S0lsa0RMdUxNQmgrOWxYUjQ5eENMcEhvc3lJK0FucElWTit0a25IaTJtR3JMN0laRkx3bDNqUC9WZENiCmVKc1N4ODhEcWZzZ1R0Tk1SWnhZa2x5clR6NTZNbzdpRjJLSWZLc2FuSEUzNlE2dVpyOTZ2YytOOXVzSFZvYmsKR1duM1JLeE5wWERwL1JFalJrYWw0TWx2REpJYjNsQk4KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:15 GMT
+      - Thu, 16 Nov 2023 16:01:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b31f51b-130f-4f62-9cf1-eab5d996b4a4
+      - 10d5f79d-cf97-4068-9ddf-91ea765a0f64
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,19 +1304,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:15 GMT
+      - Thu, 16 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28fdfa22-c676-473e-9c1f-c50222c1a46d
+      - a1c9bf8d-78b9-4cc1-8553-3308123e2925
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,19 +1337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4a4cc7aa-d5ba-4098-a5c8-58e535e65999
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-02T18:49:46.021270Z"}'
+    body: '{"created_at":"2023-11-16T16:00:27.153222Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4a4cc7aa-d5ba-4098-a5c8-58e535e65999","instance_id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-16T16:00:28.896788Z"}'
     headers:
       Content-Length:
-      - "420"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:16 GMT
+      - Thu, 16 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24b30ae6-a9fe-4561-9a74-447d425255b7
+      - abea4177-7092-4eb9-ac19-88910760473f
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,19 +1370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4a4cc7aa-d5ba-4098-a5c8-58e535e65999
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-02T18:49:46.021270Z"}'
+    body: '{"created_at":"2023-11-16T16:00:27.153222Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4a4cc7aa-d5ba-4098-a5c8-58e535e65999","instance_id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-11-16T16:00:28.896788Z"}'
     headers:
       Content-Length:
-      - "420"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:16 GMT
+      - Thu, 16 Nov 2023 16:01:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1392,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aed2e13a-592c-4cac-947b-3371495d2885
+      - ef04d328-2ea6-4f01-ae41-4bfc2b893b12
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,19 +1403,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4a4cc7aa-d5ba-4098-a5c8-58e535e65999
     method: DELETE
   response:
-    body: '{"created_at":"2023-11-02T18:49:44.206371Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","instance_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"deleting","updated_at":"2023-11-02T18:49:46.021270Z"}'
+    body: '{"created_at":"2023-11-16T16:00:27.153222Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"4a4cc7aa-d5ba-4098-a5c8-58e535e65999","instance_id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"deleting","updated_at":"2023-11-16T16:00:28.896788Z"}'
     headers:
       Content-Length:
-      - "423"
+      - "436"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:17 GMT
+      - Thu, 16 Nov 2023 16:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e83df395-0f46-4af4-b90d-12cf23af89f3
+      - a90eba61-8533-42ae-a861-ca8f499ffddd
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,10 +1436,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4a4cc7aa-d5ba-4098-a5c8-58e535e65999
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"4a4cc7aa-d5ba-4098-a5c8-58e535e65999","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -1448,7 +1448,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:17 GMT
+      - Thu, 16 Nov 2023 16:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d2d308a-14ef-4f4a-add3-673113b7e996
+      - 3498bddb-3e10-4a04-be50-038be1419133
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1469,19 +1469,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:17 GMT
+      - Thu, 16 Nov 2023 16:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a37a091f-bf6a-4a82-a286-fd9dbd8db683
+      - e423080d-bc0f-4d53-b833-d92c549fa816
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,7 +1502,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e/databases/foo
     method: DELETE
   response:
     body: ""
@@ -1512,7 +1512,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:17 GMT
+      - Thu, 16 Nov 2023 16:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e53bbd8-a5da-4774-968f-7f179f2ca2d8
+      - 03a2d87d-a193-411e-843b-41220a69a405
     status: 204 No Content
     code: 204
     duration: ""
@@ -1533,19 +1533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:17 GMT
+      - Thu, 16 Nov 2023 16:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efe54419-cbfd-4bc4-b2e7-4990fda4a8dd
+      - b67c2cbc-e52c-46b5-8ab7-75a5655f3eb3
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,19 +1566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:18 GMT
+      - Thu, 16 Nov 2023 16:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21655f83-65aa-47b8-a91a-57eac53469db
+      - 0179dfce-c7e3-4ea5-9508-488196406655
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,19 +1599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1230"
+      - "1276"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:18 GMT
+      - Thu, 16 Nov 2023 16:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 968b049a-33a5-4bb9-9b0c-981aa6206392
+      - 34552be0-f5b4-41f9-b41c-cadab4d7736c
     status: 200 OK
     code: 200
     duration: ""
@@ -1632,19 +1632,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.083047Z","retention":7},"created_at":"2023-11-02T18:46:38.083047Z","endpoint":{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324},"endpoints":[{"id":"4bdd09f2-2cec-4a3a-9e91-8fc6a9e22db2","ip":"51.159.26.223","load_balancer":{},"name":null,"port":22324}],"engine":"PostgreSQL-15","id":"efad4f84-f41a-4352-906b-4e65e2fd1632","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:57:21.612523Z","retention":7},"created_at":"2023-11-16T15:57:21.612523Z","endpoint":{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989},"endpoints":[{"id":"17687f8f-d4ba-47d3-a5eb-1f9284b68d91","ip":"195.154.197.0","load_balancer":{},"name":null,"port":18989}],"engine":"PostgreSQL-15","id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1230"
+      - "1276"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:18 GMT
+      - Thu, 16 Nov 2023 16:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b305880f-8123-44ef-9aa8-5ce5edd35cde
+      - 130121a1-c9f5-4316-a11d-920b27bf564b
     status: 200 OK
     code: 200
     duration: ""
@@ -1665,10 +1665,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1677,7 +1677,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:49 GMT
+      - Thu, 16 Nov 2023 16:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8946ab78-92f6-4a67-a123-71f8ae4fbaa9
+      - dcaba54f-6335-4f5c-a670-c7f250ee4c2a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1698,10 +1698,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/efad4f84-f41a-4352-906b-4e65e2fd1632
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8308017f-f40c-4cf4-8260-50bcbed3ab8e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"efad4f84-f41a-4352-906b-4e65e2fd1632","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"8308017f-f40c-4cf4-8260-50bcbed3ab8e","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1710,7 +1710,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:49 GMT
+      - Thu, 16 Nov 2023 16:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 651a6419-cd0f-434a-9a21-ed98d406f674
+      - 28c813d0-7333-45ea-a923-9f541dd3b170
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1731,10 +1731,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/4a4cc7aa-d5ba-4098-a5c8-58e535e65999
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"e9a09b7b-e0da-427c-aae8-4ffcb1f0b8a4","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"4a4cc7aa-d5ba-4098-a5c8-58e535e65999","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -1743,7 +1743,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:49 GMT
+      - Thu, 16 Nov 2023 16:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b053ea2-147f-47f2-b094-f95ab210fa71
+      - cfc748b9-a756-4ee8-bdc0-3f1286ccbe24
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-database-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-database-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:33 GMT
+      - Thu, 16 Nov 2023 15:52:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc2ce1a6-5023-4785-9f45-0bd82d3cca7e
+      - b0b85039-74e7-4d78-b42f-84a62dcde658
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbDatabase_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbDatabase_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "794"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59f5cd76-a25e-4b27-9a13-58058eb0f4bc
+      - 9f601aed-5c1e-48f2-9f79-df232c5cd1b6
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "794"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e0f2ea7-2146-43c4-8ba3-91739505f286
+      - 3db748e0-630c-44e3-a8bc-f8354fdb16f7
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "794"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:09 GMT
+      - Thu, 16 Nov 2023 15:52:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac91c512-e15d-468d-9ad8-41ea02887365
+      - 22586f64-e548-40e0-b239-d6863e2a00c9
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "794"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:39 GMT
+      - Thu, 16 Nov 2023 15:53:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a71a97a5-861e-49d5-a071-0f2adbf01b2e
+      - 1eacc523-b95d-4df5-9872-d0337a56685a
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "794"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:09 GMT
+      - Thu, 16 Nov 2023 15:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37a23ec4-5f5e-4838-84b0-c6619d072e9e
+      - cdc237ab-10f5-4f83-be14-fa3e6e5bd203
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "794"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:39 GMT
+      - Thu, 16 Nov 2023 15:54:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57504f45-4b45-4e74-841b-8181d3f14b9d
+      - 7486ad5c-68d4-4b12-8bda-06925e4d1e63
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "794"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:09 GMT
+      - Thu, 16 Nov 2023 15:54:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1485592d-19ea-42de-a831-32e6d4b49ded
+      - d153c535-0055-4885-8ac0-c5b17c42bdee
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1098"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ea43ef9-97da-4063-98a5-6562c25105eb
+      - 1afafa2e-e2c2-4816-9e1f-a34478fdc48b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800},"endpoints":[{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800}],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:55:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 57ac17e3-9d73-460c-b8e0-3b3cfb02fb9d
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800},"endpoints":[{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800}],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1317"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9522eee-885f-4858-b547-dcd7b6f4b12b
+      - 14644c38-6057-45b7-84a1-f1cb649f2e82
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800},"endpoints":[{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800}],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1317"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f21c08d5-a814-44ed-8869-28eb92d73236
+      - 74ed110d-aa5c-4476-aaeb-3f6a95483cbe
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSHFnT01CUzl1QmFUWFJZdGR5ZVc0QlFNOWs0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56STVXaGNOTXpNeE1ETXdNVGcwTnpJNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5CNCtid1RVaStkVXhFd0RSYklXdkRNelpXdHNOMC8yNlJBZG93b2RqY1REOXdMbzNCek5oeTkKZVdGQndkaEZnbk5janoxLzkyVjc5L1QxZHUrSk8xTHNMd0VqUzd1WXlvWFlSS252WFVELytneDhLY2hiZ0w1dwpNby9Ib25Ba1hkc29JOFJaMjJEVlBORCs2ako4SnNKV09wK1hyRmZxYWExbHQrWDVaQjRyL1hGS3dmUng0cVVPCkh5Mkc3QndzaE9aeFgzQ1gvT0xHRElGZTNMd3cxa1VaaUkvOXpZWjN6WkpyenlUUVZnQy9xWVBiQVZ5NlBMS2oKVlVPWWZvU1N1bEdkMVl0WXZkenlzd3pTM0FocG95cHZNVVRxVzFkM0s0V082NmxDOWhrTTNOdDYzTVlUVTF5bApBOWtOS09PeThtME5ub2ZETERweHdzQld5dmdRVFRzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TWpZNFpqazJZV0l0T1RJeE1TMDBaamxqTFdKak56UXRORGRrT1RNd1l6azIKWm1GakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpGcmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQnUwVW1LdXorOE1YNVorVHZlbnluemVvekk3K2hNVFowYVRjSzd4ZWN5SXFjdWtHdU9kaFR6ClJGbkowT1lHdDU1cUZRRjNtZXVkclZFSk5yaHN5NHV3UjV2bW9WVjRFaVBnMU1IcGgzRGh5MWNjUEp1TFVTMnQKRk52T0xwYXNUVjBUZlRBeWVDWVBuOUErUjQ3NjRnZ0ZlMmxWbW5BYWs1ZWtLVEUveGRKcDU2WW5zeGFFa21mUQp5R2RKNHkrQnJxUEpZUytva0dJbVovdVhoMHNjTTNnUEJRUnR6V1dHY2NKalUrWG9wYTVCcDlBZkRDcXhCY0VPClJ0S05NNk5RRzNMNy9vczJjVEFRUVNqTG1zNlVPaWF3SURUU3JPc1d5d2VGN01YZ3RzREVSNzBkaTRTWVUyZ24KejVtcEx5RTBwajEzNnBaUk1HT1M4ZmtSSFpOUXYrdUwKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSld5QzBVWFUwVmx5ZE5IVUh4Y1hFdkJ2R1FBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UVXdPVm9YRFRNek1URXhNekUxTlRVd09Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQWtTR2s5M1dVUmY2dG9vc0wxRW14MzN5STJNNWVtaUVRekN4eGsxdkVDNmRmMVhOMmFtenoKb0pmVC9USWM1MTFxYkZlMi9XaVJKWlI2S2pkT0tYc1NTVGFYQWdBSDcrQXRlM3F4c2ROMUcwOEVMQUpjNXpzTApkWHNTYkZJRFpNUVF0anMzWXduSldQTkxaRUhPOENaNGN2M3JVbGsrRldSM201KzJOM3pyc1pVOEl6UEh3OThFClNITDdHdi9RWW5kamxOOHpVWjdIZXJGN1JOemRWN290UWRpQUI5dXJSWTZUUzJjemduMkZjUVo5ak5MQlFyZSsKMk83SlhvNUVmZldNYXBENXJMVFJ5cmhVd3p3REpIMys3MG5FVktBRndvdEFQcmJBME9HWUFpdU03K2V4VFFhTgpBcnkvR2dnU2hsR0M1QnEvUjcrVHF0TzVaZzArZENpQlVRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE56UmlZbVUxWldRdFlqTXpNaTAwTWpVM0xUZzFZVFF0T0dWa01qVTIKWkdVME1EZG1MbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5raTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFwU25aRjNuK0ZLY0h1ZGd1UFhhVmR2c2ZudjE3eVV0Wm5iaWdyNXhuK3JhZWt3TW5VClU4L3Y5eU0razlHUFBuU3dFU1RPZCtrQ0RYajhMZ1pCTFhSbi9PazMwTlZVTmdKa0N3dmVqMkFMclBzQVRlZXkKMmJ1K3R0VWF2Wk5GM2xlMEJLRXFmQllsVW02R2Z0a1U5Qi9wL2wzakwwVGNWMmRRTW9sKzBKaHdUL0laTldOSQo4WWc1R0poWGMxNVYveEZCQ2RjMGRMVGExTElYTkw4MTV0bWRPNmo5U2hSQmIvZVpaeWU0OHo5QWVZQWNpRHArCjRuV2RraWNaUFUrUkNueUlYUXpQZExFdlRTQ0NhSUhDVkxsMFBOVGhMbXhDY080ZTFtUTlEaVV4elBMWlZuY2YKbnVvbWRzTmV3MGtmMGVLTzVpTzNLN0dIbU1FcnFTNTRFRGhNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1378b32-c286-4a2b-a111-54d3f0ff74a8
+      - f3b99033-70e7-4f31-af54-978181b62722
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800},"endpoints":[{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800}],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1317"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52d9c927-a5e2-43c6-aef5-93856f6eda0e
+      - 6d943998-fd80-4812-9b9a-296c4105ce12
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
     headers:
       Content-Length:
-      - "49"
+      - "52"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 155793f5-33bc-4019-9cd6-b2f256e04b5d
+      - 36c44618-dace-4327-9cfc-7ddefeaaccc3
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800},"endpoints":[{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800}],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1317"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5908593-46c4-411b-a1e1-17f73e52a00f
+      - 422639f8-053c-47a6-8201-df8ebc0eba89
     status: 200 OK
     code: 200
     duration: ""
@@ -807,52 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "102"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 87859bce-bf7e-4fbb-9a5d-7f0dc89ca2bd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42f2096e-aa11-48b5-a01c-094df9a41b2c
+      - 97b244de-5a38-4e30-998b-a8023d35d6a3
     status: 200 OK
     code: 200
     duration: ""
@@ -873,85 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1265"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1211278d-2c44-4e2c-92c7-d112d7393355
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSHFnT01CUzl1QmFUWFJZdGR5ZVc0QlFNOWs0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56STVXaGNOTXpNeE1ETXdNVGcwTnpJNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5CNCtid1RVaStkVXhFd0RSYklXdkRNelpXdHNOMC8yNlJBZG93b2RqY1REOXdMbzNCek5oeTkKZVdGQndkaEZnbk5janoxLzkyVjc5L1QxZHUrSk8xTHNMd0VqUzd1WXlvWFlSS252WFVELytneDhLY2hiZ0w1dwpNby9Ib25Ba1hkc29JOFJaMjJEVlBORCs2ako4SnNKV09wK1hyRmZxYWExbHQrWDVaQjRyL1hGS3dmUng0cVVPCkh5Mkc3QndzaE9aeFgzQ1gvT0xHRElGZTNMd3cxa1VaaUkvOXpZWjN6WkpyenlUUVZnQy9xWVBiQVZ5NlBMS2oKVlVPWWZvU1N1bEdkMVl0WXZkenlzd3pTM0FocG95cHZNVVRxVzFkM0s0V082NmxDOWhrTTNOdDYzTVlUVTF5bApBOWtOS09PeThtME5ub2ZETERweHdzQld5dmdRVFRzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TWpZNFpqazJZV0l0T1RJeE1TMDBaamxqTFdKak56UXRORGRrT1RNd1l6azIKWm1GakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpGcmh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQnUwVW1LdXorOE1YNVorVHZlbnluemVvekk3K2hNVFowYVRjSzd4ZWN5SXFjdWtHdU9kaFR6ClJGbkowT1lHdDU1cUZRRjNtZXVkclZFSk5yaHN5NHV3UjV2bW9WVjRFaVBnMU1IcGgzRGh5MWNjUEp1TFVTMnQKRk52T0xwYXNUVjBUZlRBeWVDWVBuOUErUjQ3NjRnZ0ZlMmxWbW5BYWs1ZWtLVEUveGRKcDU2WW5zeGFFa21mUQp5R2RKNHkrQnJxUEpZUytva0dJbVovdVhoMHNjTTNnUEJRUnR6V1dHY2NKalUrWG9wYTVCcDlBZkRDcXhCY0VPClJ0S05NNk5RRzNMNy9vczJjVEFRUVNqTG1zNlVPaWF3SURUU3JPc1d5d2VGN01YZ3RzREVSNzBkaTRTWVUyZ24KejVtcEx5RTBwajEzNnBaUk1HT1M4ZmtSSFpOUXYrdUwKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1843"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1749a588-31eb-4b22-80eb-8068a7eb1dca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
+      - Thu, 16 Nov 2023 15:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58adb256-edf3-4e68-8c46-28ee4ec71cd1
+      - 18845791-a0c4-4151-80e5-470aba634bd3
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800},"endpoints":[{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800}],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1317"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:43 GMT
+      - Thu, 16 Nov 2023 15:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16d550df-fb2a-4af5-b80b-1c665a3d9620
+      - ec427687-1a46-4a53-961e-268f93183012
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,7 +939,106 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSld5QzBVWFUwVmx5ZE5IVUh4Y1hFdkJ2R1FBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UVXdPVm9YRFRNek1URXhNekUxTlRVd09Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQWtTR2s5M1dVUmY2dG9vc0wxRW14MzN5STJNNWVtaUVRekN4eGsxdkVDNmRmMVhOMmFtenoKb0pmVC9USWM1MTFxYkZlMi9XaVJKWlI2S2pkT0tYc1NTVGFYQWdBSDcrQXRlM3F4c2ROMUcwOEVMQUpjNXpzTApkWHNTYkZJRFpNUVF0anMzWXduSldQTkxaRUhPOENaNGN2M3JVbGsrRldSM201KzJOM3pyc1pVOEl6UEh3OThFClNITDdHdi9RWW5kamxOOHpVWjdIZXJGN1JOemRWN290UWRpQUI5dXJSWTZUUzJjemduMkZjUVo5ak5MQlFyZSsKMk83SlhvNUVmZldNYXBENXJMVFJ5cmhVd3p3REpIMys3MG5FVktBRndvdEFQcmJBME9HWUFpdU03K2V4VFFhTgpBcnkvR2dnU2hsR0M1QnEvUjcrVHF0TzVaZzArZENpQlVRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE56UmlZbVUxWldRdFlqTXpNaTAwTWpVM0xUZzFZVFF0T0dWa01qVTIKWkdVME1EZG1MbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5raTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFwU25aRjNuK0ZLY0h1ZGd1UFhhVmR2c2ZudjE3eVV0Wm5iaWdyNXhuK3JhZWt3TW5VClU4L3Y5eU0razlHUFBuU3dFU1RPZCtrQ0RYajhMZ1pCTFhSbi9PazMwTlZVTmdKa0N3dmVqMkFMclBzQVRlZXkKMmJ1K3R0VWF2Wk5GM2xlMEJLRXFmQllsVW02R2Z0a1U5Qi9wL2wzakwwVGNWMmRRTW9sKzBKaHdUL0laTldOSQo4WWc1R0poWGMxNVYveEZCQ2RjMGRMVGExTElYTkw4MTV0bWRPNmo5U2hSQmIvZVpaeWU0OHo5QWVZQWNpRHArCjRuV2RraWNaUFUrUkNueUlYUXpQZExFdlRTQ0NhSUhDVkxsMFBOVGhMbXhDY080ZTFtUTlEaVV4elBMWlZuY2YKbnVvbWRzTmV3MGtmMGVLTzVpTzNLN0dIbU1FcnFTNTRFRGhNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1849"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:55:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5b2ed13b-1bcc-4e14-96be-7d55c27132db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f/databases?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "106"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:55:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 841f7b4e-965f-4f84-867e-cacd96c1bdbc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800},"endpoints":[{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800}],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:55:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 51553492-6047-4229-b9a6-675d784ff9bb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f/databases/foo
     method: DELETE
   response:
     body: ""
@@ -1015,7 +1048,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:43 GMT
+      - Thu, 16 Nov 2023 15:55:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9493f65a-bc0d-4a07-a128-64dba2d6a308
+      - 13a28c43-1c6e-4574-98f2-1210da7ffc4d
     status: 204 No Content
     code: 204
     duration: ""
@@ -1036,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800},"endpoints":[{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800}],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1317"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:43 GMT
+      - Thu, 16 Nov 2023 15:55:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7774febb-b244-4546-80b9-d904f58046f4
+      - 343c4df4-093c-4b04-89e9-a32d489b28cb
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800},"endpoints":[{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800}],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1317"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:43 GMT
+      - Thu, 16 Nov 2023 15:55:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca20c142-e21a-41c0-8223-5b7a3852de34
+      - 134866fa-b7b5-44c8-b304-031aa5595cd2
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800},"endpoints":[{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800}],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1320"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:44 GMT
+      - Thu, 16 Nov 2023 15:55:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b19aeb42-a62f-443f-8d82-0bb42d3b3eb7
+      - c1ca9509-23a8-4403-94a0-93e32f862015
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,19 +1168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:38.110382Z","retention":7},"created_at":"2023-11-02T18:46:38.110382Z","endpoint":{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709},"endpoints":[{"id":"2c9498c9-ee84-4fb0-a213-e166f0565620","ip":"51.159.26.223","load_balancer":{},"name":null,"port":3709}],"engine":"PostgreSQL-15","id":"268f96ab-9211-4f9c-bc74-47d930c96fac","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:10.020836Z","retention":7},"created_at":"2023-11-16T15:52:10.020836Z","endpoint":{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800},"endpoints":[{"id":"c4a658a7-e8ea-4694-9102-5436463e5ce5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":27800}],"engine":"PostgreSQL-15","id":"74bbe5ed-b332-4257-85a4-8ed256de407f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1320"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:44 GMT
+      - Thu, 16 Nov 2023 15:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7807052-e846-42de-b638-554a96940c42
+      - 38333e53-f02d-47c4-b7e7-18434bfd4545
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,10 +1201,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"268f96ab-9211-4f9c-bc74-47d930c96fac","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"74bbe5ed-b332-4257-85a4-8ed256de407f","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1180,7 +1213,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 15:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e5beefa-1f8d-4f56-b908-797e70964d62
+      - e91d5d29-c16b-4426-9171-3ccd41826040
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1201,10 +1234,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/268f96ab-9211-4f9c-bc74-47d930c96fac
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74bbe5ed-b332-4257-85a4-8ed256de407f
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"268f96ab-9211-4f9c-bc74-47d930c96fac","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"74bbe5ed-b332-4257-85a4-8ed256de407f","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1213,7 +1246,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:14 GMT
+      - Thu, 16 Nov 2023 15:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49e50d47-a0ab-40cf-870a-0ba621da8038
+      - b94cce97-dbdd-4035-a681-e19e96b48626
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-database-manual-delete.cassette.yaml
+++ b/scaleway/testdata/rdb-database-manual-delete.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:33 GMT
+      - Thu, 16 Nov 2023 15:52:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 306071b1-007f-49c5-8afb-fdb5154274f0
+      - 9321822a-2ef9-460b-a466-5f736a9e117a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"bug","engine":"PostgreSQL-15","user_name":"admin","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-m","is_ha_cluster":false,"disable_backup":true,"tags":["bug"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"bug","engine":"PostgreSQL-15","user_name":"admin","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-m","is_ha_cluster":false,"disable_backup":true,"tags":["bug"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "699"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:13 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fc866c3-7a48-4535-8799-c94b57037c26
+      - 0fa040b4-1d72-4d06-9b17-2bec45ee1e42
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "699"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:13 GMT
+      - Thu, 16 Nov 2023 15:56:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5258796-201f-4a5c-9f43-c7cb2b7c8eb7
+      - 5d33a228-6b34-454d-9adf-e80f9bc5538f
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "699"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:43 GMT
+      - Thu, 16 Nov 2023 15:56:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64d0a6ca-c5eb-441e-8d72-3741988b6a8c
+      - ed864886-e6b4-4042-922b-45c57c16087e
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "699"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:13 GMT
+      - Thu, 16 Nov 2023 15:57:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e2481d4-2085-4121-8605-601b4437727c
+      - f63625b0-8204-42ea-86c7-0863d1588849
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "699"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:43 GMT
+      - Thu, 16 Nov 2023 15:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25515151-8aff-41b0-ade3-48872cca3d03
+      - 9f6b611c-a9f2-46b3-b5a8-2e930040d142
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "699"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:13 GMT
+      - Thu, 16 Nov 2023 15:58:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 709e750e-00d4-4ae7-b13c-cbe842720bee
+      - 7d2bef7c-410b-4aca-9ac9-1ec3344572aa
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:43 GMT
+      - Thu, 16 Nov 2023 15:58:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2001603d-56a3-49eb-aa52-b5d272ae9561
+      - fa520f98-b322-4763-806a-8e5d036fd5ed
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSSs4c0ltWnM1eG9aWk9DanFCNGZ1NzNpNnl3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVd05ESmFGdzB6TXpFd016QXhPRFV3TkRKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNxdEczcUJVYmZHV2V0Y09nV2JPSFpCclBQOTEzcC9SM1VBTGhZQ2Urc0M3OVBNUTRPUUJxN044TWoKY1ZYTzUwT3FNN2dxRkhxRUtSUGc2UG1Lc0Y4SEk4VFhlbmMzNVZ0U0U1MTJoZldZUW91emVCU3IrWGx3enBKRwpyTWNUNjhLNEJITXBhSWgxN3pvbzliN2RnKzhBRFF1ZS9YR0U3VkpwMjFiMDVjS3FaSU80aVFldG13YVR2dkRxCk5oMVRkOStaTmw0UDJ1YjQxODFtL0F6L3NsMUlkL2p4bTFQSEMvWDZTQkVNb0JHZG1ZcU03WjZmWDg5SlphRDYKRXpGSE5JRkZXc051SndPQXg5K0ViNWZIaDJDWnJJOFZKVWYzRDh1aStoOHk4RU52SDROL1play9yeXA0ZDlGSQpyL0pUL0ZWMnAyVzNhQWQxc0QzUjVPeG1uNFgvQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPVFF6TmpRNFlURXRNRFk0WXkwME16bG1MV0ZpWkRFdFpqUmpPRGRqT1dZMlptSTUKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubkhLaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFDTTh0TkR3VktoakpFVk9rN3l3VnF0clExRlNLUnIrT0R3Q1VhU2NIUHV1VW8yODVwZy9iRjVBaEowCkt3L2d4VmdYQTdxblB5cE5YdlBieEkvZktIakh3aE1DeXZnR2hld3RHWEpKbFRlbDNOT1poblFTaWt1dHY4MVMKVmZjMDNvTEZUMmpLc1VoUnJ3bHF5Nno0VjZJeVlaUnZoZEYvMll6K2Q0MGM4Sy9tTlJsak9HWHpoaEJQbEp4dQoyUGpwZzBxT05RNnlLeFJONENLdDdnZ3FCR1lJNDg4YTZ1ejB2OC90dmJYcENTZWowVmpINzlYOU9WMlBwTlJOCllva3dYZ1h4cHlra1h6eDV4dUh0eG9paGFQcnlqd0pvc2VGVnVkSjQ3eDlWMURydlpBS3FjZi8yTHZEZTl4YnEKcE1EU0xCdFZUVDlKdzFacUN1MWdUQm9obk1lSgotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1839"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:44 GMT
+      - Thu, 16 Nov 2023 15:59:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a73a26f-8a54-49c6-a30c-9928f1021e7c
+      - 865b04ed-36ff-4b66-aa7d-45338ef2db17
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:44 GMT
+      - Thu, 16 Nov 2023 15:59:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 260f1f3e-730f-4f35-a07d-5e7deacb95f0
+      - 451406d3-9613-4b68-adf3-8e6f95accf3c
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVUXdmcktjQTJ3enRnQzU5eS9mNUY5cXZaMXRVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5Ua3pOVm9YRFRNek1URXhNekUxTlRrek5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRQVXRYbXVhNHV1V2NhWGpKS3cwRHlyTWoxKzdWclFvcU02VDdGMlJ3QUNDc3pVU1YwS2kKVUN4ZUhyVklZVjdmWjFoTHlEMHRJNURkMC9HbGdSSUszeUNxN2hMVU1iUUNXQ2JuVmhPdng0RU05czh6aEoyZgpqTXRKbW5VNUlhbzJiWDl1YmQ2bEZRRmZYRjdqcG1OVUo2TkpqSjFGcktEQlA2Mk02bWZ1dHF5cnUvZitLNUF2Cm05bjFqQkNEbitQaVVTZmRrd01QTFVsUXBCTWc0VmlCZ1JpcHhYamQvajkyRDN3aktQRm9ZZldCT2toM2tNNkIKR2NadWZCKzNveHVDNkZIZDJpbUlVbW5sS1ZSTzdJTlcvR2o1Nzh2L0ZNOWUyV09PRUZpd2dINlBtUHRMRGkyZAptMU1sU25qN3I4MWswdEc4SmNhS1pWMmJNcmh5Ri80RjVRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1Ea3hPRE14TkdFdFlXUTRZaTAwTkdZM0xUaGlZV1V0WkdWbU1EWmsKTURJeE1tSXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJJOThod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFXVWZDMjZEbmlVOUVXZTZrT0xRYmN5cHpsbklnb3BJNWxrelRNa2dob3VyQUYrYWlFClR1MkQ5SWpwYWd6ZkZNZTVJT2ZtWnhKbUwyOEl2VmpIWllPT0hkT0ZyN1cyZnJMREJuRHV4SXhUUUowYlVHeUcKRFRSUUl6VExiNGF0eEpobVAva0FkdjhCVXQ0SlIyQjJQc0IvbEhiRk1PZmJ5N0FDcXFodTJGKzNSdlg0MUc5cApSQnFNR3RRNGN6RFM5ZUFudS9wUS9YSnFZdm9MdEgxRVdKUU5lcm9rZGJXOTRFQ0NqeDdxbkxrelFSblN1U1JFClBHaTZxNnluMFhHckRtMDVPNy95Zkg4RXNad0J4ZWhRZlZwckJiNlFnbXpjcWNhSmdqbi9hYTVwS0JlN2ZjT2cKTmhzM3FKNm82M3JTNHhmYUFtdmdacnBUaS9SMjBLZmVrSVVJCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1170"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:44 GMT
+      - Thu, 16 Nov 2023 15:59:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 653354a7-9013-44a6-9356-bbfb691e4659
+      - 643c1282-e421-4bca-abf6-60a8a2b45408
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1220"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:59:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4d680302-1fbc-444c-85aa-d21254148c90
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1220"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:59:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 81acd600-d65a-4b82-8dd2-b04891bace69
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"bug"}'
     headers:
       Content-Length:
-      - "31"
+      - "32"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:44 GMT
+      - Thu, 16 Nov 2023 15:59:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fb1df89-58f1-4f69-b450-d3c0af0947ba
+      - fc571aa3-3dcf-4a75-b1d1-9271f170249a
     status: 200 OK
     code: 200
     duration: ""
@@ -708,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/databases
     method: POST
   response:
     body: '{"managed":true,"name":"bug","owner":"","size":0}'
     headers:
       Content-Length:
-      - "49"
+      - "52"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:44 GMT
+      - Thu, 16 Nov 2023 15:59:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b50db6fe-d9bf-49bd-b86e-789d4e84151c
+      - afa71d50-9e1e-42b7-abb2-959c334a6824
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:44 GMT
+      - Thu, 16 Nov 2023 15:59:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 421e3643-0964-4117-81ef-1bae2c5c901b
+      - 12929a88-f9c6-4d65-ace7-b6a3d716fa47
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:44 GMT
+      - Thu, 16 Nov 2023 15:59:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20c46eb4-365c-44ca-a799-5e54b4464be4
+      - bb4acd9f-c168-401f-b924-0b20ba15b4a1
     status: 200 OK
     code: 200
     duration: ""
@@ -807,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:44 GMT
+      - Thu, 16 Nov 2023 15:59:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6f0cbe0-737a-48d5-b40f-16bc4ca862c0
+      - 1b1b2fa0-9d1f-487a-959f-9513f7fd3d45
     status: 200 OK
     code: 200
     duration: ""
@@ -840,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/databases?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/databases?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"bug","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:44 GMT
+      - Thu, 16 Nov 2023 15:59:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b85da48f-c32b-4ce9-afb7-a54604d0fbbd
+      - f57d9c55-3386-4253-a65f-951c54780506
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:44 GMT
+      - Thu, 16 Nov 2023 15:59:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0e90bb8-65dd-4f22-8b47-8d5fab990ebe
+      - e198514a-7861-40ba-ad21-9934ba1ed79c
     status: 200 OK
     code: 200
     duration: ""
@@ -908,19 +974,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/privileges
     method: PUT
   response:
     body: '{"database_name":"bug","permission":"all","user_name":"bug"}'
     headers:
       Content-Length:
-      - "60"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:44 GMT
+      - Thu, 16 Nov 2023 15:59:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -930,7 +996,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad002d95-2fbf-4430-b8a7-835ec81623ec
+      - b9eff9b0-336a-4936-a9b9-4a34252839e2
     status: 200 OK
     code: 200
     duration: ""
@@ -941,19 +1007,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:45 GMT
+      - Thu, 16 Nov 2023 15:59:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -963,7 +1029,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e540150e-4aef-4bad-b6e1-d8bc02b241ab
+      - 8b22ceb1-fb67-45f2-9c9f-aadc87f9c5a9
     status: 200 OK
     code: 200
     duration: ""
@@ -974,19 +1040,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:45 GMT
+      - Thu, 16 Nov 2023 15:59:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -996,7 +1062,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 417b1454-5457-4f9b-b7a6-eb866e46b109
+      - 4c32dce1-c75e-4f75-94ce-c83e19dd9ca3
     status: 200 OK
     code: 200
     duration: ""
@@ -1007,19 +1073,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:49 GMT
+      - Thu, 16 Nov 2023 15:59:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1029,7 +1095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da60b52b-51bc-4591-b0da-725f286f01d5
+      - c2bdece5-8ddb-4e69-ba6f-6062939d0af8
     status: 200 OK
     code: 200
     duration: ""
@@ -1040,19 +1106,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/privileges?database_name=bug&order_by=user_name_asc&user_name=bug
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/privileges?database_name=bug&order_by=user_name_asc&user_name=bug
     method: GET
   response:
     body: '{"privileges":[{"database_name":"bug","permission":"all","user_name":"bug"}],"total_count":1}'
     headers:
       Content-Length:
-      - "93"
+      - "96"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:50 GMT
+      - Thu, 16 Nov 2023 15:59:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1062,7 +1128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72dd32af-1747-4675-97eb-3187ec596e25
+      - eee68796-dddd-49f1-adcd-c764ea924111
     status: 200 OK
     code: 200
     duration: ""
@@ -1073,19 +1139,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/databases?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/databases?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"bug","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:51 GMT
+      - Thu, 16 Nov 2023 15:59:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1095,7 +1161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a3dbc87-c1d9-4612-9ca9-1d4c0bc1ecf8
+      - fd950ed6-9979-4ff5-9cf2-59cab37deb81
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,19 +1172,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 15:59:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1128,7 +1194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ece9296-3678-445d-9a0a-239da2eb6928
+      - 3210322a-c63e-482e-81a2-f15e6429b85a
     status: 200 OK
     code: 200
     duration: ""
@@ -1139,19 +1205,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSSs4c0ltWnM1eG9aWk9DanFCNGZ1NzNpNnl3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVd05ESmFGdzB6TXpFd016QXhPRFV3TkRKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNxdEczcUJVYmZHV2V0Y09nV2JPSFpCclBQOTEzcC9SM1VBTGhZQ2Urc0M3OVBNUTRPUUJxN044TWoKY1ZYTzUwT3FNN2dxRkhxRUtSUGc2UG1Lc0Y4SEk4VFhlbmMzNVZ0U0U1MTJoZldZUW91emVCU3IrWGx3enBKRwpyTWNUNjhLNEJITXBhSWgxN3pvbzliN2RnKzhBRFF1ZS9YR0U3VkpwMjFiMDVjS3FaSU80aVFldG13YVR2dkRxCk5oMVRkOStaTmw0UDJ1YjQxODFtL0F6L3NsMUlkL2p4bTFQSEMvWDZTQkVNb0JHZG1ZcU03WjZmWDg5SlphRDYKRXpGSE5JRkZXc051SndPQXg5K0ViNWZIaDJDWnJJOFZKVWYzRDh1aStoOHk4RU52SDROL1play9yeXA0ZDlGSQpyL0pUL0ZWMnAyVzNhQWQxc0QzUjVPeG1uNFgvQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPVFF6TmpRNFlURXRNRFk0WXkwME16bG1MV0ZpWkRFdFpqUmpPRGRqT1dZMlptSTUKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubkhLaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFDTTh0TkR3VktoakpFVk9rN3l3VnF0clExRlNLUnIrT0R3Q1VhU2NIUHV1VW8yODVwZy9iRjVBaEowCkt3L2d4VmdYQTdxblB5cE5YdlBieEkvZktIakh3aE1DeXZnR2hld3RHWEpKbFRlbDNOT1poblFTaWt1dHY4MVMKVmZjMDNvTEZUMmpLc1VoUnJ3bHF5Nno0VjZJeVlaUnZoZEYvMll6K2Q0MGM4Sy9tTlJsak9HWHpoaEJQbEp4dQoyUGpwZzBxT05RNnlLeFJONENLdDdnZ3FCR1lJNDg4YTZ1ejB2OC90dmJYcENTZWowVmpINzlYOU9WMlBwTlJOCllva3dYZ1h4cHlra1h6eDV4dUh0eG9paGFQcnlqd0pvc2VGVnVkSjQ3eDlWMURydlpBS3FjZi8yTHZEZTl4YnEKcE1EU0xCdFZUVDlKdzFacUN1MWdUQm9obk1lSgotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVUXdmcktjQTJ3enRnQzU5eS9mNUY5cXZaMXRVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5Ua3pOVm9YRFRNek1URXhNekUxTlRrek5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRQVXRYbXVhNHV1V2NhWGpKS3cwRHlyTWoxKzdWclFvcU02VDdGMlJ3QUNDc3pVU1YwS2kKVUN4ZUhyVklZVjdmWjFoTHlEMHRJNURkMC9HbGdSSUszeUNxN2hMVU1iUUNXQ2JuVmhPdng0RU05czh6aEoyZgpqTXRKbW5VNUlhbzJiWDl1YmQ2bEZRRmZYRjdqcG1OVUo2TkpqSjFGcktEQlA2Mk02bWZ1dHF5cnUvZitLNUF2Cm05bjFqQkNEbitQaVVTZmRrd01QTFVsUXBCTWc0VmlCZ1JpcHhYamQvajkyRDN3aktQRm9ZZldCT2toM2tNNkIKR2NadWZCKzNveHVDNkZIZDJpbUlVbW5sS1ZSTzdJTlcvR2o1Nzh2L0ZNOWUyV09PRUZpd2dINlBtUHRMRGkyZAptMU1sU25qN3I4MWswdEc4SmNhS1pWMmJNcmh5Ri80RjVRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1Ea3hPRE14TkdFdFlXUTRZaTAwTkdZM0xUaGlZV1V0WkdWbU1EWmsKTURJeE1tSXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJJOThod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFXVWZDMjZEbmlVOUVXZTZrT0xRYmN5cHpsbklnb3BJNWxrelRNa2dob3VyQUYrYWlFClR1MkQ5SWpwYWd6ZkZNZTVJT2ZtWnhKbUwyOEl2VmpIWllPT0hkT0ZyN1cyZnJMREJuRHV4SXhUUUowYlVHeUcKRFRSUUl6VExiNGF0eEpobVAva0FkdjhCVXQ0SlIyQjJQc0IvbEhiRk1PZmJ5N0FDcXFodTJGKzNSdlg0MUc5cApSQnFNR3RRNGN6RFM5ZUFudS9wUS9YSnFZdm9MdEgxRVdKUU5lcm9rZGJXOTRFQ0NqeDdxbkxrelFSblN1U1JFClBHaTZxNnluMFhHckRtMDVPNy95Zkg4RXNad0J4ZWhRZlZwckJiNlFnbXpjcWNhSmdqbi9hYTVwS0JlN2ZjT2cKTmhzM3FKNm82M3JTNHhmYUFtdmdacnBUaS9SMjBLZmVrSVVJCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1839"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 15:59:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1161,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7ae2d34-2734-47d8-91d0-b38298f4f7c2
+      - 2bb7dd7a-b313-489e-aa50-ad328e95a5c7
     status: 200 OK
     code: 200
     duration: ""
@@ -1172,19 +1238,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 15:59:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1194,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 010532da-4653-4acf-bee2-f38e064ee7ed
+      - aa949512-f291-4db5-b2b6-5562d7d7d67f
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,19 +1271,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/databases?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/databases?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"bug","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 15:59:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1227,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dafa363e-280b-4aed-83c8-731d3cdd4a26
+      - 1391cf89-34e2-4a2a-b1a9-b6c51a8617b6
     status: 200 OK
     code: 200
     duration: ""
@@ -1238,19 +1304,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 15:59:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92711829-21af-4aca-b3da-b16477ec38cd
+      - 9a4947d0-5cab-4c78-b5b4-3a4f7dab52b3
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,19 +1337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 16:00:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6cd780e3-36c5-48f8-a99d-4f080da60a5d
+      - b5ee52e9-3974-45fe-ab1d-00c23c7744c4
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,19 +1370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 16:00:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c65671a1-1eeb-4b69-9129-04d056493fa8
+      - 19fc1b7f-a3ce-4f18-82e3-65e27e6ae269
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,19 +1403,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/privileges?database_name=bug&order_by=user_name_asc&user_name=bug
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/privileges?database_name=bug&order_by=user_name_asc&user_name=bug
     method: GET
   response:
     body: '{"privileges":[{"database_name":"bug","permission":"all","user_name":"bug"}],"total_count":1}'
     headers:
       Content-Length:
-      - "93"
+      - "96"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:53 GMT
+      - Thu, 16 Nov 2023 16:00:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 982009e1-a159-47f9-9157-5b4cbf4348fb
+      - 61992c97-eb7b-483e-bc2d-194d0d94c360
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,19 +1436,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:54 GMT
+      - Thu, 16 Nov 2023 16:00:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1392,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65873be7-de7f-4601-b3d1-6219df258743
+      - 3dc6721c-0343-4abe-80f1-42410d524eae
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,52 +1469,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users?name=bug&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:52:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0dfe9f97-0f59-49d4-b771-0a4be411db0f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:54 GMT
+      - Thu, 16 Nov 2023 16:00:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1491,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25591045-bb5b-4423-8fd8-ef2863f3dc83
+      - 6d0b25ca-787f-407b-ad07-24fe3badcee5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/users?name=bug&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
+    headers:
+      Content-Length:
+      - "61"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c47c046a-85f9-4887-ab89-eae3767349d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1471,19 +1537,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/privileges
     method: PUT
   response:
     body: '{"database_name":"bug","permission":"none","user_name":"bug"}'
     headers:
       Content-Length:
-      - "61"
+      - "63"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:54 GMT
+      - Thu, 16 Nov 2023 16:00:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1493,7 +1559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce2fbe21-f292-43c7-9c4a-a25928534cd6
+      - 08c635b1-08eb-4f13-9741-e7c37ebaf212
     status: 200 OK
     code: 200
     duration: ""
@@ -1504,19 +1570,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:54 GMT
+      - Thu, 16 Nov 2023 16:00:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1526,7 +1592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35e2adf2-b9f8-45c3-9391-d73b7323b48b
+      - d379d75c-a20e-4975-b107-4d8b0cf19c8f
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,19 +1603,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:55 GMT
+      - Thu, 16 Nov 2023 16:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1559,7 +1625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01df8188-15cf-4b86-85a4-dfa02ae1f5a7
+      - b2aedbf8-1c22-4804-b8db-6dfd7cb7fdb6
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,19 +1636,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:55 GMT
+      - Thu, 16 Nov 2023 16:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1592,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b0727e1-5820-49aa-9f9e-9537bcfc7eaf
+      - 6d359bd0-fe37-4261-8365-516a574461b9
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,7 +1669,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/users/bug
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/users/bug
     method: DELETE
   response:
     body: ""
@@ -1613,7 +1679,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:59 GMT
+      - Thu, 16 Nov 2023 16:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c4b5eda-49d2-41d2-9f70-c79c52905834
+      - af3cb426-d713-47fc-a2f5-f34c6d6ff558
     status: 204 No Content
     code: 204
     duration: ""
@@ -1634,7 +1700,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9/databases/bug
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2/databases/bug
     method: DELETE
   response:
     body: ""
@@ -1644,7 +1710,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:01 GMT
+      - Thu, 16 Nov 2023 16:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3b69253-056a-4d5c-9fbe-071cdf076220
+      - 119139e4-f9be-4a40-96c7-bf49c67d0147
     status: 204 No Content
     code: 204
     duration: ""
@@ -1665,19 +1731,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:01 GMT
+      - Thu, 16 Nov 2023 16:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a95030d1-d17a-4cb2-b360-ae63e393ed3e
+      - cb11b9ba-4c25-4082-bd33-e9a1f307ed96
     status: 200 OK
     code: 200
     duration: ""
@@ -1698,19 +1764,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:01 GMT
+      - Thu, 16 Nov 2023 16:00:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1786,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 643fb9cf-f5c1-4903-a0da-ccf00f748e39
+      - 68951132-28d8-4e99-b0c6-9a501d38c820
     status: 200 OK
     code: 200
     duration: ""
@@ -1731,19 +1797,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1173"
+      - "1223"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:01 GMT
+      - Thu, 16 Nov 2023 16:00:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 308cf78f-1590-4d71-b16c-fcb5c36cf331
+      - d336f5f7-dde2-4193-b204-4fbbc96851ea
     status: 200 OK
     code: 200
     duration: ""
@@ -1764,19 +1830,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.976391Z","endpoint":{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851},"endpoints":[{"id":"58f39db5-9462-4eb9-907b-e3c4a7d08033","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13851}],"engine":"PostgreSQL-15","id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.789594Z","endpoint":{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033},"endpoints":[{"id":"17cb7cc7-cf3a-4365-b95c-91b92ba8e68c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15033}],"engine":"PostgreSQL-15","id":"0918314a-ad8b-44f7-8bae-def06d0212b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1173"
+      - "1223"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:01 GMT
+      - Thu, 16 Nov 2023 16:00:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fdb35bf-174b-4b5e-b2e8-12e69058c154
+      - 9f68a6b4-8dd3-40a8-b4c3-0598a54f47c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1797,10 +1863,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"0918314a-ad8b-44f7-8bae-def06d0212b2","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1809,7 +1875,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:32 GMT
+      - Thu, 16 Nov 2023 16:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7c16a61-152c-46e9-b112-b2bcf47e48ae
+      - b3707cc9-b831-4bd5-b5ac-82d9bd848e03
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1830,10 +1896,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/943648a1-068c-439f-abd1-f4c87c9f6fb9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0918314a-ad8b-44f7-8bae-def06d0212b2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"943648a1-068c-439f-abd1-f4c87c9f6fb9","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"0918314a-ad8b-44f7-8bae-def06d0212b2","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1842,7 +1908,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:32 GMT
+      - Thu, 16 Nov 2023 16:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +1918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d45bcb4-e93a-4650-8889-2fd624d88eab
+      - 821bf80d-55de-4494-9569-9e9b5ca856c0
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-backup-schedule.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-backup-schedule.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:34 GMT
+      - Thu, 16 Nov 2023 15:52:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5538dfa-c3dc-4a76-8a9f-05b865b5f97a
+      - f4282124-d609-420c-bea8-5708133eea19
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_instance","volume"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_instance","volume"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.311517Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "773"
+      - "802"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:36 GMT
+      - Thu, 16 Nov 2023 15:52:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e9a7a99-7c0a-4578-bc3c-6f6bf531f152
+      - b91819d7-9f64-4e25-8074-5bd02525cc84
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.311517Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "773"
+      - "802"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:36 GMT
+      - Thu, 16 Nov 2023 15:52:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cef47a51-3483-404d-afb6-8254484b4332
+      - 9fbc866d-3c6a-47c7-a954-3f85dcad12ae
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.311517Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "773"
+      - "802"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:06 GMT
+      - Thu, 16 Nov 2023 15:52:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b98fc3e4-0722-4a5f-aaf6-b1a283f821f6
+      - 66acbad0-55e4-4084-aff4-0ee479d3518e
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.311517Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "773"
+      - "802"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:36 GMT
+      - Thu, 16 Nov 2023 15:53:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7c521a9-b46e-49e4-828f-44ad2110c6ef
+      - ef20b3e2-26e8-460a-ad27-159623fbdf00
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.311517Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "773"
+      - "802"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 15:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdf93da3-02e3-4d23-98d7-3e35ab3b6be1
+      - ef779024-16d1-470f-9fa8-81d4d07b6a95
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.311517Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "773"
+      - "802"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:36 GMT
+      - Thu, 16 Nov 2023 15:54:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a1cf67f-4093-40fd-aa6b-b37c506ea402
+      - 73e1d1f9-f9cb-47f4-a736-e1ea8b43832b
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:57:36.054032Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.311517Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1246"
+      - "802"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:07 GMT
+      - Thu, 16 Nov 2023 15:54:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aebca7fd-2fe5-44c8-a8ea-0af44a27194f
+      - 1dd7c6a4-46ea-4ace-add6-1384f5342d73
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.311517Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1077"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:55:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6c3c3380-f45e-4420-b175-6e184f88a5a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.311517Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791},"endpoints":[{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791}],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1296"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:55:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99b4dc0a-a3fb-4217-8952-3fff084f747d
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: PATCH
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:55:40.998297Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791},"endpoints":[{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791}],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1245"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:07 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d1d71b8-4eb6-4b94-9089-0ad629e03ac7
+      - 8df28440-5c51-4411-9b3f-a69c3d72fb08
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:55:40.998297Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791},"endpoints":[{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791}],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1245"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:07 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09f464e8-7668-4893-905a-6d3efeb01695
+      - aea971e4-ad8c-4662-a6aa-88d547791a3a
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSm90MVRXZUcwRnY1NS9keEpHZ05jL0JwSEs0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UZ3hNVm9YRFRNek1UQXpNREU0TlRneE1Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXBZKzN5SHdnWUtUM1ppc3hjREppS3p1TCtpc3hEK3FaS0xKMjRlQ0JUSGs4ajkvV3dtWHgKSTNhTFhJMm1LcTRGaDN0MzRLSU1EaWgvL2oyTm9MVVJJbVc4bG5BNHA2MVZKb3FxbUxqNVgweXlwVDg1MEg1ZgpMM2lMYXpPV3FPeElHemxqclNYUUgzZk13bHFPYjNpc0FUMi9XVE4vbzMrRGRVaWdwa21ib3NUaHV3UFVvRGt1Clc5dWQzZ0s4S1dOODRsc0duM0VrVjBqQk5OR1VKaUM1RnNZSzBBNmJVeTVJYnlPd2pHZ3QzMktiVWxod2JJY2MKbEZ1cGVkZWpPZ2ptaEY4dUhoNFArVDUzMnU2QnREN3VObjJlT2kzZlp6ZG9rM0dMeDMxcnkrdkJrVXFFRmFVawpvSFZCUWVDTkR6SmM2YU0xbmI4MWtXcko1Q3k1c1diWVlRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdFlUWmtZekl5T0RrdE9UazROQzAwTUdVNUxUbGpObVV0TXpZeE9HTTAKT0RCaE5XUmpMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekQxeTNod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJTcUl4YzBHbDVab0k3YkxjR1Njb3B3bUF5RUo1eUYzMzlUUndlMGVHZXhIQnRvS1huCk9IYm5VMUQxTTU2UytYK1E1TTVmQ2V3K2hXQ2dIYXh6V1pzY1dGeWRhWS9iTUpaV0REMzZYOUk0bnNvY0NhVlAKc1FRS1dGVVdUWldPRURSMDhkbTNIMldtK0w5aWZuQ2xCczAvVktjSmthTU44c01iaU5pNW5rQlBCbDdiWVZqMgp0Z1BpTUIyWGkxRkc0SndVQlcrRGJpTzAvVFFlZlpDSklsa01sZ2ZOMnc1RWFjdXExRkorRTQ4R29zNmlWd0h2CmJ1VU4wY3BYNVM3RENlU09IcnNZTXNNQjBxejlJbkR2U3BlMXBwRmgyOUVydjhaNVh5VmRER3U0ZkFFQzk1Y0IKb0hXQlZQUnZRKzZScThZUHF6dmJxWXhyWVgwL3hpNGIyTlh4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVVlJCc3E4ZXI5VnBkN0ZCbEdNSnExck9saW9Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR5TVRBdU1qTTVNQjRYCkRUSXpNVEV4TmpFMU5UUTFObG9YRFRNek1URXhNekUxTlRRMU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHlNVEF1TWpNNU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTdneU9zZGgxczFiN2VBdWlranZzbjhHK2FjVDhXK1pUV0JzMkN5SE8vUVpSMFBoWVdTR2IKZ1A1RVB6YThWVDlqZjBPc2RvbjFtcUtVMFdUSnd4alBncFl5ajdTWE8zeGE5RGVISmZudU50TFFDZEJKTlIyRwpRSmtYNEFlMUttcGYxSGZxSU85ckUwdnlmRnpNK3ZZUUpwOFMrNGFIN1A0cTFuRUJDOXg0T1B5QWZjRmkxSm5RCmlUaFIwR2tOUXRWY25vNFJ0YWtNRjBQVklyQVdVTmVMcjllQm1MVnU2MWR3aGpUSDZXTE1QZmh5WTZmMVdaL2kKajZIdG9RNmFic3pGYkQzcDZPUXR2U21kK2l3MTJyUlRPbHIyNHZsUXZ5MFM3NHE1ckNzVTFobGlOR0I4THI1Ngo3SmVYRmMxS0l3MkIwemN2L3BhRFFIekJWQ0JrMElWaTlRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TWpFd0xqSXpPWUk4Y25jdE5HUTBNVE5tT1RndE1qZ3laaTAwTlRSaExXSXdOVGt0TlRBeFpUazMKWmpSbE1HWmxMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekR6L3hod1F6bnRMdk1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUURRNUMvdjZsSDRXQmRxTlBMOVcrL2FoRTV6aTFZT1ZqMmY4c1krQ1E2Nm81Q1EzMFJ5Ck1xZGtCUTBjM3RhTUNHN2NYaTVFYzl5dkRENXhwS0dCbHg5b0wvbXJFdnBTTldaT1NZN2pRRXRKWlU3Q1lpdTUKTXVsdy9NeXdvSGNaWTl3eHdFK2FIcDdNdWdaSmVDcXF1Y0JQREQ2bS8rMjJmZDZ0UmNKbEdabEVMVEVaTXMwKwpCUitpcERmWUk2elRTMWZ5QjM1dnpzaFFaNW1nV2Q5SFozK0JZNzdCVWwveENXbHZ2SmIrQ1pjZ2liSkE4c0hrCk5OTnZNUDNNT29xMFl3Sld2amloeE04aVVuS2tLQldKZXZzOEJlOWVjazZNZUpDN0QzUGlHMmFsbzFabm5ZbUMKWitCdDBlUWt0WWVObmxGWFNoQlJndHN5RWp1U3hsMmR0TVF1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:07 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96b0bd4d-74f1-48d9-a05a-98060df3b1bb
+      - 5a7bd64d-f707-41b2-86e4-c43db25334ff
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:55:40.998297Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791},"endpoints":[{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791}],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1245"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:07 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27d3188a-130c-49c9-abce-a688efa94931
+      - 3e9f4773-f73c-4ce3-9c2f-c83e05a3a032
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:55:40.998297Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791},"endpoints":[{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791}],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1245"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:08 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1b9a980-2ce5-46aa-a3d3-0e8a08ca1b06
+      - 056d53dd-15eb-4be8-afb7-2e7672998b7c
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSm90MVRXZUcwRnY1NS9keEpHZ05jL0JwSEs0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UZ3hNVm9YRFRNek1UQXpNREU0TlRneE1Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXBZKzN5SHdnWUtUM1ppc3hjREppS3p1TCtpc3hEK3FaS0xKMjRlQ0JUSGs4ajkvV3dtWHgKSTNhTFhJMm1LcTRGaDN0MzRLSU1EaWgvL2oyTm9MVVJJbVc4bG5BNHA2MVZKb3FxbUxqNVgweXlwVDg1MEg1ZgpMM2lMYXpPV3FPeElHemxqclNYUUgzZk13bHFPYjNpc0FUMi9XVE4vbzMrRGRVaWdwa21ib3NUaHV3UFVvRGt1Clc5dWQzZ0s4S1dOODRsc0duM0VrVjBqQk5OR1VKaUM1RnNZSzBBNmJVeTVJYnlPd2pHZ3QzMktiVWxod2JJY2MKbEZ1cGVkZWpPZ2ptaEY4dUhoNFArVDUzMnU2QnREN3VObjJlT2kzZlp6ZG9rM0dMeDMxcnkrdkJrVXFFRmFVawpvSFZCUWVDTkR6SmM2YU0xbmI4MWtXcko1Q3k1c1diWVlRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdFlUWmtZekl5T0RrdE9UazROQzAwTUdVNUxUbGpObVV0TXpZeE9HTTAKT0RCaE5XUmpMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekQxeTNod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJTcUl4YzBHbDVab0k3YkxjR1Njb3B3bUF5RUo1eUYzMzlUUndlMGVHZXhIQnRvS1huCk9IYm5VMUQxTTU2UytYK1E1TTVmQ2V3K2hXQ2dIYXh6V1pzY1dGeWRhWS9iTUpaV0REMzZYOUk0bnNvY0NhVlAKc1FRS1dGVVdUWldPRURSMDhkbTNIMldtK0w5aWZuQ2xCczAvVktjSmthTU44c01iaU5pNW5rQlBCbDdiWVZqMgp0Z1BpTUIyWGkxRkc0SndVQlcrRGJpTzAvVFFlZlpDSklsa01sZ2ZOMnc1RWFjdXExRkorRTQ4R29zNmlWd0h2CmJ1VU4wY3BYNVM3RENlU09IcnNZTXNNQjBxejlJbkR2U3BlMXBwRmgyOUVydjhaNVh5VmRER3U0ZkFFQzk1Y0IKb0hXQlZQUnZRKzZScThZUHF6dmJxWXhyWVgwL3hpNGIyTlh4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVVlJCc3E4ZXI5VnBkN0ZCbEdNSnExck9saW9Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR5TVRBdU1qTTVNQjRYCkRUSXpNVEV4TmpFMU5UUTFObG9YRFRNek1URXhNekUxTlRRMU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHlNVEF1TWpNNU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTdneU9zZGgxczFiN2VBdWlranZzbjhHK2FjVDhXK1pUV0JzMkN5SE8vUVpSMFBoWVdTR2IKZ1A1RVB6YThWVDlqZjBPc2RvbjFtcUtVMFdUSnd4alBncFl5ajdTWE8zeGE5RGVISmZudU50TFFDZEJKTlIyRwpRSmtYNEFlMUttcGYxSGZxSU85ckUwdnlmRnpNK3ZZUUpwOFMrNGFIN1A0cTFuRUJDOXg0T1B5QWZjRmkxSm5RCmlUaFIwR2tOUXRWY25vNFJ0YWtNRjBQVklyQVdVTmVMcjllQm1MVnU2MWR3aGpUSDZXTE1QZmh5WTZmMVdaL2kKajZIdG9RNmFic3pGYkQzcDZPUXR2U21kK2l3MTJyUlRPbHIyNHZsUXZ5MFM3NHE1ckNzVTFobGlOR0I4THI1Ngo3SmVYRmMxS0l3MkIwemN2L3BhRFFIekJWQ0JrMElWaTlRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TWpFd0xqSXpPWUk4Y25jdE5HUTBNVE5tT1RndE1qZ3laaTAwTlRSaExXSXdOVGt0TlRBeFpUazMKWmpSbE1HWmxMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekR6L3hod1F6bnRMdk1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUURRNUMvdjZsSDRXQmRxTlBMOVcrL2FoRTV6aTFZT1ZqMmY4c1krQ1E2Nm81Q1EzMFJ5Ck1xZGtCUTBjM3RhTUNHN2NYaTVFYzl5dkRENXhwS0dCbHg5b0wvbXJFdnBTTldaT1NZN2pRRXRKWlU3Q1lpdTUKTXVsdy9NeXdvSGNaWTl3eHdFK2FIcDdNdWdaSmVDcXF1Y0JQREQ2bS8rMjJmZDZ0UmNKbEdabEVMVEVaTXMwKwpCUitpcERmWUk2elRTMWZ5QjM1dnpzaFFaNW1nV2Q5SFozK0JZNzdCVWwveENXbHZ2SmIrQ1pjZ2liSkE4c0hrCk5OTnZNUDNNT29xMFl3Sld2amloeE04aVVuS2tLQldKZXZzOEJlOWVjazZNZUpDN0QzUGlHMmFsbzFabm5ZbUMKWitCdDBlUWt0WWVObmxGWFNoQlJndHN5RWp1U3hsMmR0TVF1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:08 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8aaae32-9b33-48f5-bd10-57348c299dc6
+      - fc6d8140-6348-48a4-8ffa-62e57b1067f6
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:55:40.998297Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791},"endpoints":[{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791}],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1245"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:08 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c92260fc-30ca-4166-9a3a-1cae7c5fcb4b
+      - 3b47ce19-e84e-4fac-b2fb-9deba082036d
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: DELETE
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:55:40.998297Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791},"endpoints":[{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791}],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1248"
+      - "1298"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:09 GMT
+      - Thu, 16 Nov 2023 15:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 363b7ff7-0a86-4f7a-830b-7c136c58a2f4
+      - 413e67a0-9113-4065-9378-43c75181e52a
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T19:00:07.360312Z","retention":7},"created_at":"2023-11-02T18:57:36.054032Z","endpoint":{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794},"endpoints":[{"id":"e5f7b552-c095-43d1-b2af-d1812858f556","ip":"51.158.130.202","load_balancer":{},"name":null,"port":5794}],"engine":"PostgreSQL-15","id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:55:40.998297Z","retention":7},"created_at":"2023-11-16T15:52:09.311517Z","endpoint":{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791},"endpoints":[{"id":"2dd670f5-8e5a-470f-aa29-f42f7f396dfd","ip":"51.158.210.239","load_balancer":{},"name":null,"port":26791}],"engine":"PostgreSQL-15","id":"4d413f98-282f-454a-b059-501e97f4e0fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1248"
+      - "1298"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:09 GMT
+      - Thu, 16 Nov 2023 15:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64b8225a-6160-4170-a7ee-49b9b2ee2ac3
+      - 62fb5b04-4677-48ad-85dc-819e9f3b63ae
     status: 200 OK
     code: 200
     duration: ""
@@ -871,10 +937,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"4d413f98-282f-454a-b059-501e97f4e0fe","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -883,7 +949,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:39 GMT
+      - Thu, 16 Nov 2023 15:56:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09e0e002-74b2-4c78-9c36-4e150b7f5cb8
+      - 3b99cee6-1230-4036-881d-ea596429d2f4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -904,10 +970,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a6dc2289-9984-40e9-9c6e-3618c480a5dc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4d413f98-282f-454a-b059-501e97f4e0fe
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"a6dc2289-9984-40e9-9c6e-3618c480a5dc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"4d413f98-282f-454a-b059-501e97f4e0fe","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -916,7 +982,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:39 GMT
+      - Thu, 16 Nov 2023 15:56:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5838b4ff-4d67-470f-ab1b-9850e2dcf12b
+      - ac74b5c2-9203-4119-af71-5e986ac429e9
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:33 GMT
+      - Thu, 16 Nov 2023 15:52:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90448ced-6320-4f63-8a81-43c20e992f2e
+      - b6d746dc-b2fa-4e28-b2a4-c577bd079c85
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:12 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 760f742d-c8b9-4afc-b3ec-03635af74e7d
+      - d00487b9-c33e-43dd-8ad7-000e66923d9a
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:12 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b421bae0-1cf1-4300-a62c-dbe1c97ff030
+      - 4ddbfcd0-7e5e-4080-adff-554b8ee89b6a
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:42 GMT
+      - Thu, 16 Nov 2023 15:56:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75551769-3c14-4456-8260-a7290875aa17
+      - c0ccf0ef-7c82-4a20-be47-3d316f22b3cc
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:12 GMT
+      - Thu, 16 Nov 2023 15:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e78e4441-4b77-4d6b-880a-df7b8dbf3243
+      - 6bb06756-86ef-48d3-8cd2-eea552d94ed7
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:42 GMT
+      - Thu, 16 Nov 2023 15:57:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fe5b4e8-08ef-494c-8fc3-5a49f3a32b4c
+      - 5a6e69cc-6eb6-478b-8afe-eb0f85ce3ee5
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:13 GMT
+      - Thu, 16 Nov 2023 15:58:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2890c9d6-9015-4a67-8f55-df69ae721af0
+      - 840f30b2-1dab-4c9d-93b9-96a631b66236
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:43 GMT
+      - Thu, 16 Nov 2023 15:58:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d76f2e38-8940-4d93-aa26-d2796dac7249
+      - b724c4c5-276e-4ebe-9749-597f3aaee377
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:13 GMT
+      - Thu, 16 Nov 2023 15:59:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36c154c7-f0bd-4935-a498-a8c34bab7239
+      - 26623b8d-2341-4b5c-b1c3-b3749426b1d6
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFRoS0RPWEZGU29uMG5vdWxySVREa3l1VmUwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU1EVXhXaGNOTXpNeE1ETXdNVGcxTURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUp2amtlY3hLUmxEMGExQXExV3hqdCtRZWVrWVRjNGpBT3h3OUdobysxVW5DTkNtd0lEWkhvVEIKQUpLWi9xRzg1U0ZPNnFiT0hsSjBaY1NQcndLNU1lMWdWaThWRzJmNGxuSmVkNUlmSUltcHN2VmpsV0orcHNSVQo2dXVmYmlRa2ZqSy9NOFpMV2xIK0VuSGNOU2Yvalk5blJGTFhHSW9MeThHNmlUMkcwRWNTQ0RpK3BZNUdlQTBmCjNmZ3Flb3dLU3NQVWdjVWdIVlY0MmNwZCthWDh6WC9La2ZNZGdtOVk4SHVkOThvb3FsV2N5UzR6UVloRlNCZ2oKdlp1bmdOZE85WUQ1Zm1tOEV3RDg3Q0FBV2lXbnFQYUxxU3NkRFdBd3FhTWcwR1JKbG9RU1k2UjNDSHhNMFRCMgpYckIyLzRqOGxJc3ZZQkdNTjQyNVVWejRGS25mKy9FQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0TkdVMVltUXhORGt0Tmpjd01TMDBNakF3TFRrd05EWXROREZrTm1SbE5HUTQKTVRFekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtSbWh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQms3dHl3bzk1SDZpWnp4M0hDaUVwSjhLelRsTUZ5c2xXU0k2TGFnVVh3ZURVbnAxZGcwekRiCllIK3NqRnI3MzBiL055eUFTaGJuRjZIT2JKcllPdjNNZkRNK1ZPb0FNM0tOUU1jRDdFR3BVZk0yd3JmakJkQ2EKY1gyVmFOdG5VMG00b3l4Mm9XSmxHcURSWlZ1UGV2UzNXbkNmZGNlbXpQaEdCdDJTTmpXMTJOUEFyR0t3ZWxsMAo3K0tqSTRoSjJ1WitiOHo5V1NlZEFJZVYvbVNxL2ZHUktvNGlmV0p3bWZFd0phVTJMWWMrMjY2TEVRVTd4aFVTClB4NklsRWl0bEtEaG0vZURsTXVveU5lUzVkS1VFck8vd2FkVk5NMGp4OWtQbS8vTDd1d0tLT0VQZHIwTVZFN2EKTWVYdktsWGgxTFVLSU92NUZjanNraVBvSWc0d1ZSVEkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1058"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:13 GMT
+      - Thu, 16 Nov 2023 15:59:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d26b65ab-0218-4ecb-958c-a9f7c8f4773e
+      - 299ef5fd-ddb3-49b3-8141-6d47fc4bda65
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1277"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:13 GMT
+      - Thu, 16 Nov 2023 16:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c532895a-bbcf-4ec1-93f4-3ba61e72c0d4
+      - 4b9ae92f-3d5e-4c4f-8f22-b56e7acf8132
     status: 200 OK
     code: 200
     duration: ""
@@ -671,19 +671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVVWF3L1huNnFndGdYWGYxK1pXK2lCcHErclc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBNVm9YRFRNek1URXhNekUxTlRrME1Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXhaOGxKSzNtTldCaHlUdW5wYXZUci91TTNnWUJNaUYzNWhYZnhBRzZiTU9QSUNjV295YlkKQWNNdzlkQ3EzTnA2N1FiYUVBeTdpUjNiUjhzRzlkayticG1GN2N0Y1MrQlVDeG9zQkR0U004TTJ1dlQ4ZzVkRAoxdGYxb2wySFNWL3dadWlqVlpRVTZUdzhEcHlKRnVvTzlWK1pUUUtSK1IzMmhCMUwya2xzNWxMK3J1em13aDYxClZYeUZxOUw5c3ZESFVXaGxkdno2Q3grMmNVZGVwQzdMYm1hWFpEVG1Bbms3b29kWGJtSzN2ZzhocnZsV21pWmsKNlpPZ0tOUWZndUlBRkVrTzI4eVRjUzB2WDBCMGFsVzR6M3A4YjFMUE1VNXdYa3BYc2M5ZENwZTN4blJST3ZndQpveFFidHVmRUYxV3NnanFjclhiZVNqY3hzWTIzTCtlV1R3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1UVTNPR1JrWlRrdE1EZzVaUzAwWkdZeUxXRmpaalF0WWpJMk0yRTQKTjJabU1tRXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJVMlFKM2NsSDJHYVc2aHR5WEp0dENTeC9HOEhmRnNzMXUrREVmU1V0UjBEaURlRnJSCmdxMVBIK2l1c1FPYklLQ0lpNjlneHp3RjZJT0VVc3YyK3ArQ0dxNml6WFFOcS90MWIwdU9IYnhaeGdiWGpBWVIKYzltbDl3N21oOU0vUkZRTDE0WXVXd3p1OXM0SU91T2RoVzFtSUdVV05HSHpIOFV4OVZzMlJ5RUtycmJLdldsNwpRc05iclRiOTBMK0NFeEw1WUgyQXQwUy9IRG9zOEk5aHlHcTVzZkpKdmVTemU4T2xKQmJvQUY5NEdUaEQwc2V0CnNvV3VrYVdxVE80dks4NmNkeTB1eVlmMFVBYXQ4aHRCZXJTcmhiOW42SytqWWJEdURnSWpFc3U0ampzK3g3LzMKNklaRXN6RUlnM2JwTHlIM0JBL1NTbSt2bXJXZ2s0WkYxTndICi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1227"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:13 GMT
+      - Thu, 16 Nov 2023 16:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -693,7 +693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfb041ab-97dd-4058-8f46-63cb3fd626be
+      - bf8fc660-a9be-4b51-8267-671e6dacd6fc
     status: 200 OK
     code: 200
     duration: ""
@@ -704,19 +704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFRoS0RPWEZGU29uMG5vdWxySVREa3l1VmUwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU1EVXhXaGNOTXpNeE1ETXdNVGcxTURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUp2amtlY3hLUmxEMGExQXExV3hqdCtRZWVrWVRjNGpBT3h3OUdobysxVW5DTkNtd0lEWkhvVEIKQUpLWi9xRzg1U0ZPNnFiT0hsSjBaY1NQcndLNU1lMWdWaThWRzJmNGxuSmVkNUlmSUltcHN2VmpsV0orcHNSVQo2dXVmYmlRa2ZqSy9NOFpMV2xIK0VuSGNOU2Yvalk5blJGTFhHSW9MeThHNmlUMkcwRWNTQ0RpK3BZNUdlQTBmCjNmZ3Flb3dLU3NQVWdjVWdIVlY0MmNwZCthWDh6WC9La2ZNZGdtOVk4SHVkOThvb3FsV2N5UzR6UVloRlNCZ2oKdlp1bmdOZE85WUQ1Zm1tOEV3RDg3Q0FBV2lXbnFQYUxxU3NkRFdBd3FhTWcwR1JKbG9RU1k2UjNDSHhNMFRCMgpYckIyLzRqOGxJc3ZZQkdNTjQyNVVWejRGS25mKy9FQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0TkdVMVltUXhORGt0Tmpjd01TMDBNakF3TFRrd05EWXROREZrTm1SbE5HUTQKTVRFekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtSbWh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQms3dHl3bzk1SDZpWnp4M0hDaUVwSjhLelRsTUZ5c2xXU0k2TGFnVVh3ZURVbnAxZGcwekRiCllIK3NqRnI3MzBiL055eUFTaGJuRjZIT2JKcllPdjNNZkRNK1ZPb0FNM0tOUU1jRDdFR3BVZk0yd3JmakJkQ2EKY1gyVmFOdG5VMG00b3l4Mm9XSmxHcURSWlZ1UGV2UzNXbkNmZGNlbXpQaEdCdDJTTmpXMTJOUEFyR0t3ZWxsMAo3K0tqSTRoSjJ1WitiOHo5V1NlZEFJZVYvbVNxL2ZHUktvNGlmV0p3bWZFd0phVTJMWWMrMjY2TEVRVTd4aFVTClB4NklsRWl0bEtEaG0vZURsTXVveU5lUzVkS1VFck8vd2FkVk5NMGp4OWtQbS8vTDd1d0tLT0VQZHIwTVZFN2EKTWVYdktsWGgxTFVLSU92NUZjanNraVBvSWc0d1ZSVEkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1277"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:13 GMT
+      - Thu, 16 Nov 2023 16:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -726,7 +726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34dece40-d437-4c64-a190-05450fdaa5e2
+      - 18f1f096-e5fa-4d66-87dc-768a617e891f
     status: 200 OK
     code: 200
     duration: ""
@@ -737,19 +737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1277"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:14 GMT
+      - Thu, 16 Nov 2023 16:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -759,7 +759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4680f601-9fce-46c2-9f83-96ac2e1af8df
+      - cbd65601-36a5-4ea8-84a1-0e03fca2c0a7
     status: 200 OK
     code: 200
     duration: ""
@@ -770,19 +770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFRoS0RPWEZGU29uMG5vdWxySVREa3l1VmUwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU1EVXhXaGNOTXpNeE1ETXdNVGcxTURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUp2amtlY3hLUmxEMGExQXExV3hqdCtRZWVrWVRjNGpBT3h3OUdobysxVW5DTkNtd0lEWkhvVEIKQUpLWi9xRzg1U0ZPNnFiT0hsSjBaY1NQcndLNU1lMWdWaThWRzJmNGxuSmVkNUlmSUltcHN2VmpsV0orcHNSVQo2dXVmYmlRa2ZqSy9NOFpMV2xIK0VuSGNOU2Yvalk5blJGTFhHSW9MeThHNmlUMkcwRWNTQ0RpK3BZNUdlQTBmCjNmZ3Flb3dLU3NQVWdjVWdIVlY0MmNwZCthWDh6WC9La2ZNZGdtOVk4SHVkOThvb3FsV2N5UzR6UVloRlNCZ2oKdlp1bmdOZE85WUQ1Zm1tOEV3RDg3Q0FBV2lXbnFQYUxxU3NkRFdBd3FhTWcwR1JKbG9RU1k2UjNDSHhNMFRCMgpYckIyLzRqOGxJc3ZZQkdNTjQyNVVWejRGS25mKy9FQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0TkdVMVltUXhORGt0Tmpjd01TMDBNakF3TFRrd05EWXROREZrTm1SbE5HUTQKTVRFekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtSbWh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQms3dHl3bzk1SDZpWnp4M0hDaUVwSjhLelRsTUZ5c2xXU0k2TGFnVVh3ZURVbnAxZGcwekRiCllIK3NqRnI3MzBiL055eUFTaGJuRjZIT2JKcllPdjNNZkRNK1ZPb0FNM0tOUU1jRDdFR3BVZk0yd3JmakJkQ2EKY1gyVmFOdG5VMG00b3l4Mm9XSmxHcURSWlZ1UGV2UzNXbkNmZGNlbXpQaEdCdDJTTmpXMTJOUEFyR0t3ZWxsMAo3K0tqSTRoSjJ1WitiOHo5V1NlZEFJZVYvbVNxL2ZHUktvNGlmV0p3bWZFd0phVTJMWWMrMjY2TEVRVTd4aFVTClB4NklsRWl0bEtEaG0vZURsTXVveU5lUzVkS1VFck8vd2FkVk5NMGp4OWtQbS8vTDd1d0tLT0VQZHIwTVZFN2EKTWVYdktsWGgxTFVLSU92NUZjanNraVBvSWc0d1ZSVEkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVVWF3L1huNnFndGdYWGYxK1pXK2lCcHErclc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBNVm9YRFRNek1URXhNekUxTlRrME1Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXhaOGxKSzNtTldCaHlUdW5wYXZUci91TTNnWUJNaUYzNWhYZnhBRzZiTU9QSUNjV295YlkKQWNNdzlkQ3EzTnA2N1FiYUVBeTdpUjNiUjhzRzlkayticG1GN2N0Y1MrQlVDeG9zQkR0U004TTJ1dlQ4ZzVkRAoxdGYxb2wySFNWL3dadWlqVlpRVTZUdzhEcHlKRnVvTzlWK1pUUUtSK1IzMmhCMUwya2xzNWxMK3J1em13aDYxClZYeUZxOUw5c3ZESFVXaGxkdno2Q3grMmNVZGVwQzdMYm1hWFpEVG1Bbms3b29kWGJtSzN2ZzhocnZsV21pWmsKNlpPZ0tOUWZndUlBRkVrTzI4eVRjUzB2WDBCMGFsVzR6M3A4YjFMUE1VNXdYa3BYc2M5ZENwZTN4blJST3ZndQpveFFidHVmRUYxV3NnanFjclhiZVNqY3hzWTIzTCtlV1R3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1UVTNPR1JrWlRrdE1EZzVaUzAwWkdZeUxXRmpaalF0WWpJMk0yRTQKTjJabU1tRXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJVMlFKM2NsSDJHYVc2aHR5WEp0dENTeC9HOEhmRnNzMXUrREVmU1V0UjBEaURlRnJSCmdxMVBIK2l1c1FPYklLQ0lpNjlneHp3RjZJT0VVc3YyK3ArQ0dxNml6WFFOcS90MWIwdU9IYnhaeGdiWGpBWVIKYzltbDl3N21oOU0vUkZRTDE0WXVXd3p1OXM0SU91T2RoVzFtSUdVV05HSHpIOFV4OVZzMlJ5RUtycmJLdldsNwpRc05iclRiOTBMK0NFeEw1WUgyQXQwUy9IRG9zOEk5aHlHcTVzZkpKdmVTemU4T2xKQmJvQUY5NEdUaEQwc2V0CnNvV3VrYVdxVE80dks4NmNkeTB1eVlmMFVBYXQ4aHRCZXJTcmhiOW42SytqWWJEdURnSWpFc3U0ampzK3g3LzMKNklaRXN6RUlnM2JwTHlIM0JBL1NTbSt2bXJXZ2s0WkYxTndICi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:14 GMT
+      - Thu, 16 Nov 2023 16:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -792,7 +792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bf02eae-bd2f-4130-aa20-8e30372ab295
+      - c614cfe2-3f65-47e3-852b-e82e30cf2f8c
     status: 200 OK
     code: 200
     duration: ""
@@ -803,19 +803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1277"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:14 GMT
+      - Thu, 16 Nov 2023 16:00:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -825,7 +825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39595319-c1ea-49e0-a541-c56df53233d7
+      - 473bb3dd-07e6-4919-a33b-0ee82a5c8378
     status: 200 OK
     code: 200
     duration: ""
@@ -836,19 +836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVVWF3L1huNnFndGdYWGYxK1pXK2lCcHErclc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBNVm9YRFRNek1URXhNekUxTlRrME1Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXhaOGxKSzNtTldCaHlUdW5wYXZUci91TTNnWUJNaUYzNWhYZnhBRzZiTU9QSUNjV295YlkKQWNNdzlkQ3EzTnA2N1FiYUVBeTdpUjNiUjhzRzlkayticG1GN2N0Y1MrQlVDeG9zQkR0U004TTJ1dlQ4ZzVkRAoxdGYxb2wySFNWL3dadWlqVlpRVTZUdzhEcHlKRnVvTzlWK1pUUUtSK1IzMmhCMUwya2xzNWxMK3J1em13aDYxClZYeUZxOUw5c3ZESFVXaGxkdno2Q3grMmNVZGVwQzdMYm1hWFpEVG1Bbms3b29kWGJtSzN2ZzhocnZsV21pWmsKNlpPZ0tOUWZndUlBRkVrTzI4eVRjUzB2WDBCMGFsVzR6M3A4YjFMUE1VNXdYa3BYc2M5ZENwZTN4blJST3ZndQpveFFidHVmRUYxV3NnanFjclhiZVNqY3hzWTIzTCtlV1R3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1UVTNPR1JrWlRrdE1EZzVaUzAwWkdZeUxXRmpaalF0WWpJMk0yRTQKTjJabU1tRXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJVMlFKM2NsSDJHYVc2aHR5WEp0dENTeC9HOEhmRnNzMXUrREVmU1V0UjBEaURlRnJSCmdxMVBIK2l1c1FPYklLQ0lpNjlneHp3RjZJT0VVc3YyK3ArQ0dxNml6WFFOcS90MWIwdU9IYnhaeGdiWGpBWVIKYzltbDl3N21oOU0vUkZRTDE0WXVXd3p1OXM0SU91T2RoVzFtSUdVV05HSHpIOFV4OVZzMlJ5RUtycmJLdldsNwpRc05iclRiOTBMK0NFeEw1WUgyQXQwUy9IRG9zOEk5aHlHcTVzZkpKdmVTemU4T2xKQmJvQUY5NEdUaEQwc2V0CnNvV3VrYVdxVE80dks4NmNkeTB1eVlmMFVBYXQ4aHRCZXJTcmhiOW42SytqWWJEdURnSWpFc3U0ampzK3g3LzMKNklaRXN6RUlnM2JwTHlIM0JBL1NTbSt2bXJXZ2s0WkYxTndICi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1227"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
+      - Thu, 16 Nov 2023 16:00:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -858,7 +858,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42539b7b-acac-4b0b-b9bc-c25128a5f793
+      - e242bef7-faa6-418f-9fcf-65370987b320
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1277"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1632275a-33ab-4e28-98da-02a47d391ed0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1277"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dd24eb6d-28e7-450e-8ba9-d42b4c08c51d
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1199"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2efaa875-4cf4-41d4-bf58-0576b363f918
+      - aced92d2-55ab-4607-8a34-2376a61b0e86
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1199"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afe7ee28-90b8-4e80-ae2d-6ca2e5a68f8f
+      - b8c21ccc-0cbc-4966-a637-89c4e5f30387
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFRoS0RPWEZGU29uMG5vdWxySVREa3l1VmUwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU1EVXhXaGNOTXpNeE1ETXdNVGcxTURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUp2amtlY3hLUmxEMGExQXExV3hqdCtRZWVrWVRjNGpBT3h3OUdobysxVW5DTkNtd0lEWkhvVEIKQUpLWi9xRzg1U0ZPNnFiT0hsSjBaY1NQcndLNU1lMWdWaThWRzJmNGxuSmVkNUlmSUltcHN2VmpsV0orcHNSVQo2dXVmYmlRa2ZqSy9NOFpMV2xIK0VuSGNOU2Yvalk5blJGTFhHSW9MeThHNmlUMkcwRWNTQ0RpK3BZNUdlQTBmCjNmZ3Flb3dLU3NQVWdjVWdIVlY0MmNwZCthWDh6WC9La2ZNZGdtOVk4SHVkOThvb3FsV2N5UzR6UVloRlNCZ2oKdlp1bmdOZE85WUQ1Zm1tOEV3RDg3Q0FBV2lXbnFQYUxxU3NkRFdBd3FhTWcwR1JKbG9RU1k2UjNDSHhNMFRCMgpYckIyLzRqOGxJc3ZZQkdNTjQyNVVWejRGS25mKy9FQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0TkdVMVltUXhORGt0Tmpjd01TMDBNakF3TFRrd05EWXROREZrTm1SbE5HUTQKTVRFekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtSbWh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQms3dHl3bzk1SDZpWnp4M0hDaUVwSjhLelRsTUZ5c2xXU0k2TGFnVVh3ZURVbnAxZGcwekRiCllIK3NqRnI3MzBiL055eUFTaGJuRjZIT2JKcllPdjNNZkRNK1ZPb0FNM0tOUU1jRDdFR3BVZk0yd3JmakJkQ2EKY1gyVmFOdG5VMG00b3l4Mm9XSmxHcURSWlZ1UGV2UzNXbkNmZGNlbXpQaEdCdDJTTmpXMTJOUEFyR0t3ZWxsMAo3K0tqSTRoSjJ1WitiOHo5V1NlZEFJZVYvbVNxL2ZHUktvNGlmV0p3bWZFd0phVTJMWWMrMjY2TEVRVTd4aFVTClB4NklsRWl0bEtEaG0vZURsTXVveU5lUzVkS1VFck8vd2FkVk5NMGp4OWtQbS8vTDd1d0tLT0VQZHIwTVZFN2EKTWVYdktsWGgxTFVLSU92NUZjanNraVBvSWc0d1ZSVEkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVVWF3L1huNnFndGdYWGYxK1pXK2lCcHErclc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBNVm9YRFRNek1URXhNekUxTlRrME1Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXhaOGxKSzNtTldCaHlUdW5wYXZUci91TTNnWUJNaUYzNWhYZnhBRzZiTU9QSUNjV295YlkKQWNNdzlkQ3EzTnA2N1FiYUVBeTdpUjNiUjhzRzlkayticG1GN2N0Y1MrQlVDeG9zQkR0U004TTJ1dlQ4ZzVkRAoxdGYxb2wySFNWL3dadWlqVlpRVTZUdzhEcHlKRnVvTzlWK1pUUUtSK1IzMmhCMUwya2xzNWxMK3J1em13aDYxClZYeUZxOUw5c3ZESFVXaGxkdno2Q3grMmNVZGVwQzdMYm1hWFpEVG1Bbms3b29kWGJtSzN2ZzhocnZsV21pWmsKNlpPZ0tOUWZndUlBRkVrTzI4eVRjUzB2WDBCMGFsVzR6M3A4YjFMUE1VNXdYa3BYc2M5ZENwZTN4blJST3ZndQpveFFidHVmRUYxV3NnanFjclhiZVNqY3hzWTIzTCtlV1R3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1UVTNPR1JrWlRrdE1EZzVaUzAwWkdZeUxXRmpaalF0WWpJMk0yRTQKTjJabU1tRXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJVMlFKM2NsSDJHYVc2aHR5WEp0dENTeC9HOEhmRnNzMXUrREVmU1V0UjBEaURlRnJSCmdxMVBIK2l1c1FPYklLQ0lpNjlneHp3RjZJT0VVc3YyK3ArQ0dxNml6WFFOcS90MWIwdU9IYnhaeGdiWGpBWVIKYzltbDl3N21oOU0vUkZRTDE0WXVXd3p1OXM0SU91T2RoVzFtSUdVV05HSHpIOFV4OVZzMlJ5RUtycmJLdldsNwpRc05iclRiOTBMK0NFeEw1WUgyQXQwUy9IRG9zOEk5aHlHcTVzZkpKdmVTemU4T2xKQmJvQUY5NEdUaEQwc2V0CnNvV3VrYVdxVE80dks4NmNkeTB1eVlmMFVBYXQ4aHRCZXJTcmhiOW42SytqWWJEdURnSWpFc3U0ampzK3g3LzMKNklaRXN6RUlnM2JwTHlIM0JBL1NTbSt2bXJXZ2s0WkYxTndICi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d17c9ea5-b98e-44e0-a016-6b83dada38c5
+      - 3e31d746-342a-4a06-b21c-fd79fffe5841
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1199"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20956b46-adcd-4cb8-b31b-bec3af1b3fcf
+      - 645ca8b8-c41f-44f8-9642-b51129f3f60e
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1199"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:15 GMT
+      - Thu, 16 Nov 2023 16:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0d12f43-da2b-4287-81de-5cbba83bc75f
+      - 3bd8a09d-fa9f-4329-bdc2-7cf794c4f884
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUFRoS0RPWEZGU29uMG5vdWxySVREa3l1VmUwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eU16QXdIaGNOCk1qTXhNVEF5TVRnMU1EVXhXaGNOTXpNeE1ETXdNVGcxTURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakl6TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUp2amtlY3hLUmxEMGExQXExV3hqdCtRZWVrWVRjNGpBT3h3OUdobysxVW5DTkNtd0lEWkhvVEIKQUpLWi9xRzg1U0ZPNnFiT0hsSjBaY1NQcndLNU1lMWdWaThWRzJmNGxuSmVkNUlmSUltcHN2VmpsV0orcHNSVQo2dXVmYmlRa2ZqSy9NOFpMV2xIK0VuSGNOU2Yvalk5blJGTFhHSW9MeThHNmlUMkcwRWNTQ0RpK3BZNUdlQTBmCjNmZ3Flb3dLU3NQVWdjVWdIVlY0MmNwZCthWDh6WC9La2ZNZGdtOVk4SHVkOThvb3FsV2N5UzR6UVloRlNCZ2oKdlp1bmdOZE85WUQ1Zm1tOEV3RDg3Q0FBV2lXbnFQYUxxU3NkRFdBd3FhTWcwR1JKbG9RU1k2UjNDSHhNMFRCMgpYckIyLzRqOGxJc3ZZQkdNTjQyNVVWejRGS25mKy9FQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTRMalUyTGpJek1JSThjbmN0TkdVMVltUXhORGt0Tmpjd01TMDBNakF3TFRrd05EWXROREZrTm1SbE5HUTQKTVRFekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtSbWh3UXpuamptTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQms3dHl3bzk1SDZpWnp4M0hDaUVwSjhLelRsTUZ5c2xXU0k2TGFnVVh3ZURVbnAxZGcwekRiCllIK3NqRnI3MzBiL055eUFTaGJuRjZIT2JKcllPdjNNZkRNK1ZPb0FNM0tOUU1jRDdFR3BVZk0yd3JmakJkQ2EKY1gyVmFOdG5VMG00b3l4Mm9XSmxHcURSWlZ1UGV2UzNXbkNmZGNlbXpQaEdCdDJTTmpXMTJOUEFyR0t3ZWxsMAo3K0tqSTRoSjJ1WitiOHo5V1NlZEFJZVYvbVNxL2ZHUktvNGlmV0p3bWZFd0phVTJMWWMrMjY2TEVRVTd4aFVTClB4NklsRWl0bEtEaG0vZURsTXVveU5lUzVkS1VFck8vd2FkVk5NMGp4OWtQbS8vTDd1d0tLT0VQZHIwTVZFN2EKTWVYdktsWGgxTFVLSU92NUZjanNraVBvSWc0d1ZSVEkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVVWF3L1huNnFndGdYWGYxK1pXK2lCcHErclc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UazBNVm9YRFRNek1URXhNekUxTlRrME1Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXhaOGxKSzNtTldCaHlUdW5wYXZUci91TTNnWUJNaUYzNWhYZnhBRzZiTU9QSUNjV295YlkKQWNNdzlkQ3EzTnA2N1FiYUVBeTdpUjNiUjhzRzlkayticG1GN2N0Y1MrQlVDeG9zQkR0U004TTJ1dlQ4ZzVkRAoxdGYxb2wySFNWL3dadWlqVlpRVTZUdzhEcHlKRnVvTzlWK1pUUUtSK1IzMmhCMUwya2xzNWxMK3J1em13aDYxClZYeUZxOUw5c3ZESFVXaGxkdno2Q3grMmNVZGVwQzdMYm1hWFpEVG1Bbms3b29kWGJtSzN2ZzhocnZsV21pWmsKNlpPZ0tOUWZndUlBRkVrTzI4eVRjUzB2WDBCMGFsVzR6M3A4YjFMUE1VNXdYa3BYc2M5ZENwZTN4blJST3ZndQpveFFidHVmRUYxV3NnanFjclhiZVNqY3hzWTIzTCtlV1R3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1UVTNPR1JrWlRrdE1EZzVaUzAwWkdZeUxXRmpaalF0WWpJMk0yRTQKTjJabU1tRXlMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrYTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJVMlFKM2NsSDJHYVc2aHR5WEp0dENTeC9HOEhmRnNzMXUrREVmU1V0UjBEaURlRnJSCmdxMVBIK2l1c1FPYklLQ0lpNjlneHp3RjZJT0VVc3YyK3ArQ0dxNml6WFFOcS90MWIwdU9IYnhaeGdiWGpBWVIKYzltbDl3N21oOU0vUkZRTDE0WXVXd3p1OXM0SU91T2RoVzFtSUdVV05HSHpIOFV4OVZzMlJ5RUtycmJLdldsNwpRc05iclRiOTBMK0NFeEw1WUgyQXQwUy9IRG9zOEk5aHlHcTVzZkpKdmVTemU4T2xKQmJvQUY5NEdUaEQwc2V0CnNvV3VrYVdxVE80dks4NmNkeTB1eVlmMFVBYXQ4aHRCZXJTcmhiOW42SytqWWJEdURnSWpFc3U0ampzK3g3LzMKNklaRXN6RUlnM2JwTHlIM0JBL1NTbSt2bXJXZ2s0WkYxTndICi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:00:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a05d6b6-8c0b-4fbc-ba70-8b8aa55de961
+      - 19dc2d1d-7105-4332-897a-1a97a37c08c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1199"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:00:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa38ecb9-a4d0-429f-8ef1-e1b1cfa0dcf6
+      - d6b5e042-48d1-4377-87f4-6e2d66f2c0da
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:00:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f48e4b4b-c633-469b-aa5b-fb5d00757959
+      - 6c167641-1143-4605-9d60-5ecb622d4387
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:50:12.043699Z","endpoint":{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390},"endpoints":[{"id":"26ced9c5-bdeb-440b-9bf3-4f2cd078beba","ip":"51.158.56.230","load_balancer":{},"name":null,"port":27390}],"engine":"PostgreSQL-15","id":"4e5bd149-6701-4200-9046-41d6de4d8113","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.276871Z","endpoint":{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066},"endpoints":[{"id":"fa93b047-4485-4c5c-b4fb-43816147c40d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":17066}],"engine":"PostgreSQL-15","id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1202"
+      - "1250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:16 GMT
+      - Thu, 16 Nov 2023 16:00:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fca5fec-8e32-4271-8ee0-eb9f4bd14122
+      - ab5d3695-c97c-49e8-ae09-8650254446d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,10 +1234,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"4e5bd149-6701-4200-9046-41d6de4d8113","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1180,7 +1246,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:47 GMT
+      - Thu, 16 Nov 2023 16:00:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2f50ec8-5364-4027-9d78-e93d885b5a55
+      - 65b605cb-00e7-429d-b8d3-114e412ee4bf
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1201,10 +1267,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4e5bd149-6701-4200-9046-41d6de4d8113
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1578dde9-089e-4df2-acf4-b263a87ff2a2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"4e5bd149-6701-4200-9046-41d6de4d8113","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1578dde9-089e-4df2-acf4-b263a87ff2a2","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1213,7 +1279,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:51 GMT
+      - Thu, 16 Nov 2023 16:00:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f038daf4-9af1-49ce-acb6-44f55d739548
+      - 9815391e-e217-4874-8b92-89ca4c17d311
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-capitalize.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-capitalize.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:34 GMT
+      - Thu, 16 Nov 2023 15:52:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17876c81-3e62-4858-8ff1-0d83cd3c13e4
+      - 75fa8847-cfbb-478e-bf36-b9c2f5af4bde
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"DB-DEV-S","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"DB-DEV-S","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bbddad3-774d-4637-b96d-54fa8640b270
+      - 4a7ce676-3204-43ec-a008-a124d8ec4d60
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c41fc23-6e8f-4b7f-bdd5-dc32c3ecc68c
+      - e06d943a-2f93-4ee8-9627-cf8848135ed0
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:08 GMT
+      - Thu, 16 Nov 2023 15:52:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d9e9676-928d-4705-8b51-5719841fc82d
+      - 733769be-a6a8-4e70-923d-f1fa4fe2f982
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:38 GMT
+      - Thu, 16 Nov 2023 15:53:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6cec3901-d7ff-47aa-9cf2-c47bce034483
+      - 7c8ced28-cffd-4b0d-92e5-5cde90e05414
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:08 GMT
+      - Thu, 16 Nov 2023 15:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d36ebbc3-f8b1-47d0-b5ae-1210f0ba9700
+      - 99aa3075-bcd8-4a8a-b09b-2fa0f544fd2f
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:38 GMT
+      - Thu, 16 Nov 2023 15:54:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c8f7e6c-f63e-4ff3-b244-8f4770a8b093
+      - 70c900b1-3ac8-4b99-9c5d-7c15f9120985
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:09 GMT
+      - Thu, 16 Nov 2023 15:54:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2aeee37-c0bf-48d4-aceb-8d68c3795b72
+      - 7496cb56-1e03-41b9-b025-4fd6ca71a973
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681},"endpoints":[{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681}],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1171"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53d10831-9710-4fde-a66c-f332917a6d00
+      - b105be17-5f07-4ea0-abb8-c0781797e863
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRzB2M3RWL25JVEVsNEZVa25jdnBGaW5wdjZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56STRXaGNOTXpNeE1ETXdNVGcwTnpJNFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxmT3l3RkNDODUwOG5sMDZmWlh0YnNGN3NJVzJ6eFlFeFZwOEF4TXIxMklxalNxaU1sMmhnSU0KSUltR1ZhWlQ0ZEZmMENvaFNPMGZMNmR0Snd0Zk9XV0VRVzRzdHpCZGFpVm1vdk5NaWVaV2RFeUxZNkpUcGtXYgphbld0RUF0U1dHTUc5VllNQy9GbW9NclVaenZIVWVyeEVNNEh2R0o4eVlSMmNFbzJUc2VpcGptblhjdUpxQkpNCkQ0T0FDbnVIWGNwWC9iM21ac2hwTTRpanpxNlJyclhuTk5od1h0d0ZRTFpFOHl1U0hZdk94ci9QSm1SaGhGTWQKYk1WVThFaUMwakNSOG9pSG5XRGs1bysvdHkyRDZFd0lUTTR1N2ZCUlQyaFRBdkRsMmRTTGphRkJ4VXd1SUJCTwpvd1NVNU1haHUyOE9uMTNINmFCRjJmdnd1Z2tqWkI4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TVRZd1pXUTFOekl0WkRkbU55MDBOalUxTFdFeU5qQXRZamc1TnpBeE5XVmgKTURjeExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQWkxc2pTS3pKOWNSRnFVUEU5QnBtN2JnK0NFUnVIaUpnMXdRSE1uWHRVSVptL0JrYm9xSWZ5CmxyaEdDb1phK2FQYktYWWN0VTdJK1U3Zkx4NzMveHJVcmZSR0dIcVpEYy9PNHNCTFlwSHFmTFNQRmZHNXdRMFEKZXY0eFNpc0c0UzBweEpQY3hiSXBpTVl1WTV3MThzamJXUTg4STJjbmdzR1pIU3ZNOW01ZEVKeUo0OWc5Mmp5ZwpPMSt4dm9NTEI4NnYrcGszbmEza3dMRFpaSm5NLzVBT1Y5UmdLOFRROENaNVhTb2RXL2t3alZ0dTJSWUZyRmowCmFFYS9WeWtkVGhLQXFkWUNiVWovQmRNRmpRZTJQWFpPYmZ6NWl0YXZ5R04vU1VNQmxYM1ZDeGUzbHZ1bFhsdmQKc3AyTk1WMEVTUzU5OU5OeXhlNnZQM3VPN2VtaUNYYXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":{"id":"7e8681f8-82a0-4177-a402-08b18a94d08a","ip":"51.159.74.238","load_balancer":{},"name":null,"port":26430},"endpoints":[{"id":"7e8681f8-82a0-4177-a402-08b18a94d08a","ip":"51.159.74.238","load_balancer":{},"name":null,"port":26430}],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1217"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35554a88-e0f1-4e1b-bdc9-dde45bb1e211
+      - 4ff31b1f-2f2c-43c0-ba93-6a6438ef600f
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681},"endpoints":[{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681}],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVVWFKcUZvNHVPd280SVdaZVNyMmVMZ2VzMUpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNVEUyTVRVMU5EVTVXaGNOTXpNeE1URXpNVFUxTkRVNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9oWktldTJtOVZRdTlQZWFDUnJkVTNaSG5hSHRTcm0zYkJWNXZtU29VSHUrRGNTQllRbStMN1oKRXFnU0ZxNUljMWR6K2tzUFQzR2hkb1I4eDNEMnB5TWM3dG9kdk5pbTJYbXNkNEF4U0dMOVplbmRrRkxobGJCeApVS3hYUVdnQi9kdEw1UEUvT3FFTTlORTdIRTRPdGVsYktCM2E2dFJmYmFXMGpIYnl1TGtJT2hyT3l5Z2l5S1RKCkRaaTBRTWRhaC9DTHc5alEzSThZTFgvVE9SdUNYOWxjeTdzQU5IVHAwRWJsZjlKZ2xacnVTWHRuWHJiSWpvNTYKWUcraVphRFM4d0lleXBxK1VuOS9GVmNnWElUUHB2aExXSTI5R2ZUMEhMVDZjQkdRcUF2K0I4bTFUN3NvSHdySQozRTcvQklxNVI3a1c0dCtVNTJuS1Rna01MOStwbFowQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMamMwTGpJek9JSThjbmN0WWpCak5HSTRNV1l0TURFM09DMDBOR1EyTFdFMU9EY3RaV00wTmpGa05USTEKTkdZekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCs5eWh3UXpuMHJ1TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1hzREM5RmZyamxBK09EblhKTEpYa2I3aXRhWmY2emxjYlEvMWp3cjRQWUxOVnNWU3ppUmNwCnc1THpYZGh3UXpFMkFoazNmSWk5NDhXNENHKzFlMHNwMlh0ODI3cWJuM0hBOXVCZ2NPZEl2bGw5aXhXMWl0THIKMW9EUkpzUkFPdlY5OXBKeDJCRnF0c0tlVVZtZXpjYnZYQmxnM3AzQk9NeXBtbmJRRUd5ZTMyZTF6b1dMSUczUgpDQkVEZUd0QmVBc1BlZkJvTXpnMUJJK0g5MThxbFIvN1BWOHZyNGNhZS9RamhrV2dIOTF3VzFOdDAySUpRa2ZiCnNRNXFkQXNGbGUvNE9nak91Mkw3M2pPWW5NWk5SRXpheWlYWUNBTit1RXB4ckRKUUtla0Y0TVZIUmdHb1ZOM1gKUXhhOGtGNERVanFWd2MxTnJieDJISy8zVDFxakJBRWsKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1171"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed7a308a-4371-4893-b728-264622fa9009
+      - 9fbbaff9-1e25-4844-b97d-4a71783853fe
     status: 200 OK
     code: 200
     duration: ""
@@ -671,19 +671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681},"endpoints":[{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681}],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":{"id":"7e8681f8-82a0-4177-a402-08b18a94d08a","ip":"51.159.74.238","load_balancer":{},"name":null,"port":26430},"endpoints":[{"id":"7e8681f8-82a0-4177-a402-08b18a94d08a","ip":"51.159.74.238","load_balancer":{},"name":null,"port":26430}],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1171"
+      - "1217"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -693,7 +693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7be87144-4d82-4a50-b03e-869e82c87db3
+      - 58fbac5d-1d10-4ffe-829e-bddc0c371e13
     status: 200 OK
     code: 200
     duration: ""
@@ -704,19 +704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVRzB2M3RWL25JVEVsNEZVa25jdnBGaW5wdjZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56STRXaGNOTXpNeE1ETXdNVGcwTnpJNFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxmT3l3RkNDODUwOG5sMDZmWlh0YnNGN3NJVzJ6eFlFeFZwOEF4TXIxMklxalNxaU1sMmhnSU0KSUltR1ZhWlQ0ZEZmMENvaFNPMGZMNmR0Snd0Zk9XV0VRVzRzdHpCZGFpVm1vdk5NaWVaV2RFeUxZNkpUcGtXYgphbld0RUF0U1dHTUc5VllNQy9GbW9NclVaenZIVWVyeEVNNEh2R0o4eVlSMmNFbzJUc2VpcGptblhjdUpxQkpNCkQ0T0FDbnVIWGNwWC9iM21ac2hwTTRpanpxNlJyclhuTk5od1h0d0ZRTFpFOHl1U0hZdk94ci9QSm1SaGhGTWQKYk1WVThFaUMwakNSOG9pSG5XRGs1bysvdHkyRDZFd0lUTTR1N2ZCUlQyaFRBdkRsMmRTTGphRkJ4VXd1SUJCTwpvd1NVNU1haHUyOE9uMTNINmFCRjJmdnd1Z2tqWkI4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0TVRZd1pXUTFOekl0WkRkbU55MDBOalUxTFdFeU5qQXRZamc1TnpBeE5XVmgKTURjeExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQWkxc2pTS3pKOWNSRnFVUEU5QnBtN2JnK0NFUnVIaUpnMXdRSE1uWHRVSVptL0JrYm9xSWZ5CmxyaEdDb1phK2FQYktYWWN0VTdJK1U3Zkx4NzMveHJVcmZSR0dIcVpEYy9PNHNCTFlwSHFmTFNQRmZHNXdRMFEKZXY0eFNpc0c0UzBweEpQY3hiSXBpTVl1WTV3MThzamJXUTg4STJjbmdzR1pIU3ZNOW01ZEVKeUo0OWc5Mmp5ZwpPMSt4dm9NTEI4NnYrcGszbmEza3dMRFpaSm5NLzVBT1Y5UmdLOFRROENaNVhTb2RXL2t3alZ0dTJSWUZyRmowCmFFYS9WeWtkVGhLQXFkWUNiVWovQmRNRmpRZTJQWFpPYmZ6NWl0YXZ5R04vU1VNQmxYM1ZDeGUzbHZ1bFhsdmQKc3AyTk1WMEVTUzU5OU5OeXhlNnZQM3VPN2VtaUNYYXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":{"id":"7e8681f8-82a0-4177-a402-08b18a94d08a","ip":"51.159.74.238","load_balancer":{},"name":null,"port":26430},"endpoints":[{"id":"7e8681f8-82a0-4177-a402-08b18a94d08a","ip":"51.159.74.238","load_balancer":{},"name":null,"port":26430}],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1217"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -726,7 +726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7e4c482-d33d-4c88-9ae1-069c4aa09ff9
+      - ce5f837c-897d-4980-85a7-4825183be0ea
     status: 200 OK
     code: 200
     duration: ""
@@ -737,19 +737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681},"endpoints":[{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681}],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVVWFKcUZvNHVPd280SVdaZVNyMmVMZ2VzMUpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNVEUyTVRVMU5EVTVXaGNOTXpNeE1URXpNVFUxTkRVNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9oWktldTJtOVZRdTlQZWFDUnJkVTNaSG5hSHRTcm0zYkJWNXZtU29VSHUrRGNTQllRbStMN1oKRXFnU0ZxNUljMWR6K2tzUFQzR2hkb1I4eDNEMnB5TWM3dG9kdk5pbTJYbXNkNEF4U0dMOVplbmRrRkxobGJCeApVS3hYUVdnQi9kdEw1UEUvT3FFTTlORTdIRTRPdGVsYktCM2E2dFJmYmFXMGpIYnl1TGtJT2hyT3l5Z2l5S1RKCkRaaTBRTWRhaC9DTHc5alEzSThZTFgvVE9SdUNYOWxjeTdzQU5IVHAwRWJsZjlKZ2xacnVTWHRuWHJiSWpvNTYKWUcraVphRFM4d0lleXBxK1VuOS9GVmNnWElUUHB2aExXSTI5R2ZUMEhMVDZjQkdRcUF2K0I4bTFUN3NvSHdySQozRTcvQklxNVI3a1c0dCtVNTJuS1Rna01MOStwbFowQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMamMwTGpJek9JSThjbmN0WWpCak5HSTRNV1l0TURFM09DMDBOR1EyTFdFMU9EY3RaV00wTmpGa05USTEKTkdZekxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCs5eWh3UXpuMHJ1TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1hzREM5RmZyamxBK09EblhKTEpYa2I3aXRhWmY2emxjYlEvMWp3cjRQWUxOVnNWU3ppUmNwCnc1THpYZGh3UXpFMkFoazNmSWk5NDhXNENHKzFlMHNwMlh0ODI3cWJuM0hBOXVCZ2NPZEl2bGw5aXhXMWl0THIKMW9EUkpzUkFPdlY5OXBKeDJCRnF0c0tlVVZtZXpjYnZYQmxnM3AzQk9NeXBtbmJRRUd5ZTMyZTF6b1dMSUczUgpDQkVEZUd0QmVBc1BlZkJvTXpnMUJJK0g5MThxbFIvN1BWOHZyNGNhZS9RamhrV2dIOTF3VzFOdDAySUpRa2ZiCnNRNXFkQXNGbGUvNE9nak91Mkw3M2pPWW5NWk5SRXpheWlYWUNBTit1RXB4ckRKUUtla0Y0TVZIUmdHb1ZOM1gKUXhhOGtGNERVanFWd2MxTnJieDJISy8zVDFxakJBRWsKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1171"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -759,7 +759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 940c56cc-26e6-496a-a885-b14351efb306
+      - 3ff75665-fdc8-4fe2-9f12-6378ffcaea29
     status: 200 OK
     code: 200
     duration: ""
@@ -770,19 +770,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":{"id":"7e8681f8-82a0-4177-a402-08b18a94d08a","ip":"51.159.74.238","load_balancer":{},"name":null,"port":26430},"endpoints":[{"id":"7e8681f8-82a0-4177-a402-08b18a94d08a","ip":"51.159.74.238","load_balancer":{},"name":null,"port":26430}],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1217"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:55:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 94b8605d-1070-4835-b8a0-dfc5a1d8843b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681},"endpoints":[{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681}],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":{"id":"7e8681f8-82a0-4177-a402-08b18a94d08a","ip":"51.159.74.238","load_balancer":{},"name":null,"port":26430},"endpoints":[{"id":"7e8681f8-82a0-4177-a402-08b18a94d08a","ip":"51.159.74.238","load_balancer":{},"name":null,"port":26430}],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1174"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -792,7 +825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8afb83fc-420f-4466-bb64-48a2a7fe7d72
+      - dd2a777f-07b5-46bc-8ac3-6c9c0e81a254
     status: 200 OK
     code: 200
     duration: ""
@@ -803,19 +836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.881922Z","endpoint":{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681},"endpoints":[{"id":"8b012a94-430c-465e-855c-d257fccc17be","ip":"51.159.26.223","load_balancer":{},"name":null,"port":13681}],"engine":"PostgreSQL-15","id":"160ed572-d7f7-4655-a260-b897015ea071","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.840586Z","endpoint":{"id":"7e8681f8-82a0-4177-a402-08b18a94d08a","ip":"51.159.74.238","load_balancer":{},"name":null,"port":26430},"endpoints":[{"id":"7e8681f8-82a0-4177-a402-08b18a94d08a","ip":"51.159.74.238","load_balancer":{},"name":null,"port":26430}],"engine":"PostgreSQL-15","id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1174"
+      - "1220"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -825,7 +858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26edf8e7-74e2-4df0-bdc4-9fb2e58b4c07
+      - b9d6977a-1ca9-4918-a49f-9a02e6fc858d
     status: 200 OK
     code: 200
     duration: ""
@@ -836,10 +869,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"160ed572-d7f7-4655-a260-b897015ea071","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -848,7 +881,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 15:56:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -858,7 +891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fbd92b8-288f-452f-b27a-ce7470a387c4
+      - 1ffe5202-a122-4b1e-88d2-f0148129d7db
     status: 404 Not Found
     code: 404
     duration: ""
@@ -869,10 +902,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/160ed572-d7f7-4655-a260-b897015ea071
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b0c4b81f-0178-44d6-a587-ec461d5254f3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"160ed572-d7f7-4655-a260-b897015ea071","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"b0c4b81f-0178-44d6-a587-ec461d5254f3","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -881,7 +914,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 15:56:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -891,7 +924,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0a05ede-e1b1-4c2e-b41d-39ab0039e0e1
+      - 7cd01430-fafa-4e83-9c40-e2bad57180c0
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-init-settings.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-init-settings.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:34 GMT
+      - Thu, 16 Nov 2023 15:52:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29399ff7-c93c-4b9f-aa54-794dd6347fb5
+      - 154c7975-621c-4fa9-a8c2-1b32e73acf53
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-init-settings","engine":"MySQL-8","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":[{"name":"lower_case_table_names","value":"1"}],"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-init-settings","engine":"MySQL-8","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":[{"name":"lower_case_table_names","value":"1"}],"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 16:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89967ef5-89f3-4c21-89be-bb667ca9497d
+      - f0f30a7c-f4a4-42ca-ba98-5334d94e1c37
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 16:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae1d7c73-7f00-481b-870b-7849bfecf4e4
+      - a037d34e-c0c2-4550-9690-2074284eb6ad
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:08 GMT
+      - Thu, 16 Nov 2023 16:01:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e7cabbc-0ae2-4162-a262-b0ee7430bc50
+      - 75c52acd-69ca-44b5-a22d-c8916ea0ff80
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:38 GMT
+      - Thu, 16 Nov 2023 16:02:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1da24bc3-5351-453a-89bf-20a14d4343f1
+      - 7d27b70b-a07a-4d51-9647-98c674a97248
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:09 GMT
+      - Thu, 16 Nov 2023 16:02:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e8071a3-a142-4485-b973-e5e1de222be2
+      - b2406cc3-1792-4abb-9b2b-6fed3304dcd3
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:39 GMT
+      - Thu, 16 Nov 2023 16:03:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abec11fa-1a0b-406e-8993-f1af03f83d5e
+      - 197b922e-b6a0-4518-981f-e50b93356ae7
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:09 GMT
+      - Thu, 16 Nov 2023 16:03:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fef20a2-c8b3-4e8a-9927-bf09a7a7834b
+      - f6a61ae4-87d7-4ba5-bf72-4f88df6cf4c7
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"100"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"100"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1000"
+      - "820"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:04:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f54251f-1421-4ffc-b661-cce41407cea3
+      - 29107f18-2cbe-4ebf-beb3-98544e81161f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106},"endpoints":[{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106}],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"100"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1037"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 622ae934-9a47-4dab-a65d-44d206e4fc98
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7/settings
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802/settings
     method: PUT
   response:
     body: '{"settings":[{"name":"max_connections","value":"350"}]}'
     headers:
       Content-Length:
-      - "55"
+      - "56"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:04:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 785bda7b-1605-4580-bcc0-b824d9f4407d
+      - e7529e2e-894a-46df-a0c0-aef4f609dba0
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106},"endpoints":[{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106}],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1006"
+      - "1043"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:04:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9eadd1e1-7aee-47d4-b8d9-fc71666ca5e4
+      - 77faee5c-8c74-42ac-9fbd-05ffd9df296d
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106},"endpoints":[{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106}],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1000"
+      - "1037"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:10 GMT
+      - Thu, 16 Nov 2023 16:05:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b39d9c7-b14a-4c4e-a2bb-ca0425a4b0e0
+      - 66369771-3fcd-4551-b698-5c2649dff463
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTE1wNjJJWjBIVEtGQ3hWY2dEZVVjbXhXaGdrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56TXdXaGNOTXpNeE1ETXdNVGcwTnpNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0vNktDUnZlUlZ6U1FETWFsenByN3NHWGc2U1lhV04rVGZzQW9lY3gvbEZPTjB3RkdxNXlTRGsKRkxqQzFWbE42OTEyT1JiWHdCRitJSGdEaDBQYmtSd0Z2TnpkYnp0QXA0MWp6YUxyd3d4ekpORzYxVFZiNnRXQgpEN0ZDaXk0WUtGdXVYQ1lHZURzS3JTZVpXSlFpSG50NUszeXFOTytKb0pJN3BIQ3NSR0NxY0dwclhKM0F1Mkc2ClZjQmVQRDRKQWVvaDJhNmZXVXZmVzNqdDlIQkZob284dnFoUklYb0xNeUlPVDltbFF6Z2dSZ3RmS3pMYW4xWTQKbmdHNWJTdXU5T2ZJRWJRRXZjYWIwNXhzVk1IZ091Uks0bjZqKzhMWUwreGJwVUJOR29RYWFhdE5OUW4rU1ZWQQphcTdlV09KRzcyTndVcnk5czNjQUMycUcvRmhtT2JFQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WVRBMFpUQm1NREF0TWpFMFpDMDBZamhsTFdJMFkyRXRZV0V3Wm1Vd1pHUXkKTUdJM0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckt0Z2h3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQzQzM2o0dEp5MWZ1TUE3Z2pBMlpvOS8rT00xRGZlWGYrUlJ2a2V5OENCRHdDMkMwSXBBcVAzClNEcW1YZ3BvTVNVL3J3ek5ORlZuL1BwUzgwSE53WEtXZW9oZTh6Qys5V0ZBdVBaalVYdjVSL0FXVlZublV0disKVmcwNm11dWFCQXFSK3JUV292YjA0Nk1xYXNkeUtOU0xJaUFpRXFLeStidjR6aFlxQ2VDakEwaENPMVJ4VmJWTApnN2ZCcUY3SFZXNXFnOGZKM2RHeDg3blZQRDgxNGlRd29wQ0toQkZWbzdPMFBhOW1Ta1cyUmFyNXNrQ2UveUxOCmMyMlA1VUNNUWlTTTVscjk1U2tTNklpc2d4Y0NiS1J5RURzR2xlbC9IOVRxWlFnOURqZXJmbGl1M1RMY2xHRDAKbW1BSVZLOWg2THprRVc0cVlJWjIwcUNRMzlIRUd1em0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVZWp1aC9UeGNlWmx2WE9GaWdVSjZSZEZWVG8wd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNVEUyTVRZd05ERXlXaGNOTXpNeE1URXpNVFl3TkRFeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU16d3lIUXpOK05seDJlVm1xNVNjNVFQLzM5cWl6WkZqN0dJcjc3VVNnNHhIZlZtYTgxNUNCMXIKUXJTMUhwREVSc3Q1RnVaYlppNy9GZjlGNEwyOUE0dG1VSW5FenVwNjMrQm5CQVVLdWtQaTZIOFZ3eEZZN05TRApoZXlDcXdXK3lxQnpqYVJybzNZVHJjbml2TExEUmpscEY5TlNqWHdJWmV6RWQzcUZoZFhkS2ltT2R1TGh3MFZxCnB5RmNCam1kWkhzcUxJaXdlU2NyS3psaVo3UHN6OFk2SkZ5ay9sYWZoTG9xdXNVOGs3SlM1bDJOQlpHTzVHY3oKTTUvU3poeE84aStKSUxzMlVMTTdrUm1RdGhlcFlFM21ScHczRmw4b2RFMjZ2MmwweUZKSDNMblhwR21UZlhxOQp4cExrNU5hN1Npc3JOSk5vY3gxOHhQb3hFN0ZIajI4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMamMwTGpJek9JSThjbmN0TmpGa05qWXhPREl0TVdFME9TMDBNbU15TFRrek56VXRaV000TWpZNVpUaGwKT0RBeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckorNWh3UXpuMHJ1TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQmMyNS8xYlRaK01SUi81NW4wRnh5ZFVWVjdkSlIvdGg4NytFbklXcUhxK3BRVU82c2RNKzVBCmpQRHRoUlhuc0N1cS9lVUsrME10WE1nVHdCUFVxOGZmUXpvdjF1Um1TTzJ1K1J5MXJWUnUxb0tMUEIzT3JCbzgKMWZ0NnVyeld0eVNEWVM0bUEzaVBRekR0QWtYWkFvR1g0TFg0cCtyRlU0ejdOR3Rtd3ZkY1NBQ3hyRVZ6WHAvdwpNanRMb3BoTFpOaDNLcVRvekd0NkhFbk1mNXZGaTcyS1NFMEgxVThXK1I2SklUM3Q4RnZLOFhNZ1hMNjEzQWkzCmJTRUMwUTc2SVpvWEw3WWFEWWNNNEcvem9jbmVDanZZbFIwVFdJVVIwa3kvS2RlSlluVUVVUTN0TXN3ek5BNGoKTTFTOGRoZ3dwQUZSakxPN0g3YnhmUU9SLzZZOVRpUkwKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:10 GMT
+      - Thu, 16 Nov 2023 16:05:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5640477e-8723-4fe1-bc33-f614885c9f5e
+      - 28483024-5f64-4fb2-81d8-592d594add82
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106},"endpoints":[{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106}],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1000"
+      - "1037"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:10 GMT
+      - Thu, 16 Nov 2023 16:05:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4fe7e42-f5b7-4f39-a30c-c22a30056b0e
+      - 4284d913-c0dc-4d8c-b748-bebb02d5359c
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106},"endpoints":[{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106}],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1000"
+      - "1037"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:10 GMT
+      - Thu, 16 Nov 2023 16:05:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca71fff1-e337-4abe-a4f3-031dfbd30392
+      - 3d7aaddc-0b4e-4c65-a850-2950251676e6
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTE1wNjJJWjBIVEtGQ3hWY2dEZVVjbXhXaGdrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56TXdXaGNOTXpNeE1ETXdNVGcwTnpNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0vNktDUnZlUlZ6U1FETWFsenByN3NHWGc2U1lhV04rVGZzQW9lY3gvbEZPTjB3RkdxNXlTRGsKRkxqQzFWbE42OTEyT1JiWHdCRitJSGdEaDBQYmtSd0Z2TnpkYnp0QXA0MWp6YUxyd3d4ekpORzYxVFZiNnRXQgpEN0ZDaXk0WUtGdXVYQ1lHZURzS3JTZVpXSlFpSG50NUszeXFOTytKb0pJN3BIQ3NSR0NxY0dwclhKM0F1Mkc2ClZjQmVQRDRKQWVvaDJhNmZXVXZmVzNqdDlIQkZob284dnFoUklYb0xNeUlPVDltbFF6Z2dSZ3RmS3pMYW4xWTQKbmdHNWJTdXU5T2ZJRWJRRXZjYWIwNXhzVk1IZ091Uks0bjZqKzhMWUwreGJwVUJOR29RYWFhdE5OUW4rU1ZWQQphcTdlV09KRzcyTndVcnk5czNjQUMycUcvRmhtT2JFQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WVRBMFpUQm1NREF0TWpFMFpDMDBZamhsTFdJMFkyRXRZV0V3Wm1Vd1pHUXkKTUdJM0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1Nqckt0Z2h3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQzQzM2o0dEp5MWZ1TUE3Z2pBMlpvOS8rT00xRGZlWGYrUlJ2a2V5OENCRHdDMkMwSXBBcVAzClNEcW1YZ3BvTVNVL3J3ek5ORlZuL1BwUzgwSE53WEtXZW9oZTh6Qys5V0ZBdVBaalVYdjVSL0FXVlZublV0disKVmcwNm11dWFCQXFSK3JUV292YjA0Nk1xYXNkeUtOU0xJaUFpRXFLeStidjR6aFlxQ2VDakEwaENPMVJ4VmJWTApnN2ZCcUY3SFZXNXFnOGZKM2RHeDg3blZQRDgxNGlRd29wQ0toQkZWbzdPMFBhOW1Ta1cyUmFyNXNrQ2UveUxOCmMyMlA1VUNNUWlTTTVscjk1U2tTNklpc2d4Y0NiS1J5RURzR2xlbC9IOVRxWlFnOURqZXJmbGl1M1RMY2xHRDAKbW1BSVZLOWg2THprRVc0cVlJWjIwcUNRMzlIRUd1em0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVZWp1aC9UeGNlWmx2WE9GaWdVSjZSZEZWVG8wd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNVEUyTVRZd05ERXlXaGNOTXpNeE1URXpNVFl3TkRFeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU16d3lIUXpOK05seDJlVm1xNVNjNVFQLzM5cWl6WkZqN0dJcjc3VVNnNHhIZlZtYTgxNUNCMXIKUXJTMUhwREVSc3Q1RnVaYlppNy9GZjlGNEwyOUE0dG1VSW5FenVwNjMrQm5CQVVLdWtQaTZIOFZ3eEZZN05TRApoZXlDcXdXK3lxQnpqYVJybzNZVHJjbml2TExEUmpscEY5TlNqWHdJWmV6RWQzcUZoZFhkS2ltT2R1TGh3MFZxCnB5RmNCam1kWkhzcUxJaXdlU2NyS3psaVo3UHN6OFk2SkZ5ay9sYWZoTG9xdXNVOGs3SlM1bDJOQlpHTzVHY3oKTTUvU3poeE84aStKSUxzMlVMTTdrUm1RdGhlcFlFM21ScHczRmw4b2RFMjZ2MmwweUZKSDNMblhwR21UZlhxOQp4cExrNU5hN1Npc3JOSk5vY3gxOHhQb3hFN0ZIajI4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMamMwTGpJek9JSThjbmN0TmpGa05qWXhPREl0TVdFME9TMDBNbU15TFRrek56VXRaV000TWpZNVpUaGwKT0RBeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckorNWh3UXpuMHJ1TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQmMyNS8xYlRaK01SUi81NW4wRnh5ZFVWVjdkSlIvdGg4NytFbklXcUhxK3BRVU82c2RNKzVBCmpQRHRoUlhuc0N1cS9lVUsrME10WE1nVHdCUFVxOGZmUXpvdjF1Um1TTzJ1K1J5MXJWUnUxb0tMUEIzT3JCbzgKMWZ0NnVyeld0eVNEWVM0bUEzaVBRekR0QWtYWkFvR1g0TFg0cCtyRlU0ejdOR3Rtd3ZkY1NBQ3hyRVZ6WHAvdwpNanRMb3BoTFpOaDNLcVRvekd0NkhFbk1mNXZGaTcyS1NFMEgxVThXK1I2SklUM3Q4RnZLOFhNZ1hMNjEzQWkzCmJTRUMwUTc2SVpvWEw3WWFEWWNNNEcvem9jbmVDanZZbFIwVFdJVVIwa3kvS2RlSlluVUVVUTN0TXN3ek5BNGoKTTFTOGRoZ3dwQUZSakxPN0g3YnhmUU9SLzZZOVRpUkwKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:10 GMT
+      - Thu, 16 Nov 2023 16:05:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81325a3a-ffc9-4628-8a16-9ce2fe39d308
+      - 14eb2c33-f368-45fe-9e9d-cd25075101b3
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106},"endpoints":[{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106}],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1000"
+      - "1037"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 16:05:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d7f06b4-86ed-44a2-940b-fb06c632d4e3
+      - db461379-b46e-4fc4-ab29-68aab0bdaf58
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106},"endpoints":[{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106}],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1003"
+      - "1040"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 16:05:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 571fb242-c5ab-4a01-89a4-f50b10d0cce3
+      - 2b629bcb-72e4-4ae3-9a92-e8344074c1f4
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.875802Z","endpoint":{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787},"endpoints":[{"id":"3803b6bb-4a42-4417-a986-589e578c4bbb","ip":"51.159.26.223","load_balancer":{},"name":null,"port":27787}],"engine":"MySQL-8","id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:00:59.987384Z","endpoint":{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106},"endpoints":[{"id":"36285439-74ad-4d0b-b4e2-4e671af1f86b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":16106}],"engine":"MySQL-8","id":"61d66182-1a49-42c2-9375-ec8269e8e802","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1003"
+      - "1040"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 16:05:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d97783b8-1475-4209-ae47-86ddcb4a0142
+      - 92c1780c-f790-456c-8265-3fe427e44d28
     status: 200 OK
     code: 200
     duration: ""
@@ -937,10 +970,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"61d66182-1a49-42c2-9375-ec8269e8e802","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -949,7 +982,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:42 GMT
+      - Thu, 16 Nov 2023 16:05:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8d6129b-9f07-4b46-bb04-5e8299fdb7b4
+      - e25f621b-d2bf-42cb-ba35-d7950e4309fd
     status: 404 Not Found
     code: 404
     duration: ""
@@ -970,10 +1003,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/61d66182-1a49-42c2-9375-ec8269e8e802
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"a04e0f00-214d-4b8e-b4ca-aa0fe0dd20b7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"61d66182-1a49-42c2-9375-ec8269e8e802","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -982,7 +1015,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:42 GMT
+      - Thu, 16 Nov 2023 16:05:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4292792e-bb79-479a-bd61-826e1eee64d1
+      - bfcedce2-b9a1-45e6-b9f3-9aeb617a4179
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network-dhcp.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network-dhcp.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:34 GMT
+      - Thu, 16 Nov 2023 15:52:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7fb5bf4-669a-4234-bb2d-f9dbc457f83f
+      - 65bbe7e2-68ca-4e56-aeeb-1cc0093f1d9e
     status: 200 OK
     code: 200
     duration: ""
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:00 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a432dedc-89fd-4d23-8a6e-47d1e07f8a1a
+      - a67cffa5-ec70-4c7c-99c4-65198ed6b842
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/f664ab2c-301f-4cbd-9d28-cf56fe37db7d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/317cfabe-4cd7-4d20-bf34-f02382122edb
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:00 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,75 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 912d9355-4893-4057-a228-0f86cb67e941
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
-    method: POST
-  response:
-    body: '{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":null,"id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "356"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:59:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 80ce42f7-f2b9-4105-9ce9-0c87fc878f26
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e
-    method: GET
-  response:
-    body: '{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":null,"id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "356"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:59:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ea43283f-d0d9-4c1c-a24f-cb41235dbb4c
+      - ec799c64-cd4c-4053-b45c-b377c1e09072
     status: 200 OK
     code: 200
     duration: ""
@@ -480,16 +412,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-02T18:59:00.881462Z","dhcp_enabled":true,"id":"0fc899b5-fd8e-408d-91d8-d0c477185680","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T18:59:00.881462Z","id":"a739db4b-6d5c-408e-ae89-80c252c0961f","subnet":"172.16.0.0/22","updated_at":"2023-11-02T18:59:00.881462Z"},{"created_at":"2023-11-02T18:59:00.881462Z","id":"be07ed5e-b85b-4c20-80e1-2012ddce8863","subnet":"fd68:d440:21c4:a8a7::/64","updated_at":"2023-11-02T18:59:00.881462Z"}],"tags":[],"updated_at":"2023-11-02T18:59:00.881462Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T15:52:10.392929Z","dhcp_enabled":true,"id":"34efb194-d086-4064-b419-2f4d354f51ce","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T15:52:10.392929Z","id":"e7bf9686-1bcb-4537-92bb-dec9104b9af2","subnet":"172.16.8.0/22","updated_at":"2023-11-16T15:52:10.392929Z"},{"created_at":"2023-11-16T15:52:10.392929Z","id":"ed0972d9-734c-4a86-8ac1-e27d65ccc2ac","subnet":"fd68:d440:21c4:9399::/64","updated_at":"2023-11-16T15:52:10.392929Z"}],"tags":[],"updated_at":"2023-11-16T15:52:10.392929Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "701"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:01 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -499,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 287d9142-e5f1-454b-87a9-da4c0e842133
+      - a6ac8337-705e-4903-a819-058122a93087
     status: 200 OK
     code: 200
     duration: ""
@@ -510,19 +442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/0fc899b5-fd8e-408d-91d8-d0c477185680
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/34efb194-d086-4064-b419-2f4d354f51ce
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:59:00.881462Z","dhcp_enabled":true,"id":"0fc899b5-fd8e-408d-91d8-d0c477185680","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T18:59:00.881462Z","id":"a739db4b-6d5c-408e-ae89-80c252c0961f","subnet":"172.16.0.0/22","updated_at":"2023-11-02T18:59:00.881462Z"},{"created_at":"2023-11-02T18:59:00.881462Z","id":"be07ed5e-b85b-4c20-80e1-2012ddce8863","subnet":"fd68:d440:21c4:a8a7::/64","updated_at":"2023-11-02T18:59:00.881462Z"}],"tags":[],"updated_at":"2023-11-02T18:59:00.881462Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T15:52:10.392929Z","dhcp_enabled":true,"id":"34efb194-d086-4064-b419-2f4d354f51ce","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T15:52:10.392929Z","id":"e7bf9686-1bcb-4537-92bb-dec9104b9af2","subnet":"172.16.8.0/22","updated_at":"2023-11-16T15:52:10.392929Z"},{"created_at":"2023-11-16T15:52:10.392929Z","id":"ed0972d9-734c-4a86-8ac1-e27d65ccc2ac","subnet":"fd68:d440:21c4:9399::/64","updated_at":"2023-11-16T15:52:10.392929Z"}],"tags":[],"updated_at":"2023-11-16T15:52:10.392929Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "701"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:01 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -532,12 +464,80 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6edac651-cda2-48c1-b5b4-66ce1bc9a88f
+      - 30c2608f-4be5-4225-838d-9488dac1316e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","enable_smtp":false,"enable_bastion":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
+    method: POST
+  response:
+    body: '{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":null,"id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "365"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:52:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8509c0a9-2dee-4788-b57e-c74eec7a9fa8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/20691f3b-2fe1-420e-8b12-a50fe77c594e
+    method: GET
+  response:
+    body: '{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":null,"id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "365"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:52:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 97901003-e5ee-40f2-9809-52e40c32e85d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
@@ -548,16 +548,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:01.565830Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:11.260711Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "967"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:01 GMT
+      - Thu, 16 Nov 2023 15:52:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -567,7 +567,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7670081d-3866-4302-a7aa-f6fb09d56066
+      - 9b3fe088-b6a9-4c09-88d5-25fa7721ab80
     status: 200 OK
     code: 200
     duration: ""
@@ -578,19 +578,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:01.623189Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:11.313795Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "941"
+      - "970"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:01 GMT
+      - Thu, 16 Nov 2023 15:52:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -600,12 +600,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b31fffa7-f202-4a18-8e72-ef1c25899a54
+      - 9be37c48-4f30-4584-b6dc-b9233f63f665
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24"}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24"}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -616,16 +616,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":null,"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "977"
+      - "1013"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:02 GMT
+      - Thu, 16 Nov 2023 15:52:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -635,7 +635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e34b416-bbe4-4f23-add9-7101f29e6da6
+      - c968e61a-63d9-4259-bdd9-2714bfbcb443
     status: 200 OK
     code: 200
     duration: ""
@@ -646,19 +646,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":null,"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "977"
+      - "1013"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:02 GMT
+      - Thu, 16 Nov 2023 15:52:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -668,7 +668,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9418eee5-6ed1-43fd-8ec0-cf7441f86b4a
+      - 8b2bc08b-2a2b-40e6-be48-8fdfa2a9c5f8
     status: 200 OK
     code: 200
     duration: ""
@@ -679,19 +679,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:02.295207Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:11.985373Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "967"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 15:52:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -701,7 +701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09b35c99-9eb6-4178-846d-d3e87c056d1c
+      - 6920c395-03e8-47cf-b9d4-26d214673651
     status: 200 OK
     code: 200
     duration: ""
@@ -712,19 +712,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:02.295207Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:11.985373Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "967"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 15:52:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -734,7 +734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4c3dbd3-2fb1-4e68-b9b0-4c43b084807f
+      - e61bd304-8f46-4759-b5d1-3386705c08bb
     status: 200 OK
     code: 200
     duration: ""
@@ -745,19 +745,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:02.295207Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:11.985373Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "967"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 15:52:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -767,12 +767,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad389005-99dc-4517-b7c0-4dc2fe924bcf
+      - a0076826-c91a-49e5-89df-0459c79f9155
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d"}'
+    body: '{"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"317cfabe-4cd7-4d20-bf34-f02382122edb"}'
     form: {}
     headers:
       Content-Type:
@@ -783,16 +783,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":null,"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"created","updated_at":"2023-11-02T18:59:08.412434Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":null,"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"created","updated_at":"2023-11-16T15:52:17.605329Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "953"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:08 GMT
+      - Thu, 16 Nov 2023 15:52:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -802,7 +802,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2743ed17-106f-488a-99d8-951afe7bb4a8
+      - 86987c8d-f209-4512-91f1-a8c7cbfcd76f
     status: 200 OK
     code: 200
     duration: ""
@@ -813,19 +813,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":null,"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"created","updated_at":"2023-11-02T18:59:08.412434Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:08.607849Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":null,"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"created","updated_at":"2023-11-16T15:52:17.605329Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:17.791628Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1894"
+      - "1953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:08 GMT
+      - Thu, 16 Nov 2023 15:52:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -835,7 +835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbdb536a-e1bf-428f-ae04-c3197c2b824d
+      - c0428eb7-beef-4556-aa11-f2def9a39a5f
     status: 200 OK
     code: 200
     duration: ""
@@ -846,19 +846,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":null,"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"created","updated_at":"2023-11-02T18:59:08.412434Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:08.607849Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":null,"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"created","updated_at":"2023-11-16T15:52:17.605329Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:17.791628Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1894"
+      - "1953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:13 GMT
+      - Thu, 16 Nov 2023 15:52:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -868,7 +868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52b3c7e7-a9b5-4b95-8154-f4ec8099e984
+      - b7f1c70b-4e3f-494c-8fba-a24b611c443c
     status: 200 OK
     code: 200
     duration: ""
@@ -879,19 +879,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1962"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:18 GMT
+      - Thu, 16 Nov 2023 15:52:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -901,7 +901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97796922-6d5e-4e62-a6e2-d607d602b031
+      - a5baea3a-af23-40ff-829a-09408e690d34
     status: 200 OK
     code: 200
     duration: ""
@@ -912,19 +912,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/0bed21f9-1668-46d6-8498-0cb446a38bbd
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:18 GMT
+      - Thu, 16 Nov 2023 15:52:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -934,7 +934,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eadc99d1-68d6-4825-a33d-79a24be16394
+      - 420ab675-949f-45cd-8c07-db715200e3f4
     status: 200 OK
     code: 200
     duration: ""
@@ -945,19 +945,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/0bed21f9-1668-46d6-8498-0cb446a38bbd
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:18 GMT
+      - Thu, 16 Nov 2023 15:52:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -967,7 +967,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2462c83-2ad1-4d62-9cbd-63ae7e849b9f
+      - fb2c7c63-642d-43dc-87ae-3e516798d65a
     status: 200 OK
     code: 200
     duration: ""
@@ -978,19 +978,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1962"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:18 GMT
+      - Thu, 16 Nov 2023 15:52:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1000,7 +1000,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f46769cc-c151-4ffe-84fe-ac733365f7d1
+      - b56ac491-5a50-4889-ba08-139b88310f57
     status: 200 OK
     code: 200
     duration: ""
@@ -1011,19 +1011,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/0bed21f9-1668-46d6-8498-0cb446a38bbd
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:19 GMT
+      - Thu, 16 Nov 2023 15:52:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1033,7 +1033,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cfd47bc-f7db-43c9-a2a1-5a61dd31a0fa
+      - 3f526055-764d-4d35-825f-4db4cdb0ae6b
     status: 200 OK
     code: 200
     duration: ""
@@ -1044,19 +1044,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":null,"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "977"
+      - "1013"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:32 GMT
+      - Thu, 16 Nov 2023 15:52:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1066,7 +1066,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fde46197-94a8-4b80-bfc4-a2178f36375c
+      - 940aad5d-cbe3-464d-91d2-b98322d1563b
     status: 200 OK
     code: 200
     duration: ""
@@ -1077,19 +1077,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":null,"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "977"
+      - "1013"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:02 GMT
+      - Thu, 16 Nov 2023 15:53:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1099,7 +1099,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fe3e26b-bb55-4dc7-a67e-1cb530353e3d
+      - d1401a6d-b020-4468-8a55-b7c451cf4bd8
     status: 200 OK
     code: 200
     duration: ""
@@ -1110,19 +1110,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":null,"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "977"
+      - "1013"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:33 GMT
+      - Thu, 16 Nov 2023 15:53:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1132,7 +1132,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7fc5d08-c7cf-413d-9afb-572e99b8c313
+      - 553fd761-d85e-4485-8505-00e20c6b0b07
     status: 200 OK
     code: 200
     duration: ""
@@ -1143,19 +1143,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":null,"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "977"
+      - "1013"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:03 GMT
+      - Thu, 16 Nov 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1165,7 +1165,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f31751f0-d922-452c-923e-0dffffaa48c8
+      - bec8750b-d0dd-4b1d-903a-55ceb2dc567b
     status: 200 OK
     code: 200
     duration: ""
@@ -1176,19 +1176,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":null,"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":null,"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "977"
+      - "1013"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:33 GMT
+      - Thu, 16 Nov 2023 15:54:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1198,7 +1198,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91ab974b-8239-46fc-b683-f7a976666ca9
+      - b35b6f91-c1f3-40b0-ba4e-b2b5cfc929ff
     status: 200 OK
     code: 200
     duration: ""
@@ -1209,19 +1209,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:03 GMT
+      - Thu, 16 Nov 2023 15:55:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1231,7 +1231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d9c6a49-f1c5-4140-a7ae-51c349db89d3
+      - e6668eb9-b5f7-4a23-806c-00432cd5b516
     status: 200 OK
     code: 200
     duration: ""
@@ -1242,19 +1242,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVWnVBWFRNTEpxOExXZ3VHRVE0dExhdXdlUVZNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEF5TVRrd01ERXdXaGNOTXpNeE1ETXdNVGt3TURFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBDSGVseFVmUG9hQlRZSHFUbzEvR1cxaVhKay9MczhlUkJrR2daL0RhdEVrMEN4bkJYaUI2SjkKNXNsQVhwSUdBd2xOK29TWDJVK1BpK1NUcFBTQzJheU9NenFNczRpbVd1ckhoamR3WmNVd0hqTnplc1JHS05VagppcEJlcVBDbHk0Uy8yNHhUaWFlTUdwWFdqTlNtb1hNc3BXNG90aGNpd0FlejV0T0RCTkZsN2cvd3lUNVczSnJPCjhULzNmMzErbHkwVlZETHlHNnI3bG1DY3FVWnNWSDhIT3VSN0pLcnYwTjBjWmlQTVhXZnAwbEpqWDlhK2xmb0IKeTg4ZmRRbUJEMytVTThNRFBEVExHTWxDOW5OQ054YzJhcUVNQXlKRFhLbWFwUHdteFFBMElWT1VMNjNQTTdWbwpIaWFMcllNZVExUU4wLzNvVlNCMXNVWWRXL09MaFE4Q0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNQzR5TURLQ1BISjNMVE14TlRJd05XSTBMVFUyTVdFdE5EWmwKTnkxaE5qazFMV1ptWTJFeE5USTFaR0U0TkM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzljZW9jRQp3S2dCL29jRU01NkN5akFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBdGphYW5WRjJyaGVSYlhiSm8xSUoyUk9FClFiLzVKVjJvclpTMVA5V0Z5MEd5dDZXNWV3QzJqSTBxQzZxK0Vya3lXNVg2VzlHTk9JNnc3QUtPQmhtSFYza3EKQm9IZjlYVjZ0ZVI4SkxFbnlLODUrQWN2RUxyQXBTczAwZlcwOEhkQ2NPUGNxeFpIRUUxcHZ0RlZuckV2NE0vMwoxYzhVcFVNT0F6Ri9PQnRDWnRYUXVTTEpjS3NCNDNDRVZ3SklydFQzTjhvdlJmVUk3dTlyUk5zcHJ6eE4xZytuCk53YzhGUzR1QnVZTDJpRE5NWU1YNGk3NHgzTm0zakF3OUZTK24yZ2xRQ1dPeEFTTGt3R2xwQzRiSjZkdkhyQjcKWlZKSlFORnM2V3FXajd2YUtsNGtjcUQ4Wis2QTJlNnNTTWRILzgwZlk5OGRpUTdPVk8wb21tNjlzcTZrZXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVYnlSZzh6bjNxbnMyRVpsV3MyWkxCcjJvWlo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEUyTVRVMU5EVTNXaGNOTXpNeE1URXpNVFUxTkRVM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxRSkhFNE55ZnpRZ3B5YytBcHJDODBUSzF1MU5iMkRycGMvVzd1aUFYeE9UamVCQkdZNmYzMlIKSEVtMlF0cHI0Zk4wQ2VYU1ZFNWhFVDVhU2krUDNQampVK0ZuQ0UrMWxTdHo4ZFhlelE2RFYzRWNNNUtVUjVBRgpIWHZVbytOUm52U1Evcmp5WTR1U2hDT0xUekZLTEFlcGVoWlVlWGxWUmlGaHowY1hmcjdtQzMwbU05dXhiQkxzCitZck4za3hZL3FnL01qeEIyTjh1ZU92TXdiNzVwS2JUS1ZNcEZodk00Qko1ZnZ4S0prYml2SDNwdTZDMVp5WkoKaUhPQVBYY2cvbzVrMFgreHZjanphNUxkTVNnZFdNK1NJVm81bnpmMEd1RCtqM3NJMldXdC9vd09RZTZPRkNJOQpZRElHWFdrWHhCM2tINGVtVjk1THdnaWFsMXpJV1JNQ0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNUzR4T1RHQ1BISjNMVGRrT0dSbVpEWTNMVGxoWVRZdE5EQmsKT0MwNVl6TTFMV1EwWldJNU1XRTNPR1U1Tnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzlXakljRQp3S2dCL29jRU01NkR2ekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBZFkxcDNYSi94QzRxeGZQRDBuNk1JV05HCitLaEhFdHBUUzlCNzBxRVhaRkhvaGNFRFROZTBON0dBR2tZdWF1TlMwWENCKzNJdzVQbVBRZjBqT2FxQTZiTW4KU1RTK1o2MFBLYytQQjFEbDVabkt5cy9sdks2OFZVTjcyN3BwQ3RmdmNMNmZJTnliZFhUNWdjSDRVK1RhNnJwYwp0ZXoyK2s1NVo4SEo1N1NsamR4eU4vNFIrRjlNM1BXaEFkQnlxZUlxRXNWR084N1llVk9Vb2JpT0lZc0lIWTloClNQUW9pa01jZk1wQStKbG5xRjYveHhnSFlPd1U2SklXNzF6UVNBVWJleWJjNndOK0d6L2E5d2NpK1AxajdhcFkKUTIxRmhCYUFwR0VaVVFLUWFmc29PWFZWZ09idG9BS0Q3SCsvMzdUKzRrWW4yaDk2bGNiUmlWRUljWGFyTFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1887"
+      - "1889"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:03 GMT
+      - Thu, 16 Nov 2023 15:55:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1264,7 +1264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 553653e8-0bf8-4783-ace7-985951d8c45a
+      - b5fd8404-5577-4eb4-b2c2-4af5f7302977
     status: 200 OK
     code: 200
     duration: ""
@@ -1275,19 +1275,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1962"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:03 GMT
+      - Thu, 16 Nov 2023 15:55:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1297,7 +1297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7bd4953-83d1-45e5-bd58-b6f96d25c728
+      - e9fbde62-d86e-4a96-8e13-a043d49db628
     status: 200 OK
     code: 200
     duration: ""
@@ -1308,19 +1308,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1962"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:03 GMT
+      - Thu, 16 Nov 2023 15:55:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1330,12 +1330,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed65de23-7cd7-44d6-b7ce-439fe0c9e78a
+      - 8c88eb48-897e-41c4-ac3f-1297e68a692f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
+    body: '{"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
     form: {}
     headers:
       Content-Type:
@@ -1346,16 +1346,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2023-11-02T19:02:03.927209Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"caa010cd-8c5a-4afc-9a78-63dda87e714b","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:02:03.927209Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-16T15:55:14.769886Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"6f34a4e4-07b7-49ca-8003-6ad98917ae5e","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-16T15:55:14.769886Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:03 GMT
+      - Thu, 16 Nov 2023 15:55:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1365,7 +1365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c204e648-d3f1-498f-bad2-d3ecc6ea2ee8
+      - 77f366d0-3a91-4c32-8aff-16cfbea36ce7
     status: 200 OK
     code: 200
     duration: ""
@@ -1376,19 +1376,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1962"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:04 GMT
+      - Thu, 16 Nov 2023 15:55:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1398,7 +1398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f205ffe6-ce3e-4ef2-aa47-50b5386fa56e
+      - bd625fc6-2802-4e4c-ae56-5ba08ba6f94d
     status: 200 OK
     code: 200
     duration: ""
@@ -1409,19 +1409,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/caa010cd-8c5a-4afc-9a78-63dda87e714b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/6f34a4e4-07b7-49ca-8003-6ad98917ae5e
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:02:03.927209Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"caa010cd-8c5a-4afc-9a78-63dda87e714b","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:02:03.927209Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-16T15:55:14.769886Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"6f34a4e4-07b7-49ca-8003-6ad98917ae5e","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-16T15:55:14.769886Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:04 GMT
+      - Thu, 16 Nov 2023 15:55:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1431,7 +1431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 529718c0-7d71-4ec7-9a8a-759f3dda6b10
+      - e1f29cbc-021a-43f3-a189-adb4b49cc2d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1442,19 +1442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:04 GMT
+      - Thu, 16 Nov 2023 15:55:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1464,7 +1464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14abae39-4f97-491f-8164-a2694f705796
+      - c8007440-bf44-46e8-af03-b28f53979dc9
     status: 200 OK
     code: 200
     duration: ""
@@ -1475,19 +1475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/317cfabe-4cd7-4d20-bf34-f02382122edb
     method: GET
   response:
-    body: '{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "390"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:05 GMT
+      - Thu, 16 Nov 2023 15:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1497,7 +1497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9f46e93-3147-4ad9-bc81-023effa8fc92
+      - c3584b77-cc3b-4072-a484-a295fbb467af
     status: 200 OK
     code: 200
     duration: ""
@@ -1508,19 +1508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/0fc899b5-fd8e-408d-91d8-d0c477185680
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/34efb194-d086-4064-b419-2f4d354f51ce
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:59:00.881462Z","dhcp_enabled":true,"id":"0fc899b5-fd8e-408d-91d8-d0c477185680","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T18:59:00.881462Z","id":"a739db4b-6d5c-408e-ae89-80c252c0961f","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:07.391460Z"},{"created_at":"2023-11-02T18:59:00.881462Z","id":"be07ed5e-b85b-4c20-80e1-2012ddce8863","subnet":"fd68:d440:21c4:a8a7::/64","updated_at":"2023-11-02T18:59:07.394943Z"}],"tags":[],"updated_at":"2023-11-02T18:59:15.278924Z","vpc_id":"1633022c-3fa1-431a-b398-1c67551e922c"}'
+    body: '{"created_at":"2023-11-16T15:52:10.392929Z","dhcp_enabled":true,"id":"34efb194-d086-4064-b419-2f4d354f51ce","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T15:52:10.392929Z","id":"e7bf9686-1bcb-4537-92bb-dec9104b9af2","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:17.118596Z"},{"created_at":"2023-11-16T15:52:10.392929Z","id":"ed0972d9-734c-4a86-8ac1-e27d65ccc2ac","subnet":"fd68:d440:21c4:9399::/64","updated_at":"2023-11-16T15:52:17.124107Z"}],"tags":[],"updated_at":"2023-11-16T15:52:24.498745Z","vpc_id":"80a539c1-ab6a-4f2f-990a-f49337efb722"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:05 GMT
+      - Thu, 16 Nov 2023 15:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1530,7 +1530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - debdde4c-6e0a-4ac0-a9fb-a667474d2f4c
+      - 801c9a02-64f1-4afa-adf5-ed0f039f7caf
     status: 200 OK
     code: 200
     duration: ""
@@ -1541,19 +1541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/f664ab2c-301f-4cbd-9d28-cf56fe37db7d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/20691f3b-2fe1-420e-8b12-a50fe77c594e
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "399"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:05 GMT
+      - Thu, 16 Nov 2023 15:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1563,7 +1563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a42f51aa-bc12-4f1b-9e99-8cb00c5c3f2f
+      - b666ea27-a0af-4b25-99be-e4e46f955089
     status: 200 OK
     code: 200
     duration: ""
@@ -1574,19 +1574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1962"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:05 GMT
+      - Thu, 16 Nov 2023 15:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1596,7 +1596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e581846-4691-4a1c-8a13-6d81c2854991
+      - a073969f-628e-4ea5-83fc-8eb54ecaf888
     status: 200 OK
     code: 200
     duration: ""
@@ -1607,19 +1607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:05 GMT
+      - Thu, 16 Nov 2023 15:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1629,7 +1629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebeefca3-4fd1-4ffb-ad7f-81d768e11abe
+      - 7b8a093b-bda4-4b35-b0e6-978c768171f5
     status: 200 OK
     code: 200
     duration: ""
@@ -1640,19 +1640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/0bed21f9-1668-46d6-8498-0cb446a38bbd
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:05 GMT
+      - Thu, 16 Nov 2023 15:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1662,7 +1662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a7f9cea-6a86-4540-86d4-4245ac2c6e1b
+      - fd1b96ff-f057-4676-9aee-5036fa983785
     status: 200 OK
     code: 200
     duration: ""
@@ -1673,19 +1673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1962"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:05 GMT
+      - Thu, 16 Nov 2023 15:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1695,7 +1695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b046d710-1ae8-48c3-9184-6e5ffa567f0c
+      - 995fd75a-95ed-4769-90cf-107670a01e4e
     status: 200 OK
     code: 200
     duration: ""
@@ -1706,19 +1706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVWnVBWFRNTEpxOExXZ3VHRVE0dExhdXdlUVZNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEF5TVRrd01ERXdXaGNOTXpNeE1ETXdNVGt3TURFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBDSGVseFVmUG9hQlRZSHFUbzEvR1cxaVhKay9MczhlUkJrR2daL0RhdEVrMEN4bkJYaUI2SjkKNXNsQVhwSUdBd2xOK29TWDJVK1BpK1NUcFBTQzJheU9NenFNczRpbVd1ckhoamR3WmNVd0hqTnplc1JHS05VagppcEJlcVBDbHk0Uy8yNHhUaWFlTUdwWFdqTlNtb1hNc3BXNG90aGNpd0FlejV0T0RCTkZsN2cvd3lUNVczSnJPCjhULzNmMzErbHkwVlZETHlHNnI3bG1DY3FVWnNWSDhIT3VSN0pLcnYwTjBjWmlQTVhXZnAwbEpqWDlhK2xmb0IKeTg4ZmRRbUJEMytVTThNRFBEVExHTWxDOW5OQ054YzJhcUVNQXlKRFhLbWFwUHdteFFBMElWT1VMNjNQTTdWbwpIaWFMcllNZVExUU4wLzNvVlNCMXNVWWRXL09MaFE4Q0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNQzR5TURLQ1BISjNMVE14TlRJd05XSTBMVFUyTVdFdE5EWmwKTnkxaE5qazFMV1ptWTJFeE5USTFaR0U0TkM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzljZW9jRQp3S2dCL29jRU01NkN5akFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBdGphYW5WRjJyaGVSYlhiSm8xSUoyUk9FClFiLzVKVjJvclpTMVA5V0Z5MEd5dDZXNWV3QzJqSTBxQzZxK0Vya3lXNVg2VzlHTk9JNnc3QUtPQmhtSFYza3EKQm9IZjlYVjZ0ZVI4SkxFbnlLODUrQWN2RUxyQXBTczAwZlcwOEhkQ2NPUGNxeFpIRUUxcHZ0RlZuckV2NE0vMwoxYzhVcFVNT0F6Ri9PQnRDWnRYUXVTTEpjS3NCNDNDRVZ3SklydFQzTjhvdlJmVUk3dTlyUk5zcHJ6eE4xZytuCk53YzhGUzR1QnVZTDJpRE5NWU1YNGk3NHgzTm0zakF3OUZTK24yZ2xRQ1dPeEFTTGt3R2xwQzRiSjZkdkhyQjcKWlZKSlFORnM2V3FXajd2YUtsNGtjcUQ4Wis2QTJlNnNTTWRILzgwZlk5OGRpUTdPVk8wb21tNjlzcTZrZXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVYnlSZzh6bjNxbnMyRVpsV3MyWkxCcjJvWlo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEUyTVRVMU5EVTNXaGNOTXpNeE1URXpNVFUxTkRVM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxRSkhFNE55ZnpRZ3B5YytBcHJDODBUSzF1MU5iMkRycGMvVzd1aUFYeE9UamVCQkdZNmYzMlIKSEVtMlF0cHI0Zk4wQ2VYU1ZFNWhFVDVhU2krUDNQampVK0ZuQ0UrMWxTdHo4ZFhlelE2RFYzRWNNNUtVUjVBRgpIWHZVbytOUm52U1Evcmp5WTR1U2hDT0xUekZLTEFlcGVoWlVlWGxWUmlGaHowY1hmcjdtQzMwbU05dXhiQkxzCitZck4za3hZL3FnL01qeEIyTjh1ZU92TXdiNzVwS2JUS1ZNcEZodk00Qko1ZnZ4S0prYml2SDNwdTZDMVp5WkoKaUhPQVBYY2cvbzVrMFgreHZjanphNUxkTVNnZFdNK1NJVm81bnpmMEd1RCtqM3NJMldXdC9vd09RZTZPRkNJOQpZRElHWFdrWHhCM2tINGVtVjk1THdnaWFsMXpJV1JNQ0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNUzR4T1RHQ1BISjNMVGRrT0dSbVpEWTNMVGxoWVRZdE5EQmsKT0MwNVl6TTFMV1EwWldJNU1XRTNPR1U1Tnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzlXakljRQp3S2dCL29jRU01NkR2ekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBZFkxcDNYSi94QzRxeGZQRDBuNk1JV05HCitLaEhFdHBUUzlCNzBxRVhaRkhvaGNFRFROZTBON0dBR2tZdWF1TlMwWENCKzNJdzVQbVBRZjBqT2FxQTZiTW4KU1RTK1o2MFBLYytQQjFEbDVabkt5cy9sdks2OFZVTjcyN3BwQ3RmdmNMNmZJTnliZFhUNWdjSDRVK1RhNnJwYwp0ZXoyK2s1NVo4SEo1N1NsamR4eU4vNFIrRjlNM1BXaEFkQnlxZUlxRXNWR084N1llVk9Vb2JpT0lZc0lIWTloClNQUW9pa01jZk1wQStKbG5xRjYveHhnSFlPd1U2SklXNzF6UVNBVWJleWJjNndOK0d6L2E5d2NpK1AxajdhcFkKUTIxRmhCYUFwR0VaVVFLUWFmc29PWFZWZ09idG9BS0Q3SCsvMzdUKzRrWW4yaDk2bGNiUmlWRUljWGFyTFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1887"
+      - "1889"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:05 GMT
+      - Thu, 16 Nov 2023 15:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1728,7 +1728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d220b97d-5a7d-419f-8a46-95ac3326d7cc
+      - a7debe40-b0d7-4d91-9514-f2f6a58d1c5f
     status: 200 OK
     code: 200
     duration: ""
@@ -1739,19 +1739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/0bed21f9-1668-46d6-8498-0cb446a38bbd
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:06 GMT
+      - Thu, 16 Nov 2023 15:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1761,7 +1761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91ca4f34-a10d-499d-b0e7-ab0797f87c3f
+      - 3ab51bfd-dce0-4a9d-8a63-d2ae72210caf
     status: 200 OK
     code: 200
     duration: ""
@@ -1772,19 +1772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/caa010cd-8c5a-4afc-9a78-63dda87e714b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/6f34a4e4-07b7-49ca-8003-6ad98917ae5e
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:02:03.927209Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"caa010cd-8c5a-4afc-9a78-63dda87e714b","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:02:03.927209Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-16T15:55:14.769886Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"6f34a4e4-07b7-49ca-8003-6ad98917ae5e","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-16T15:55:14.769886Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:06 GMT
+      - Thu, 16 Nov 2023 15:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1794,7 +1794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a355282-0b35-4488-94f4-260741682419
+      - f164653b-0a3b-4c94-9ed0-c7d6b802dbba
     status: 200 OK
     code: 200
     duration: ""
@@ -1805,19 +1805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/f664ab2c-301f-4cbd-9d28-cf56fe37db7d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/20691f3b-2fe1-420e-8b12-a50fe77c594e
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "399"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 15:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1827,7 +1827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baa0881b-5e6e-4773-97e8-90b4d5dd5ca6
+      - 03703d3a-9e61-46b3-9b25-6ab76e7d51b8
     status: 200 OK
     code: 200
     duration: ""
@@ -1838,19 +1838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/caa010cd-8c5a-4afc-9a78-63dda87e714b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/317cfabe-4cd7-4d20-bf34-f02382122edb
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:02:03.927209Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"caa010cd-8c5a-4afc-9a78-63dda87e714b","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:02:03.927209Z","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 15:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1860,7 +1860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11eddec8-cac8-4932-bf07-b29d306b3af4
+      - a7189311-e4d0-474e-93a5-d057c1e593b1
     status: 200 OK
     code: 200
     duration: ""
@@ -1871,19 +1871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/0fc899b5-fd8e-408d-91d8-d0c477185680
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/6f34a4e4-07b7-49ca-8003-6ad98917ae5e
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:59:00.881462Z","dhcp_enabled":true,"id":"0fc899b5-fd8e-408d-91d8-d0c477185680","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T18:59:00.881462Z","id":"a739db4b-6d5c-408e-ae89-80c252c0961f","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:07.391460Z"},{"created_at":"2023-11-02T18:59:00.881462Z","id":"be07ed5e-b85b-4c20-80e1-2012ddce8863","subnet":"fd68:d440:21c4:a8a7::/64","updated_at":"2023-11-02T18:59:07.394943Z"}],"tags":[],"updated_at":"2023-11-02T18:59:15.278924Z","vpc_id":"1633022c-3fa1-431a-b398-1c67551e922c"}'
+    body: '{"created_at":"2023-11-16T15:55:14.769886Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"6f34a4e4-07b7-49ca-8003-6ad98917ae5e","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-16T15:55:14.769886Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "702"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 15:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1893,7 +1893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2feff567-f891-4656-87b4-7a37776da3b0
+      - 569984ac-d20c-4896-978e-08743c1e9cb1
     status: 200 OK
     code: 200
     duration: ""
@@ -1904,19 +1904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1962"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 15:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1926,7 +1926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b79182f1-4e13-4097-a4b9-f5ee40fcb236
+      - 39b95057-026b-4613-a4d0-88adc67049d3
     status: 200 OK
     code: 200
     duration: ""
@@ -1937,19 +1937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/0bed21f9-1668-46d6-8498-0cb446a38bbd
     method: GET
   response:
-    body: '{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "390"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 15:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1959,7 +1959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73b08587-2fe1-406c-865e-874cfa47f0fb
+      - 9f4461a2-924a-4eda-acfe-5eacd1a740c6
     status: 200 OK
     code: 200
     duration: ""
@@ -1970,19 +1970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/34efb194-d086-4064-b419-2f4d354f51ce
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-16T15:52:10.392929Z","dhcp_enabled":true,"id":"34efb194-d086-4064-b419-2f4d354f51ce","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T15:52:10.392929Z","id":"e7bf9686-1bcb-4537-92bb-dec9104b9af2","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:17.118596Z"},{"created_at":"2023-11-16T15:52:10.392929Z","id":"ed0972d9-734c-4a86-8ac1-e27d65ccc2ac","subnet":"fd68:d440:21c4:9399::/64","updated_at":"2023-11-16T15:52:17.124107Z"}],"tags":[],"updated_at":"2023-11-16T15:52:24.498745Z","vpc_id":"80a539c1-ab6a-4f2f-990a-f49337efb722"}'
     headers:
       Content-Length:
-      - "966"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 15:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1992,7 +1992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73a08e38-a74a-4dbd-8b53-f654ee3e3c18
+      - 100a67f4-6b4d-453b-99c9-4a07522cbb60
     status: 200 OK
     code: 200
     duration: ""
@@ -2003,19 +2003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1453"
+      - "1962"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 15:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2025,7 +2025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e94cd6d0-d35c-42f2-932a-034af9adac7e
+      - 2412870d-9c48-413e-a2c1-dfbec16a42c4
     status: 200 OK
     code: 200
     duration: ""
@@ -2036,19 +2036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1903"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 15:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2058,7 +2058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85bc0abd-ea93-4350-9c8a-ad808a76fc64
+      - d7c174b8-b5ad-4ad5-929c-70551da8d0a6
     status: 200 OK
     code: 200
     duration: ""
@@ -2069,19 +2069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84/certificate
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/0bed21f9-1668-46d6-8498-0cb446a38bbd
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVWnVBWFRNTEpxOExXZ3VHRVE0dExhdXdlUVZNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEF5TVRrd01ERXdXaGNOTXpNeE1ETXdNVGt3TURFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBDSGVseFVmUG9hQlRZSHFUbzEvR1cxaVhKay9MczhlUkJrR2daL0RhdEVrMEN4bkJYaUI2SjkKNXNsQVhwSUdBd2xOK29TWDJVK1BpK1NUcFBTQzJheU9NenFNczRpbVd1ckhoamR3WmNVd0hqTnplc1JHS05VagppcEJlcVBDbHk0Uy8yNHhUaWFlTUdwWFdqTlNtb1hNc3BXNG90aGNpd0FlejV0T0RCTkZsN2cvd3lUNVczSnJPCjhULzNmMzErbHkwVlZETHlHNnI3bG1DY3FVWnNWSDhIT3VSN0pLcnYwTjBjWmlQTVhXZnAwbEpqWDlhK2xmb0IKeTg4ZmRRbUJEMytVTThNRFBEVExHTWxDOW5OQ054YzJhcUVNQXlKRFhLbWFwUHdteFFBMElWT1VMNjNQTTdWbwpIaWFMcllNZVExUU4wLzNvVlNCMXNVWWRXL09MaFE4Q0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNQzR5TURLQ1BISjNMVE14TlRJd05XSTBMVFUyTVdFdE5EWmwKTnkxaE5qazFMV1ptWTJFeE5USTFaR0U0TkM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzljZW9jRQp3S2dCL29jRU01NkN5akFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBdGphYW5WRjJyaGVSYlhiSm8xSUoyUk9FClFiLzVKVjJvclpTMVA5V0Z5MEd5dDZXNWV3QzJqSTBxQzZxK0Vya3lXNVg2VzlHTk9JNnc3QUtPQmhtSFYza3EKQm9IZjlYVjZ0ZVI4SkxFbnlLODUrQWN2RUxyQXBTczAwZlcwOEhkQ2NPUGNxeFpIRUUxcHZ0RlZuckV2NE0vMwoxYzhVcFVNT0F6Ri9PQnRDWnRYUXVTTEpjS3NCNDNDRVZ3SklydFQzTjhvdlJmVUk3dTlyUk5zcHJ6eE4xZytuCk53YzhGUzR1QnVZTDJpRE5NWU1YNGk3NHgzTm0zakF3OUZTK24yZ2xRQ1dPeEFTTGt3R2xwQzRiSjZkdkhyQjcKWlZKSlFORnM2V3FXajd2YUtsNGtjcUQ4Wis2QTJlNnNTTWRILzgwZlk5OGRpUTdPVk8wb21tNjlzcTZrZXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1887"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 15:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2091,7 +2091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ae7e12a-bb75-4297-8033-cc60638f06ce
+      - ca3de96d-0600-4997-8e6f-af989f6497c5
     status: 200 OK
     code: 200
     duration: ""
@@ -2102,19 +2102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97/certificate
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVYnlSZzh6bjNxbnMyRVpsV3MyWkxCcjJvWlo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEUyTVRVMU5EVTNXaGNOTXpNeE1URXpNVFUxTkRVM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxRSkhFNE55ZnpRZ3B5YytBcHJDODBUSzF1MU5iMkRycGMvVzd1aUFYeE9UamVCQkdZNmYzMlIKSEVtMlF0cHI0Zk4wQ2VYU1ZFNWhFVDVhU2krUDNQampVK0ZuQ0UrMWxTdHo4ZFhlelE2RFYzRWNNNUtVUjVBRgpIWHZVbytOUm52U1Evcmp5WTR1U2hDT0xUekZLTEFlcGVoWlVlWGxWUmlGaHowY1hmcjdtQzMwbU05dXhiQkxzCitZck4za3hZL3FnL01qeEIyTjh1ZU92TXdiNzVwS2JUS1ZNcEZodk00Qko1ZnZ4S0prYml2SDNwdTZDMVp5WkoKaUhPQVBYY2cvbzVrMFgreHZjanphNUxkTVNnZFdNK1NJVm81bnpmMEd1RCtqM3NJMldXdC9vd09RZTZPRkNJOQpZRElHWFdrWHhCM2tINGVtVjk1THdnaWFsMXpJV1JNQ0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNUzR4T1RHQ1BISjNMVGRrT0dSbVpEWTNMVGxoWVRZdE5EQmsKT0MwNVl6TTFMV1EwWldJNU1XRTNPR1U1Tnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzlXakljRQp3S2dCL29jRU01NkR2ekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBZFkxcDNYSi94QzRxeGZQRDBuNk1JV05HCitLaEhFdHBUUzlCNzBxRVhaRkhvaGNFRFROZTBON0dBR2tZdWF1TlMwWENCKzNJdzVQbVBRZjBqT2FxQTZiTW4KU1RTK1o2MFBLYytQQjFEbDVabkt5cy9sdks2OFZVTjcyN3BwQ3RmdmNMNmZJTnliZFhUNWdjSDRVK1RhNnJwYwp0ZXoyK2s1NVo4SEo1N1NsamR4eU4vNFIrRjlNM1BXaEFkQnlxZUlxRXNWR084N1llVk9Vb2JpT0lZc0lIWTloClNQUW9pa01jZk1wQStKbG5xRjYveHhnSFlPd1U2SklXNzF6UVNBVWJleWJjNndOK0d6L2E5d2NpK1AxajdhcFkKUTIxRmhCYUFwR0VaVVFLUWFmc29PWFZWZ09idG9BS0Q3SCsvMzdUKzRrWW4yaDk2bGNiUmlWRUljWGFyTFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "966"
+      - "1889"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 15:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2124,7 +2124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 109fdb67-b563-4e5c-ad4e-bb00cbb0d066
+      - 5c0d6f81-c3b4-4ab1-a766-c1e2899c9bec
     status: 200 OK
     code: 200
     duration: ""
@@ -2135,19 +2135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/caa010cd-8c5a-4afc-9a78-63dda87e714b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/6f34a4e4-07b7-49ca-8003-6ad98917ae5e
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:02:03.927209Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"caa010cd-8c5a-4afc-9a78-63dda87e714b","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:02:03.927209Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-16T15:55:14.769886Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"6f34a4e4-07b7-49ca-8003-6ad98917ae5e","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-16T15:55:14.769886Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2157,7 +2157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43725f18-1e20-4bd4-9d52-6cac4fb4772e
+      - 7f02c416-71b6-4d83-8cf1-2c0003f408fe
     status: 200 OK
     code: 200
     duration: ""
@@ -2168,19 +2168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1962"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2190,7 +2190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a62088dc-4d76-4be6-b035-6d79f096143d
+      - ca68f95d-e596-49e0-b608-6b9d6ecb6279
     status: 200 OK
     code: 200
     duration: ""
@@ -2201,7 +2201,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/caa010cd-8c5a-4afc-9a78-63dda87e714b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/6f34a4e4-07b7-49ca-8003-6ad98917ae5e
     method: DELETE
   response:
     body: ""
@@ -2211,7 +2211,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:08 GMT
+      - Thu, 16 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2221,7 +2221,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7611484b-410d-4778-bf71-9befa88d9c79
+      - 5048ac13-8ca3-4a7c-96b1-02a96e69fbdd
     status: 204 No Content
     code: 204
     duration: ""
@@ -2232,19 +2232,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1962"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:08 GMT
+      - Thu, 16 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2254,7 +2254,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24ea96c3-a343-4d66-9107-9e1f9d5a5dfc
+      - 64e3fd5f-29b4-4204-8f6e-08511ad7f3bf
     status: 200 OK
     code: 200
     duration: ""
@@ -2265,19 +2265,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/0bed21f9-1668-46d6-8498-0cb446a38bbd
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"ready","updated_at":"2023-11-02T18:59:15.588067Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"ready","updated_at":"2023-11-16T15:52:27.282645Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:08 GMT
+      - Thu, 16 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2287,7 +2287,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21362d06-ac47-40be-a8c0-186873ac9b9b
+      - d362d468-cb01-4af9-b6d9-060090fab43e
     status: 200 OK
     code: 200
     duration: ""
@@ -2298,19 +2298,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:08 GMT
+      - Thu, 16 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2320,7 +2320,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c13c2cd-92b8-4857-a910-c3f8701e7b55
+      - 6d7e5f1e-8999-43d4-999b-582682205037
     status: 200 OK
     code: 200
     duration: ""
@@ -2331,7 +2331,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/0bed21f9-1668-46d6-8498-0cb446a38bbd?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -2341,7 +2341,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:08 GMT
+      - Thu, 16 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2351,7 +2351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5db8eae-8e81-47ec-93e4-de010931a7f2
+      - a41443ad-bb3b-4eec-a694-5d8d951a4352
     status: 204 No Content
     code: 204
     duration: ""
@@ -2362,19 +2362,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:08 GMT
+      - Thu, 16 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2384,7 +2384,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 832c3f0e-f63e-40ad-9d02-b29429483f2b
+      - 6d81b47c-6013-4ddb-b356-26d3ec3111ad
     status: 200 OK
     code: 200
     duration: ""
@@ -2395,19 +2395,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/0bed21f9-1668-46d6-8498-0cb446a38bbd
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T18:59:08.412434Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T18:59:00.858700Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:00.858700Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","ipam_config":null,"mac_address":"02:00:00:11:E4:7A","private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","status":"detaching","updated_at":"2023-11-02T19:02:08.326586Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T15:52:17.605329Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T15:52:10.392443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"317cfabe-4cd7-4d20-bf34-f02382122edb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:10.392443Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","ipam_config":null,"mac_address":"02:00:00:11:F7:AA","private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","status":"detaching","updated_at":"2023-11-16T15:55:18.567607Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "970"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:08 GMT
+      - Thu, 16 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2417,7 +2417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3249ecb0-f677-4c50-a528-bd526ad024eb
+      - 3bc5d3d8-53a4-45fe-a2a1-d5f7b1e63869
     status: 200 OK
     code: 200
     duration: ""
@@ -2430,19 +2430,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:08 GMT
+      - Thu, 16 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2452,7 +2452,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 899d0e9f-f389-411e-a463-dd4b291692ce
+      - b2b6fccd-c72f-415e-979c-79757bd3be51
     status: 200 OK
     code: 200
     duration: ""
@@ -2463,19 +2463,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:08 GMT
+      - Thu, 16 Nov 2023 15:55:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2485,7 +2485,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ad98245-c483-4855-ab1a-8e2bd01da213
+      - 9d8710b5-468b-43fa-a448-73278d6ad1c5
     status: 200 OK
     code: 200
     duration: ""
@@ -2496,7 +2496,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/107453ea-e500-4318-ad8e-04cc72f93b76
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/88cc715f-67d8-4783-a28a-78b1dbbe0781
     method: DELETE
   response:
     body: ""
@@ -2506,7 +2506,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:08 GMT
+      - Thu, 16 Nov 2023 15:55:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2516,7 +2516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7edbd3f8-ab1d-4d85-abfd-20297e172313
+      - 3f3c26c9-f662-4fcf-b672-8456d9e55956
     status: 204 No Content
     code: 204
     duration: ""
@@ -2527,19 +2527,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"107453ea-e500-4318-ad8e-04cc72f93b76","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"0fc899b5-fd8e-408d-91d8-d0c477185680","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"88cc715f-67d8-4783-a28a-78b1dbbe0781","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"34efb194-d086-4064-b419-2f4d354f51ce","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1459"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:09 GMT
+      - Thu, 16 Nov 2023 15:55:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2549,7 +2549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c9f43ba-43eb-499a-8592-07e510da6d71
+      - 2ad9fc40-2d32-402b-95df-dc699e0627ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2560,10 +2560,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f986ba83-b9cb-488c-bb74-f8dc20370bbc
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/0bed21f9-1668-46d6-8498-0cb446a38bbd
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"f986ba83-b9cb-488c-bb74-f8dc20370bbc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"0bed21f9-1668-46d6-8498-0cb446a38bbd","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2572,7 +2572,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:13 GMT
+      - Thu, 16 Nov 2023 15:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2582,7 +2582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be0eebd2-e656-482b-b6c9-8d2dd273bda6
+      - b1e2acb7-fa04-4250-91f8-1dd2faaaeea8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2593,19 +2593,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "937"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:13 GMT
+      - Thu, 16 Nov 2023 15:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2615,7 +2615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91c02283-aa21-4c9e-9fb7-39519ce5fcce
+      - 5f9bf894-29e4-4e8e-8aa2-b9421e726418
     status: 200 OK
     code: 200
     duration: ""
@@ -2626,10 +2626,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/f664ab2c-301f-4cbd-9d28-cf56fe37db7d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/317cfabe-4cd7-4d20-bf34-f02382122edb
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"f664ab2c-301f-4cbd-9d28-cf56fe37db7d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"317cfabe-4cd7-4d20-bf34-f02382122edb","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -2638,7 +2638,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:13 GMT
+      - Thu, 16 Nov 2023 15:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2648,7 +2648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38f0e63a-061a-4764-9dc7-7f2c3b38a09c
+      - 8c451c3c-2188-40c3-8b9f-983baa14ddce
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2659,19 +2659,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T18:59:01.565830Z","gateway_networks":[],"id":"95a53bae-54e0-4384-8790-ba31b580b6af","ip":{"address":"51.15.76.243","created_at":"2023-11-02T18:59:01.365556Z","gateway_id":"95a53bae-54e0-4384-8790-ba31b580b6af","id":"97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"243-76-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T18:59:01.365556Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T18:59:15.699390Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T15:52:11.260711Z","gateway_networks":[],"id":"8f1f27a7-161d-47da-9596-3badf890ca97","ip":{"address":"51.15.85.121","created_at":"2023-11-16T15:52:11.027882Z","gateway_id":"8f1f27a7-161d-47da-9596-3badf890ca97","id":"20691f3b-2fe1-420e-8b12-a50fe77c594e","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"121-85-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T15:52:11.027882Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T15:52:27.402102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "937"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:13 GMT
+      - Thu, 16 Nov 2023 15:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2681,7 +2681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fa8de67-0b39-45af-879a-eae6766a6043
+      - baea9b4d-8472-496f-b3f4-bd56c4ea95d8
     status: 200 OK
     code: 200
     duration: ""
@@ -2692,7 +2692,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -2702,7 +2702,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:13 GMT
+      - Thu, 16 Nov 2023 15:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2712,7 +2712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bd40f51-ece9-4b97-9b6c-cf1baa434d70
+      - d0fa1699-3d84-4e9f-bdb1-f282d18f7951
     status: 204 No Content
     code: 204
     duration: ""
@@ -2723,10 +2723,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/95a53bae-54e0-4384-8790-ba31b580b6af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/8f1f27a7-161d-47da-9596-3badf890ca97
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"95a53bae-54e0-4384-8790-ba31b580b6af","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"8f1f27a7-161d-47da-9596-3badf890ca97","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2735,7 +2735,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:13 GMT
+      - Thu, 16 Nov 2023 15:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2745,7 +2745,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb552811-aaea-4df7-8627-85dbbcfaff52
+      - 7bbd3470-d26a-4424-a955-6cb88148f198
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2756,7 +2756,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/97ff5f3c-8e8a-4198-aaf5-b6b6d5a38f7e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/20691f3b-2fe1-420e-8b12-a50fe77c594e
     method: DELETE
   response:
     body: ""
@@ -2766,7 +2766,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:14 GMT
+      - Thu, 16 Nov 2023 15:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2776,7 +2776,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - debb9c30-9c94-4485-aac7-e398714f5a56
+      - 3b02b3e7-2730-4e5b-aa67-3e21865ceb1b
     status: 204 No Content
     code: 204
     duration: ""
@@ -2787,19 +2787,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1279"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:39 GMT
+      - Thu, 16 Nov 2023 15:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2809,7 +2809,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93da8eed-57cf-456b-8e41-c28efd5701e7
+      - 5defadda-f796-4e1c-b6e8-c2282182b4bf
     status: 200 OK
     code: 200
     duration: ""
@@ -2820,19 +2820,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1279"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:39 GMT
+      - Thu, 16 Nov 2023 15:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2842,7 +2842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d1ea08e-2882-4ef3-b455-759e8e18f6c3
+      - 051e5c21-2fa6-43f2-8c58-b7f05ae29a0d
     status: 200 OK
     code: 200
     duration: ""
@@ -2853,19 +2853,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVWnVBWFRNTEpxOExXZ3VHRVE0dExhdXdlUVZNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEF5TVRrd01ERXdXaGNOTXpNeE1ETXdNVGt3TURFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBDSGVseFVmUG9hQlRZSHFUbzEvR1cxaVhKay9MczhlUkJrR2daL0RhdEVrMEN4bkJYaUI2SjkKNXNsQVhwSUdBd2xOK29TWDJVK1BpK1NUcFBTQzJheU9NenFNczRpbVd1ckhoamR3WmNVd0hqTnplc1JHS05VagppcEJlcVBDbHk0Uy8yNHhUaWFlTUdwWFdqTlNtb1hNc3BXNG90aGNpd0FlejV0T0RCTkZsN2cvd3lUNVczSnJPCjhULzNmMzErbHkwVlZETHlHNnI3bG1DY3FVWnNWSDhIT3VSN0pLcnYwTjBjWmlQTVhXZnAwbEpqWDlhK2xmb0IKeTg4ZmRRbUJEMytVTThNRFBEVExHTWxDOW5OQ054YzJhcUVNQXlKRFhLbWFwUHdteFFBMElWT1VMNjNQTTdWbwpIaWFMcllNZVExUU4wLzNvVlNCMXNVWWRXL09MaFE4Q0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNQzR5TURLQ1BISjNMVE14TlRJd05XSTBMVFUyTVdFdE5EWmwKTnkxaE5qazFMV1ptWTJFeE5USTFaR0U0TkM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzljZW9jRQp3S2dCL29jRU01NkN5akFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBdGphYW5WRjJyaGVSYlhiSm8xSUoyUk9FClFiLzVKVjJvclpTMVA5V0Z5MEd5dDZXNWV3QzJqSTBxQzZxK0Vya3lXNVg2VzlHTk9JNnc3QUtPQmhtSFYza3EKQm9IZjlYVjZ0ZVI4SkxFbnlLODUrQWN2RUxyQXBTczAwZlcwOEhkQ2NPUGNxeFpIRUUxcHZ0RlZuckV2NE0vMwoxYzhVcFVNT0F6Ri9PQnRDWnRYUXVTTEpjS3NCNDNDRVZ3SklydFQzTjhvdlJmVUk3dTlyUk5zcHJ6eE4xZytuCk53YzhGUzR1QnVZTDJpRE5NWU1YNGk3NHgzTm0zakF3OUZTK24yZ2xRQ1dPeEFTTGt3R2xwQzRiSjZkdkhyQjcKWlZKSlFORnM2V3FXajd2YUtsNGtjcUQ4Wis2QTJlNnNTTWRILzgwZlk5OGRpUTdPVk8wb21tNjlzcTZrZXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVYnlSZzh6bjNxbnMyRVpsV3MyWkxCcjJvWlo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEUyTVRVMU5EVTNXaGNOTXpNeE1URXpNVFUxTkRVM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxRSkhFNE55ZnpRZ3B5YytBcHJDODBUSzF1MU5iMkRycGMvVzd1aUFYeE9UamVCQkdZNmYzMlIKSEVtMlF0cHI0Zk4wQ2VYU1ZFNWhFVDVhU2krUDNQampVK0ZuQ0UrMWxTdHo4ZFhlelE2RFYzRWNNNUtVUjVBRgpIWHZVbytOUm52U1Evcmp5WTR1U2hDT0xUekZLTEFlcGVoWlVlWGxWUmlGaHowY1hmcjdtQzMwbU05dXhiQkxzCitZck4za3hZL3FnL01qeEIyTjh1ZU92TXdiNzVwS2JUS1ZNcEZodk00Qko1ZnZ4S0prYml2SDNwdTZDMVp5WkoKaUhPQVBYY2cvbzVrMFgreHZjanphNUxkTVNnZFdNK1NJVm81bnpmMEd1RCtqM3NJMldXdC9vd09RZTZPRkNJOQpZRElHWFdrWHhCM2tINGVtVjk1THdnaWFsMXpJV1JNQ0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNUzR4T1RHQ1BISjNMVGRrT0dSbVpEWTNMVGxoWVRZdE5EQmsKT0MwNVl6TTFMV1EwWldJNU1XRTNPR1U1Tnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzlXakljRQp3S2dCL29jRU01NkR2ekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBZFkxcDNYSi94QzRxeGZQRDBuNk1JV05HCitLaEhFdHBUUzlCNzBxRVhaRkhvaGNFRFROZTBON0dBR2tZdWF1TlMwWENCKzNJdzVQbVBRZjBqT2FxQTZiTW4KU1RTK1o2MFBLYytQQjFEbDVabkt5cy9sdks2OFZVTjcyN3BwQ3RmdmNMNmZJTnliZFhUNWdjSDRVK1RhNnJwYwp0ZXoyK2s1NVo4SEo1N1NsamR4eU4vNFIrRjlNM1BXaEFkQnlxZUlxRXNWR084N1llVk9Vb2JpT0lZc0lIWTloClNQUW9pa01jZk1wQStKbG5xRjYveHhnSFlPd1U2SklXNzF6UVNBVWJleWJjNndOK0d6L2E5d2NpK1AxajdhcFkKUTIxRmhCYUFwR0VaVVFLUWFmc29PWFZWZ09idG9BS0Q3SCsvMzdUKzRrWW4yaDk2bGNiUmlWRUljWGFyTFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1887"
+      - "1889"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:39 GMT
+      - Thu, 16 Nov 2023 15:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2875,7 +2875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaf5e6de-3729-4bad-92f0-1b1bf852e5a8
+      - b48931a2-a56c-489d-b121-9468d4ed96ec
     status: 200 OK
     code: 200
     duration: ""
@@ -2886,19 +2886,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/0fc899b5-fd8e-408d-91d8-d0c477185680
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/34efb194-d086-4064-b419-2f4d354f51ce
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:59:00.881462Z","dhcp_enabled":true,"id":"0fc899b5-fd8e-408d-91d8-d0c477185680","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T18:59:00.881462Z","id":"a739db4b-6d5c-408e-ae89-80c252c0961f","subnet":"192.168.1.0/24","updated_at":"2023-11-02T18:59:07.391460Z"},{"created_at":"2023-11-02T18:59:00.881462Z","id":"be07ed5e-b85b-4c20-80e1-2012ddce8863","subnet":"fd68:d440:21c4:a8a7::/64","updated_at":"2023-11-02T18:59:07.394943Z"}],"tags":[],"updated_at":"2023-11-02T19:02:08.539167Z","vpc_id":"1633022c-3fa1-431a-b398-1c67551e922c"}'
+    body: '{"created_at":"2023-11-16T15:52:10.392929Z","dhcp_enabled":true,"id":"34efb194-d086-4064-b419-2f4d354f51ce","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T15:52:10.392929Z","id":"e7bf9686-1bcb-4537-92bb-dec9104b9af2","subnet":"192.168.1.0/24","updated_at":"2023-11-16T15:52:17.118596Z"},{"created_at":"2023-11-16T15:52:10.392929Z","id":"ed0972d9-734c-4a86-8ac1-e27d65ccc2ac","subnet":"fd68:d440:21c4:9399::/64","updated_at":"2023-11-16T15:52:17.124107Z"}],"tags":[],"updated_at":"2023-11-16T15:55:18.729443Z","vpc_id":"80a539c1-ab6a-4f2f-990a-f49337efb722"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:39 GMT
+      - Thu, 16 Nov 2023 15:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2908,7 +2908,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 705f449e-8971-45e5-9857-23b1093d0a1f
+      - e4f90f1d-40fb-4a6c-9922-34b6182ef71d
     status: 200 OK
     code: 200
     duration: ""
@@ -2919,19 +2919,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1279"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:39 GMT
+      - Thu, 16 Nov 2023 15:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2941,7 +2941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fdca7cdb-18a3-4c53-9633-bee543947e33
+      - 810b9bb6-902e-4e97-a704-77bf6f9b1882
     status: 200 OK
     code: 200
     duration: ""
@@ -2952,19 +2952,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVWnVBWFRNTEpxOExXZ3VHRVE0dExhdXdlUVZNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEF5TVRrd01ERXdXaGNOTXpNeE1ETXdNVGt3TURFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBDSGVseFVmUG9hQlRZSHFUbzEvR1cxaVhKay9MczhlUkJrR2daL0RhdEVrMEN4bkJYaUI2SjkKNXNsQVhwSUdBd2xOK29TWDJVK1BpK1NUcFBTQzJheU9NenFNczRpbVd1ckhoamR3WmNVd0hqTnplc1JHS05VagppcEJlcVBDbHk0Uy8yNHhUaWFlTUdwWFdqTlNtb1hNc3BXNG90aGNpd0FlejV0T0RCTkZsN2cvd3lUNVczSnJPCjhULzNmMzErbHkwVlZETHlHNnI3bG1DY3FVWnNWSDhIT3VSN0pLcnYwTjBjWmlQTVhXZnAwbEpqWDlhK2xmb0IKeTg4ZmRRbUJEMytVTThNRFBEVExHTWxDOW5OQ054YzJhcUVNQXlKRFhLbWFwUHdteFFBMElWT1VMNjNQTTdWbwpIaWFMcllNZVExUU4wLzNvVlNCMXNVWWRXL09MaFE4Q0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNQzR5TURLQ1BISjNMVE14TlRJd05XSTBMVFUyTVdFdE5EWmwKTnkxaE5qazFMV1ptWTJFeE5USTFaR0U0TkM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzljZW9jRQp3S2dCL29jRU01NkN5akFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBdGphYW5WRjJyaGVSYlhiSm8xSUoyUk9FClFiLzVKVjJvclpTMVA5V0Z5MEd5dDZXNWV3QzJqSTBxQzZxK0Vya3lXNVg2VzlHTk9JNnc3QUtPQmhtSFYza3EKQm9IZjlYVjZ0ZVI4SkxFbnlLODUrQWN2RUxyQXBTczAwZlcwOEhkQ2NPUGNxeFpIRUUxcHZ0RlZuckV2NE0vMwoxYzhVcFVNT0F6Ri9PQnRDWnRYUXVTTEpjS3NCNDNDRVZ3SklydFQzTjhvdlJmVUk3dTlyUk5zcHJ6eE4xZytuCk53YzhGUzR1QnVZTDJpRE5NWU1YNGk3NHgzTm0zakF3OUZTK24yZ2xRQ1dPeEFTTGt3R2xwQzRiSjZkdkhyQjcKWlZKSlFORnM2V3FXajd2YUtsNGtjcUQ4Wis2QTJlNnNTTWRILzgwZlk5OGRpUTdPVk8wb21tNjlzcTZrZXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVYnlSZzh6bjNxbnMyRVpsV3MyWkxCcjJvWlo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEUyTVRVMU5EVTNXaGNOTXpNeE1URXpNVFUxTkRVM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxRSkhFNE55ZnpRZ3B5YytBcHJDODBUSzF1MU5iMkRycGMvVzd1aUFYeE9UamVCQkdZNmYzMlIKSEVtMlF0cHI0Zk4wQ2VYU1ZFNWhFVDVhU2krUDNQampVK0ZuQ0UrMWxTdHo4ZFhlelE2RFYzRWNNNUtVUjVBRgpIWHZVbytOUm52U1Evcmp5WTR1U2hDT0xUekZLTEFlcGVoWlVlWGxWUmlGaHowY1hmcjdtQzMwbU05dXhiQkxzCitZck4za3hZL3FnL01qeEIyTjh1ZU92TXdiNzVwS2JUS1ZNcEZodk00Qko1ZnZ4S0prYml2SDNwdTZDMVp5WkoKaUhPQVBYY2cvbzVrMFgreHZjanphNUxkTVNnZFdNK1NJVm81bnpmMEd1RCtqM3NJMldXdC9vd09RZTZPRkNJOQpZRElHWFdrWHhCM2tINGVtVjk1THdnaWFsMXpJV1JNQ0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNUzR4T1RHQ1BISjNMVGRrT0dSbVpEWTNMVGxoWVRZdE5EQmsKT0MwNVl6TTFMV1EwWldJNU1XRTNPR1U1Tnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzlXakljRQp3S2dCL29jRU01NkR2ekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBZFkxcDNYSi94QzRxeGZQRDBuNk1JV05HCitLaEhFdHBUUzlCNzBxRVhaRkhvaGNFRFROZTBON0dBR2tZdWF1TlMwWENCKzNJdzVQbVBRZjBqT2FxQTZiTW4KU1RTK1o2MFBLYytQQjFEbDVabkt5cy9sdks2OFZVTjcyN3BwQ3RmdmNMNmZJTnliZFhUNWdjSDRVK1RhNnJwYwp0ZXoyK2s1NVo4SEo1N1NsamR4eU4vNFIrRjlNM1BXaEFkQnlxZUlxRXNWR084N1llVk9Vb2JpT0lZc0lIWTloClNQUW9pa01jZk1wQStKbG5xRjYveHhnSFlPd1U2SklXNzF6UVNBVWJleWJjNndOK0d6L2E5d2NpK1AxajdhcFkKUTIxRmhCYUFwR0VaVVFLUWFmc29PWFZWZ09idG9BS0Q3SCsvMzdUKzRrWW4yaDk2bGNiUmlWRUljWGFyTFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1887"
+      - "1889"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:40 GMT
+      - Thu, 16 Nov 2023 15:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2974,7 +2974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85f28416-bb82-41a2-907f-0375ac4d760d
+      - ac8635a5-5176-43e5-b417-54c435110f69
     status: 200 OK
     code: 200
     duration: ""
@@ -2985,19 +2985,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1279"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:40 GMT
+      - Thu, 16 Nov 2023 15:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3007,7 +3007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0612154-6488-4fcb-a091-991a94724272
+      - 9a325710-8a45-4ed7-985a-af668dbc50bd
     status: 200 OK
     code: 200
     duration: ""
@@ -3018,7 +3018,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/0fc899b5-fd8e-408d-91d8-d0c477185680
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
+    method: DELETE
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1282"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:55:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5a68c7de-782b-4905-b4b0-861c0b2b1891
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/34efb194-d086-4064-b419-2f4d354f51ce
     method: DELETE
   response:
     body: ""
@@ -3028,7 +3061,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:40 GMT
+      - Thu, 16 Nov 2023 15:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3038,7 +3071,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f4e533a-5a91-4410-ad3d-12a62bc72c6e
+      - e98ce1df-5701-491d-b9e3-81e5efff682d
     status: 204 No Content
     code: 204
     duration: ""
@@ -3049,19 +3082,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
-    method: DELETE
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
+    method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:11.303323Z","endpoint":{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218},"endpoints":[{"id":"1243a695-982d-41b6-bf75-612d251fdec2","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1218}],"engine":"PostgreSQL-15","id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1235"
+      - "1282"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:40 GMT
+      - Thu, 16 Nov 2023 15:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3071,7 +3104,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7cbadc9-8628-4716-8a4a-ad4c7064d108
+      - 246c1f73-9805-478c-b377-9f1a4424b637
     status: 200 OK
     code: 200
     duration: ""
@@ -3082,43 +3115,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:59:01.961755Z","endpoint":{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510},"endpoints":[{"id":"ba5e77a4-1be9-4b89-ba05-dd715bc3eba7","ip":"51.158.130.202","load_balancer":{},"name":null,"port":19510}],"engine":"PostgreSQL-15","id":"315205b4-561a-46e7-a695-ffca1525da84","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1235"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 19:02:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3ce97740-0185-49e8-a300-85a59ca1ed38
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"315205b4-561a-46e7-a695-ffca1525da84","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3127,7 +3127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:11 GMT
+      - Thu, 16 Nov 2023 15:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3137,7 +3137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8a848c2-082d-4b7f-b53a-0ef1170e9c61
+      - e75afe3e-9088-4ee4-8ef4-aa02445a4f52
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3148,10 +3148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/315205b4-561a-46e7-a695-ffca1525da84
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"315205b4-561a-46e7-a695-ffca1525da84","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"7d8dfd67-9aa6-40d8-9c35-d4eb91a78e97","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3160,7 +3160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:11 GMT
+      - Thu, 16 Nov 2023 15:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3170,7 +3170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79a20325-90c3-4346-bab1-19e159f54ed2
+      - 41901b0c-eb33-4668-9c56-5a37ea20e78d
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network-update.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network-update.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:34 GMT
+      - Thu, 16 Nov 2023 15:52:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7792c2b1-9719-4722-996e-0c710d5448f9
+      - abd17219-3c54-47c8-b6df-3abd5ba354a3
     status: 200 OK
     code: 200
     duration: ""
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:01:36.797044Z","dhcp_enabled":true,"id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:36.797044Z","id":"b4f26e69-5385-4845-9f62-eba27ada06ce","subnet":"172.16.24.0/22","updated_at":"2023-11-16T16:01:36.797044Z"},{"created_at":"2023-11-16T16:01:36.797044Z","id":"bfe8198d-37e2-4838-84e5-091c9ee4e7dd","subnet":"fd63:256c:45f7:b55c::/64","updated_at":"2023-11-16T16:01:36.797044Z"}],"tags":[],"updated_at":"2023-11-16T16:01:36.797044Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "701"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:15 GMT
+      - Thu, 16 Nov 2023 16:01:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2681a710-3796-4938-b9c8-68bbf12f74e1
+      - 471f1860-e0ee-478b-8343-3a94bbaa5301
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1c98c5c-2f7e-4b31-a5d3-df959a4396cd
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:01:36.797044Z","dhcp_enabled":true,"id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:36.797044Z","id":"b4f26e69-5385-4845-9f62-eba27ada06ce","subnet":"172.16.24.0/22","updated_at":"2023-11-16T16:01:36.797044Z"},{"created_at":"2023-11-16T16:01:36.797044Z","id":"bfe8198d-37e2-4838-84e5-091c9ee4e7dd","subnet":"fd63:256c:45f7:b55c::/64","updated_at":"2023-11-16T16:01:36.797044Z"}],"tags":[],"updated_at":"2023-11-16T16:01:36.797044Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "701"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:15 GMT
+      - Thu, 16 Nov 2023 16:01:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3f963f1-33dc-4614-9d17-4451a9afac8e
+      - 1f07373d-50f2-45ab-b699-4a4cfd313160
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1c98c5c-2f7e-4b31-a5d3-df959a4396cd
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:01:36.797044Z","dhcp_enabled":true,"id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:36.797044Z","id":"b4f26e69-5385-4845-9f62-eba27ada06ce","subnet":"172.16.24.0/22","updated_at":"2023-11-16T16:01:36.797044Z"},{"created_at":"2023-11-16T16:01:36.797044Z","id":"bfe8198d-37e2-4838-84e5-091c9ee4e7dd","subnet":"fd63:256c:45f7:b55c::/64","updated_at":"2023-11-16T16:01:36.797044Z"}],"tags":[],"updated_at":"2023-11-16T16:01:36.797044Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "701"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:15 GMT
+      - Thu, 16 Nov 2023 16:01:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 246bf86b-6178-4dc9-b56a-441eb59ee418
+      - f2fe51bd-91ec-45ef-b55b-f9936b8b8334
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1c98c5c-2f7e-4b31-a5d3-df959a4396cd
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:01:36.797044Z","dhcp_enabled":true,"id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:36.797044Z","id":"b4f26e69-5385-4845-9f62-eba27ada06ce","subnet":"172.16.24.0/22","updated_at":"2023-11-16T16:01:36.797044Z"},{"created_at":"2023-11-16T16:01:36.797044Z","id":"bfe8198d-37e2-4838-84e5-091c9ee4e7dd","subnet":"fd63:256c:45f7:b55c::/64","updated_at":"2023-11-16T16:01:36.797044Z"}],"tags":[],"updated_at":"2023-11-16T16:01:36.797044Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "701"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:16 GMT
+      - Thu, 16 Nov 2023 16:01:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,12 +462,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1dded89-861a-4ee8-8f43-d3467f5f18b3
+      - 7a086ffd-feab-4186-8a7a-e2777d59723b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","ipam_config":{}}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","ipam_config":{}}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -478,16 +478,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":null,"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:18 GMT
+      - Thu, 16 Nov 2023 16:01:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 887c7204-f1d0-4e51-874c-cccbc5054c18
+      - 11a2d40f-eded-40f2-bf11-9c1f8cf47013
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":null,"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:18 GMT
+      - Thu, 16 Nov 2023 16:01:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec605c69-52dd-4991-8815-53d1006ff81d
+      - 2c119097-ccd5-4a1d-93ad-5f76384649c7
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":null,"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:49 GMT
+      - Thu, 16 Nov 2023 16:02:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ba2c34e-5ec8-4959-8309-492157b0b804
+      - edca82f6-e581-49cf-83be-fe37a33318f8
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":null,"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:19 GMT
+      - Thu, 16 Nov 2023 16:02:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f575401-e3ca-41f6-99e3-a9ba963de557
+      - 5e1f2b9d-5dc5-4a07-9f27-2e366663de4b
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":null,"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:49 GMT
+      - Thu, 16 Nov 2023 16:03:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a7c21f3-9b87-4ae1-82fd-cb5c1c9fa7ea
+      - 3a008dfc-f00c-4df1-8a1d-21ca4f0dea33
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":null,"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:19 GMT
+      - Thu, 16 Nov 2023 16:03:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5109a24-c577-4e65-86ae-e24b104998a4
+      - 91d48011-335b-4197-9d19-c607b3b741cb
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":null,"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":null,"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:49 GMT
+      - Thu, 16 Nov 2023 16:04:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c7a5e29-7fa2-4166-8608-c1166be22025
+      - 459406dd-64ac-42d3-a2d4-ed844ccc43b3
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":null,"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1447"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:19 GMT
+      - Thu, 16 Nov 2023 16:04:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a07629d6-a584-47e2-b9a7-ef1eff24aa98
+      - cd6fdaa2-f991-4b70-a509-a81a58acfb33
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVUUswK3dOR2w4UEtTeGpxYU1jV1ZiNzRUTzdvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXdNakU0TlRVeU9Wb1hEVE16TVRBek1ERTROVFV5T1Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF3VDF4OHNKaVk5TVBtaGZBUklISnlsK2xRTVV1SnJhTVJ1eTRJVmMzYnlSdFVtbGRNUHlTeUlBaW51ZlYKdDRIZFFMWHNHNkkvYkZ3Y084SGJTclBMN01nRS8vbnVFSXBTRlZsSCttZWtuMXdyS0ZiVEtmU01RN0NJbkJDYQpKVVJveXh4SjhqYXJnYlhzZFM4VEhOVm13amdIQlZyRVlROFFjdGFzajFidWVlVXBSSWVoVHR1NXFLRVk0V1c4CnI4aGJHNVphcm04OXRPbWZyN3hZckxUR2NTekQ4TXY1RGkxKzNPbmtMSFZZQWRQOHd0QmVtaFFTS2ZrRXZ5SUgKaS9VT0NQVTNwQjdtUHowQ1hlK1h6eHBybUVHakpzZHIxUllVOWpyeEJuc3pweGhqVkxQS25Pdk5ROURnN0ZLcwpzUGhuZ1hkV0t3ZDRjbkNaSDZoV3JpQWVpd0lEQVFBQm8za3dkekIxQmdOVkhSRUViakJzZ2dzeE56SXVNVFl1Ck16SXVNb0lOTlRFdU1UVTVMakV3TGpJeE00SThjbmN0TWpJeVpXSTBaRE10TXprd05DMDBZbVpoTFRneE56Z3QKWkRBMk5UQTBNekkzTWpaaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3U3NFQ0FDaHdRegpud3JWTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTldldDliMlB4emFEaStyNm8xQTBLb21pUWVkWSt3OGNpCndEaGJKWkoxL0xGRTJQSnpSVjdWT0tFYklWbmE2eHdXaXNhRE9sNnlsQmZVR3BXdmVSWkF2VWhXTUdlTEd0UXoKNHR1cFJUckE0Z2Joem5YSkgzY01RUlkyb3JuL2orU2Raa1pDRS9nN2NmNko4QlJUalVvV0thWmprVEY5d1BlUApIYU1NZ25BMUJ4L2JCcVhSTGVoZHJtRW8rY01DN1hDcjVxODNTTThvM2hObG5vNERvdmRqSkw4bktTT2YvaWlzCjNaL1hTTHA0L2pna2FhL0VuZXlOWWlFR3E1eFN3OG5YUEcvNmpwZlpLdktYSjU3Z0prRk5qZlZYQ2NsRUx3T28KRHZ1d0JlbzVJa0NUVzBJU0NXZlhZZ2thcEwzQ0pVODdMWm4vcUdNQllsdWxPK1dwTTY4QwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":null,"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1871"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:20 GMT
+      - Thu, 16 Nov 2023 16:05:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39829dd5-ce30-413f-99cc-970e4a04d017
+      - 558dc1d2-73a1-462a-b236-00af899b769a
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1447"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:20 GMT
+      - Thu, 16 Nov 2023 16:05:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0189b10a-32d4-489a-936f-32ccfcb01fc6
+      - 89c5dfd1-42c6-424c-b12d-0dc980e61be1
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3/certificate
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVGlPTDZpU2FaZHErcGdlUVdjeU1BbXpna1Rvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEl6Ck1URXhOakUyTURVd01Wb1hEVE16TVRFeE16RTJNRFV3TVZvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUEvTTFlSXNlODAyYjNiZEppV3RDS29nOU1mR0wzRnNURXlaUzRMd004bE9nR1VGVFJtT0ZMMkhPNitCc0MKdXFhcVJ1dHJRcDc1c2ZxVm4xdHRHbzFTclowa0U4c3JTZktRRlhqRm1xZ1VjOHhKbG5wWjdEMFplR05xenljVQpVMEI1cE5jWHJacWo0QndsVXI4NGhaSHZVVWlrWkk5TVhuZVFpeEUrNlUrcEx6TTNPbm5WK1NQSFkyS3N3MXV6Ckt5bisxRSttR2oreGpHWThIZTYreEZNQU5hVENNaTVTME5yamhnaUdZRVcyRjM3TEZXYkpTczQxalVNK2E5RnQKVjNPaXVlNjg0ekhieVZIUWprRUZ6QWVDbVl3OHR4dmtkYUZTRWFTc1ZDVWZsd3ZEc0JQdFd4TjVsUGo2YS9ELwpWTjJzTXVvbW1zTzM5ajJMUmRHOHQ4UDNUd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck1qUXVNb0lPTlRFdU1UVTVMakV4TXk0eE56T0NQSEozTFdaaE5XWmpPVEptTFdKaE5qSXROREZoTkMxaFlqa3cKTFdSbE16RmtaakkxTldObU15NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFTXcrREtvY0VyQkFZQW9jRQpNNTl4clRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQXV1MVFpNlRWVTdrdXFJUWpNc0Z4R0doeno1Wm9ISmJZClY0QW9qZFVuVFhvbk9yNmhFa1NKLzB5YjV3bU5YTVZOYndqL2NPekVYcDNRbEVyUWUvdXZKY2g2R0VObnVxWEkKQ1lReENMU2JZR0ZjaU9oSEcwdTRBUFJuVjR1UCtZdlY4RjYrUFpZZzNsS2RJMmc2dERkNVFpN2l1UURXU2FpUwp4UXZZUnhKWFFhemRubVMrdERWcFcxQktIK2JLSmxhRlFGay9jcXRiYVB6SjYyMEs1bTR6U0ljaTB2ZXdFTW5XCnJTdmtkUGhxTkh6V1d2blRJTWR5RkNmUkJ3S1JHaXNCZ0l2LzVIQnVSQmJJSHZSWnp4NEVlbmx4a2xGRDd0SDMKNys2eWF0MXFML2VCa2ZLNEdtRm1nT3M4OG5YZU1hMHdNZzlrVVc2RFVaWnpyM1FPaVh1dnFnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "701"
+      - "1877"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:20 GMT
+      - Thu, 16 Nov 2023 16:05:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc023dd9-e951-4980-8b3c-7f801770318a
+      - cefb457e-95dc-47a9-b48b-37f133983cd3
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1447"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:20 GMT
+      - Thu, 16 Nov 2023 16:05:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b54c4cfe-29d5-410a-85af-c48c751c961f
+      - fd72fac7-0f1f-4425-992e-ffe02efc84e0
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1c98c5c-2f7e-4b31-a5d3-df959a4396cd
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVUUswK3dOR2w4UEtTeGpxYU1jV1ZiNzRUTzdvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXdNakU0TlRVeU9Wb1hEVE16TVRBek1ERTROVFV5T1Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF3VDF4OHNKaVk5TVBtaGZBUklISnlsK2xRTVV1SnJhTVJ1eTRJVmMzYnlSdFVtbGRNUHlTeUlBaW51ZlYKdDRIZFFMWHNHNkkvYkZ3Y084SGJTclBMN01nRS8vbnVFSXBTRlZsSCttZWtuMXdyS0ZiVEtmU01RN0NJbkJDYQpKVVJveXh4SjhqYXJnYlhzZFM4VEhOVm13amdIQlZyRVlROFFjdGFzajFidWVlVXBSSWVoVHR1NXFLRVk0V1c4CnI4aGJHNVphcm04OXRPbWZyN3hZckxUR2NTekQ4TXY1RGkxKzNPbmtMSFZZQWRQOHd0QmVtaFFTS2ZrRXZ5SUgKaS9VT0NQVTNwQjdtUHowQ1hlK1h6eHBybUVHakpzZHIxUllVOWpyeEJuc3pweGhqVkxQS25Pdk5ROURnN0ZLcwpzUGhuZ1hkV0t3ZDRjbkNaSDZoV3JpQWVpd0lEQVFBQm8za3dkekIxQmdOVkhSRUViakJzZ2dzeE56SXVNVFl1Ck16SXVNb0lOTlRFdU1UVTVMakV3TGpJeE00SThjbmN0TWpJeVpXSTBaRE10TXprd05DMDBZbVpoTFRneE56Z3QKWkRBMk5UQTBNekkzTWpaaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3U3NFQ0FDaHdRegpud3JWTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTldldDliMlB4emFEaStyNm8xQTBLb21pUWVkWSt3OGNpCndEaGJKWkoxL0xGRTJQSnpSVjdWT0tFYklWbmE2eHdXaXNhRE9sNnlsQmZVR3BXdmVSWkF2VWhXTUdlTEd0UXoKNHR1cFJUckE0Z2Joem5YSkgzY01RUlkyb3JuL2orU2Raa1pDRS9nN2NmNko4QlJUalVvV0thWmprVEY5d1BlUApIYU1NZ25BMUJ4L2JCcVhSTGVoZHJtRW8rY01DN1hDcjVxODNTTThvM2hObG5vNERvdmRqSkw4bktTT2YvaWlzCjNaL1hTTHA0L2pna2FhL0VuZXlOWWlFR3E1eFN3OG5YUEcvNmpwZlpLdktYSjU3Z0prRk5qZlZYQ2NsRUx3T28KRHZ1d0JlbzVJa0NUVzBJU0NXZlhZZ2thcEwzQ0pVODdMWm4vcUdNQllsdWxPK1dwTTY4QwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2023-11-16T16:01:36.797044Z","dhcp_enabled":true,"id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:36.797044Z","id":"b4f26e69-5385-4845-9f62-eba27ada06ce","subnet":"172.16.24.0/22","updated_at":"2023-11-16T16:01:36.797044Z"},{"created_at":"2023-11-16T16:01:36.797044Z","id":"bfe8198d-37e2-4838-84e5-091c9ee4e7dd","subnet":"fd63:256c:45f7:b55c::/64","updated_at":"2023-11-16T16:01:36.797044Z"}],"tags":[],"updated_at":"2023-11-16T16:01:36.797044Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1871"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:20 GMT
+      - Thu, 16 Nov 2023 16:05:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 872f8444-4487-42a9-b8f1-7dbcdffa7c3e
+      - 1825ff8b-d870-4652-8bfa-aea8d7b369e3
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "701"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:21 GMT
+      - Thu, 16 Nov 2023 16:05:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76640433-afac-4fd5-bc1f-4ba574abdf62
+      - 51f22769-2660-44c0-8e6b-1634e4d0c2cd
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVGlPTDZpU2FaZHErcGdlUVdjeU1BbXpna1Rvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEl6Ck1URXhOakUyTURVd01Wb1hEVE16TVRFeE16RTJNRFV3TVZvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUEvTTFlSXNlODAyYjNiZEppV3RDS29nOU1mR0wzRnNURXlaUzRMd004bE9nR1VGVFJtT0ZMMkhPNitCc0MKdXFhcVJ1dHJRcDc1c2ZxVm4xdHRHbzFTclowa0U4c3JTZktRRlhqRm1xZ1VjOHhKbG5wWjdEMFplR05xenljVQpVMEI1cE5jWHJacWo0QndsVXI4NGhaSHZVVWlrWkk5TVhuZVFpeEUrNlUrcEx6TTNPbm5WK1NQSFkyS3N3MXV6Ckt5bisxRSttR2oreGpHWThIZTYreEZNQU5hVENNaTVTME5yamhnaUdZRVcyRjM3TEZXYkpTczQxalVNK2E5RnQKVjNPaXVlNjg0ekhieVZIUWprRUZ6QWVDbVl3OHR4dmtkYUZTRWFTc1ZDVWZsd3ZEc0JQdFd4TjVsUGo2YS9ELwpWTjJzTXVvbW1zTzM5ajJMUmRHOHQ4UDNUd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck1qUXVNb0lPTlRFdU1UVTVMakV4TXk0eE56T0NQSEozTFdaaE5XWmpPVEptTFdKaE5qSXROREZoTkMxaFlqa3cKTFdSbE16RmtaakkxTldObU15NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFTXcrREtvY0VyQkFZQW9jRQpNNTl4clRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQXV1MVFpNlRWVTdrdXFJUWpNc0Z4R0doeno1Wm9ISmJZClY0QW9qZFVuVFhvbk9yNmhFa1NKLzB5YjV3bU5YTVZOYndqL2NPekVYcDNRbEVyUWUvdXZKY2g2R0VObnVxWEkKQ1lReENMU2JZR0ZjaU9oSEcwdTRBUFJuVjR1UCtZdlY4RjYrUFpZZzNsS2RJMmc2dERkNVFpN2l1UURXU2FpUwp4UXZZUnhKWFFhemRubVMrdERWcFcxQktIK2JLSmxhRlFGay9jcXRiYVB6SjYyMEs1bTR6U0ljaTB2ZXdFTW5XCnJTdmtkUGhxTkh6V1d2blRJTWR5RkNmUkJ3S1JHaXNCZ0l2LzVIQnVSQmJJSHZSWnp4NEVlbmx4a2xGRDd0SDMKNys2eWF0MXFML2VCa2ZLNEdtRm1nT3M4OG5YZU1hMHdNZzlrVVc2RFVaWnpyM1FPaVh1dnFnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1447"
+      - "1877"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:21 GMT
+      - Thu, 16 Nov 2023 16:05:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab21c78d-0ccc-400b-beda-eeb4430583ac
+      - 6caae678-bb0f-42d1-812f-3787a6534986
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1c98c5c-2f7e-4b31-a5d3-df959a4396cd
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVUUswK3dOR2w4UEtTeGpxYU1jV1ZiNzRUTzdvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXdNakU0TlRVeU9Wb1hEVE16TVRBek1ERTROVFV5T1Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF3VDF4OHNKaVk5TVBtaGZBUklISnlsK2xRTVV1SnJhTVJ1eTRJVmMzYnlSdFVtbGRNUHlTeUlBaW51ZlYKdDRIZFFMWHNHNkkvYkZ3Y084SGJTclBMN01nRS8vbnVFSXBTRlZsSCttZWtuMXdyS0ZiVEtmU01RN0NJbkJDYQpKVVJveXh4SjhqYXJnYlhzZFM4VEhOVm13amdIQlZyRVlROFFjdGFzajFidWVlVXBSSWVoVHR1NXFLRVk0V1c4CnI4aGJHNVphcm04OXRPbWZyN3hZckxUR2NTekQ4TXY1RGkxKzNPbmtMSFZZQWRQOHd0QmVtaFFTS2ZrRXZ5SUgKaS9VT0NQVTNwQjdtUHowQ1hlK1h6eHBybUVHakpzZHIxUllVOWpyeEJuc3pweGhqVkxQS25Pdk5ROURnN0ZLcwpzUGhuZ1hkV0t3ZDRjbkNaSDZoV3JpQWVpd0lEQVFBQm8za3dkekIxQmdOVkhSRUViakJzZ2dzeE56SXVNVFl1Ck16SXVNb0lOTlRFdU1UVTVMakV3TGpJeE00SThjbmN0TWpJeVpXSTBaRE10TXprd05DMDBZbVpoTFRneE56Z3QKWkRBMk5UQTBNekkzTWpaaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3U3NFQ0FDaHdRegpud3JWTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTldldDliMlB4emFEaStyNm8xQTBLb21pUWVkWSt3OGNpCndEaGJKWkoxL0xGRTJQSnpSVjdWT0tFYklWbmE2eHdXaXNhRE9sNnlsQmZVR3BXdmVSWkF2VWhXTUdlTEd0UXoKNHR1cFJUckE0Z2Joem5YSkgzY01RUlkyb3JuL2orU2Raa1pDRS9nN2NmNko4QlJUalVvV0thWmprVEY5d1BlUApIYU1NZ25BMUJ4L2JCcVhSTGVoZHJtRW8rY01DN1hDcjVxODNTTThvM2hObG5vNERvdmRqSkw4bktTT2YvaWlzCjNaL1hTTHA0L2pna2FhL0VuZXlOWWlFR3E1eFN3OG5YUEcvNmpwZlpLdktYSjU3Z0prRk5qZlZYQ2NsRUx3T28KRHZ1d0JlbzVJa0NUVzBJU0NXZlhZZ2thcEwzQ0pVODdMWm4vcUdNQllsdWxPK1dwTTY4QwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2023-11-16T16:01:36.797044Z","dhcp_enabled":true,"id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:36.797044Z","id":"b4f26e69-5385-4845-9f62-eba27ada06ce","subnet":"172.16.24.0/22","updated_at":"2023-11-16T16:01:36.797044Z"},{"created_at":"2023-11-16T16:01:36.797044Z","id":"bfe8198d-37e2-4838-84e5-091c9ee4e7dd","subnet":"fd63:256c:45f7:b55c::/64","updated_at":"2023-11-16T16:01:36.797044Z"}],"tags":[],"updated_at":"2023-11-16T16:01:36.797044Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1871"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:21 GMT
+      - Thu, 16 Nov 2023 16:05:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f0ccb1f-4a43-462a-b92d-cdcb447fc59b
+      - 9b95dc24-1a4a-4db9-9b65-07789fb4ea0f
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1447"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:22 GMT
+      - Thu, 16 Nov 2023 16:05:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63ed1acb-2a6b-4533-8be6-6739d3e5b77b
+      - cae5c7e9-7d48-4c2c-be07-de4e217254a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVGlPTDZpU2FaZHErcGdlUVdjeU1BbXpna1Rvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEl6Ck1URXhOakUyTURVd01Wb1hEVE16TVRFeE16RTJNRFV3TVZvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUEvTTFlSXNlODAyYjNiZEppV3RDS29nOU1mR0wzRnNURXlaUzRMd004bE9nR1VGVFJtT0ZMMkhPNitCc0MKdXFhcVJ1dHJRcDc1c2ZxVm4xdHRHbzFTclowa0U4c3JTZktRRlhqRm1xZ1VjOHhKbG5wWjdEMFplR05xenljVQpVMEI1cE5jWHJacWo0QndsVXI4NGhaSHZVVWlrWkk5TVhuZVFpeEUrNlUrcEx6TTNPbm5WK1NQSFkyS3N3MXV6Ckt5bisxRSttR2oreGpHWThIZTYreEZNQU5hVENNaTVTME5yamhnaUdZRVcyRjM3TEZXYkpTczQxalVNK2E5RnQKVjNPaXVlNjg0ekhieVZIUWprRUZ6QWVDbVl3OHR4dmtkYUZTRWFTc1ZDVWZsd3ZEc0JQdFd4TjVsUGo2YS9ELwpWTjJzTXVvbW1zTzM5ajJMUmRHOHQ4UDNUd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck1qUXVNb0lPTlRFdU1UVTVMakV4TXk0eE56T0NQSEozTFdaaE5XWmpPVEptTFdKaE5qSXROREZoTkMxaFlqa3cKTFdSbE16RmtaakkxTldObU15NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFTXcrREtvY0VyQkFZQW9jRQpNNTl4clRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQXV1MVFpNlRWVTdrdXFJUWpNc0Z4R0doeno1Wm9ISmJZClY0QW9qZFVuVFhvbk9yNmhFa1NKLzB5YjV3bU5YTVZOYndqL2NPekVYcDNRbEVyUWUvdXZKY2g2R0VObnVxWEkKQ1lReENMU2JZR0ZjaU9oSEcwdTRBUFJuVjR1UCtZdlY4RjYrUFpZZzNsS2RJMmc2dERkNVFpN2l1UURXU2FpUwp4UXZZUnhKWFFhemRubVMrdERWcFcxQktIK2JLSmxhRlFGay9jcXRiYVB6SjYyMEs1bTR6U0ljaTB2ZXdFTW5XCnJTdmtkUGhxTkh6V1d2blRJTWR5RkNmUkJ3S1JHaXNCZ0l2LzVIQnVSQmJJSHZSWnp4NEVlbmx4a2xGRDd0SDMKNys2eWF0MXFML2VCa2ZLNEdtRm1nT3M4OG5YZU1hMHdNZzlrVVc2RFVaWnpyM1FPaVh1dnFnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1447"
+      - "1877"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:22 GMT
+      - Thu, 16 Nov 2023 16:05:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1058,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2728d2a0-66ff-47e1-aaa3-9f11ea1eb72a
+      - 70a9a008-2d60-44a0-b617-cdc4c113afc1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1505"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:05:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4fd79d2c-677f-4743-b8c2-b135efe16776
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1505"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:05:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5fafbc50-57fb-4ccd-bc8f-9be992c8b625
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1447"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:22 GMT
+      - Thu, 16 Nov 2023 16:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8f9eb3c-ea7f-46dc-82de-3c011425eaf2
+      - b38bcf95-197d-4552-8975-a8a1f7405f4e
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1447"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:22 GMT
+      - Thu, 16 Nov 2023 16:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecb4979e-3871-433b-923e-e8b8dcd18e6c
+      - 0a62120f-c31d-41e7-9e61-ba81f8f7b7d3
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,7 +1203,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/a454cf1a-54cf-498c-ab55-f132e5371367
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/4f4ba9cd-8372-4035-91d2-6da9195a3d3a
     method: DELETE
   response:
     body: ""
@@ -1147,7 +1213,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:22 GMT
+      - Thu, 16 Nov 2023 16:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3920cbeb-b766-4e63-b80a-5e7c49994847
+      - 3a7a70c4-5e95-47ac-ad2c-5af910d4cdf8
     status: 204 No Content
     code: 204
     duration: ""
@@ -1168,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"a454cf1a-54cf-498c-ab55-f132e5371367","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"4f4ba9cd-8372-4035-91d2-6da9195a3d3a","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1511"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:22 GMT
+      - Thu, 16 Nov 2023 16:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1dfa5569-5a4e-4c86-baac-d19346ca33d6
+      - 41184ada-3b11-4bd1-a017-d686f8482450
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,19 +1267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1230"
+      - "1281"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:53 GMT
+      - Thu, 16 Nov 2023 16:06:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,12 +1289,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - befa3484-e2bd-449a-830a-6daf366e7afb
+      - 24731403-31ac-414e-9be7-cad94bca58f9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":{"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22"}}}'
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.4/22"}}}'
     form: {}
     headers:
       Content-Type:
@@ -1236,19 +1302,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3/endpoints
     method: POST
   response:
-    body: '{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}'
+    body: '{"id":"797ebcf0-d894-4267-ab06-fa07cbd80186","ip":"172.16.24.4","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.4/22","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "216"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:53 GMT
+      - Thu, 16 Nov 2023 16:06:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f78fb4d-2b85-456d-a3aa-ba28f75767e8
+      - 6a1a0d84-54cd-4b76-acfd-e3105e1e40ba
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"797ebcf0-d894-4267-ab06-fa07cbd80186","ip":"172.16.24.4","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.4/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1454"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:53 GMT
+      - Thu, 16 Nov 2023 16:06:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70ebe574-31ab-4d3d-9be4-c13091503e8e
+      - 2d8e8753-213e-4056-b0ae-a330cfb43303
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,19 +1368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"797ebcf0-d894-4267-ab06-fa07cbd80186","ip":"172.16.24.4","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.4/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1447"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:23 GMT
+      - Thu, 16 Nov 2023 16:06:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40d271b1-5ae0-4d65-a676-6e0cefb2aa9f
+      - 24361bf8-46ef-4f26-b221-f5fc6b1c317d
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,19 +1401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVUUswK3dOR2w4UEtTeGpxYU1jV1ZiNzRUTzdvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXdNakU0TlRVeU9Wb1hEVE16TVRBek1ERTROVFV5T1Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF3VDF4OHNKaVk5TVBtaGZBUklISnlsK2xRTVV1SnJhTVJ1eTRJVmMzYnlSdFVtbGRNUHlTeUlBaW51ZlYKdDRIZFFMWHNHNkkvYkZ3Y084SGJTclBMN01nRS8vbnVFSXBTRlZsSCttZWtuMXdyS0ZiVEtmU01RN0NJbkJDYQpKVVJveXh4SjhqYXJnYlhzZFM4VEhOVm13amdIQlZyRVlROFFjdGFzajFidWVlVXBSSWVoVHR1NXFLRVk0V1c4CnI4aGJHNVphcm04OXRPbWZyN3hZckxUR2NTekQ4TXY1RGkxKzNPbmtMSFZZQWRQOHd0QmVtaFFTS2ZrRXZ5SUgKaS9VT0NQVTNwQjdtUHowQ1hlK1h6eHBybUVHakpzZHIxUllVOWpyeEJuc3pweGhqVkxQS25Pdk5ROURnN0ZLcwpzUGhuZ1hkV0t3ZDRjbkNaSDZoV3JpQWVpd0lEQVFBQm8za3dkekIxQmdOVkhSRUViakJzZ2dzeE56SXVNVFl1Ck16SXVNb0lOTlRFdU1UVTVMakV3TGpJeE00SThjbmN0TWpJeVpXSTBaRE10TXprd05DMDBZbVpoTFRneE56Z3QKWkRBMk5UQTBNekkzTWpaaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3U3NFQ0FDaHdRegpud3JWTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTldldDliMlB4emFEaStyNm8xQTBLb21pUWVkWSt3OGNpCndEaGJKWkoxL0xGRTJQSnpSVjdWT0tFYklWbmE2eHdXaXNhRE9sNnlsQmZVR3BXdmVSWkF2VWhXTUdlTEd0UXoKNHR1cFJUckE0Z2Joem5YSkgzY01RUlkyb3JuL2orU2Raa1pDRS9nN2NmNko4QlJUalVvV0thWmprVEY5d1BlUApIYU1NZ25BMUJ4L2JCcVhSTGVoZHJtRW8rY01DN1hDcjVxODNTTThvM2hObG5vNERvdmRqSkw4bktTT2YvaWlzCjNaL1hTTHA0L2pna2FhL0VuZXlOWWlFR3E1eFN3OG5YUEcvNmpwZlpLdktYSjU3Z0prRk5qZlZYQ2NsRUx3T28KRHZ1d0JlbzVJa0NUVzBJU0NXZlhZZ2thcEwzQ0pVODdMWm4vcUdNQllsdWxPK1dwTTY4QwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVGlPTDZpU2FaZHErcGdlUVdjeU1BbXpna1Rvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEl6Ck1URXhOakUyTURVd01Wb1hEVE16TVRFeE16RTJNRFV3TVZvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUEvTTFlSXNlODAyYjNiZEppV3RDS29nOU1mR0wzRnNURXlaUzRMd004bE9nR1VGVFJtT0ZMMkhPNitCc0MKdXFhcVJ1dHJRcDc1c2ZxVm4xdHRHbzFTclowa0U4c3JTZktRRlhqRm1xZ1VjOHhKbG5wWjdEMFplR05xenljVQpVMEI1cE5jWHJacWo0QndsVXI4NGhaSHZVVWlrWkk5TVhuZVFpeEUrNlUrcEx6TTNPbm5WK1NQSFkyS3N3MXV6Ckt5bisxRSttR2oreGpHWThIZTYreEZNQU5hVENNaTVTME5yamhnaUdZRVcyRjM3TEZXYkpTczQxalVNK2E5RnQKVjNPaXVlNjg0ekhieVZIUWprRUZ6QWVDbVl3OHR4dmtkYUZTRWFTc1ZDVWZsd3ZEc0JQdFd4TjVsUGo2YS9ELwpWTjJzTXVvbW1zTzM5ajJMUmRHOHQ4UDNUd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck1qUXVNb0lPTlRFdU1UVTVMakV4TXk0eE56T0NQSEozTFdaaE5XWmpPVEptTFdKaE5qSXROREZoTkMxaFlqa3cKTFdSbE16RmtaakkxTldObU15NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFTXcrREtvY0VyQkFZQW9jRQpNNTl4clRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQXV1MVFpNlRWVTdrdXFJUWpNc0Z4R0doeno1Wm9ISmJZClY0QW9qZFVuVFhvbk9yNmhFa1NKLzB5YjV3bU5YTVZOYndqL2NPekVYcDNRbEVyUWUvdXZKY2g2R0VObnVxWEkKQ1lReENMU2JZR0ZjaU9oSEcwdTRBUFJuVjR1UCtZdlY4RjYrUFpZZzNsS2RJMmc2dERkNVFpN2l1UURXU2FpUwp4UXZZUnhKWFFhemRubVMrdERWcFcxQktIK2JLSmxhRlFGay9jcXRiYVB6SjYyMEs1bTR6U0ljaTB2ZXdFTW5XCnJTdmtkUGhxTkh6V1d2blRJTWR5RkNmUkJ3S1JHaXNCZ0l2LzVIQnVSQmJJSHZSWnp4NEVlbmx4a2xGRDd0SDMKNys2eWF0MXFML2VCa2ZLNEdtRm1nT3M4OG5YZU1hMHdNZzlrVVc2RFVaWnpyM1FPaVh1dnFnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1871"
+      - "1877"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:23 GMT
+      - Thu, 16 Nov 2023 16:06:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fe54075-00b4-4033-bcea-03c3c84f1b43
+      - 76f2058f-68c0-4705-a591-296e9b392bf8
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,19 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"797ebcf0-d894-4267-ab06-fa07cbd80186","ip":"172.16.24.4","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.4/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1447"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:24 GMT
+      - Thu, 16 Nov 2023 16:06:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edac09c5-edc2-4d71-89cd-729ebda92da6
+      - e9856025-da4d-40ae-9005-62ac79be01d1
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1c98c5c-2f7e-4b31-a5d3-df959a4396cd
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:54:14.471840Z","dhcp_enabled":true,"id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:54:14.471840Z","id":"b0f881ce-49c1-444e-84db-f850334ca776","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:54:14.471840Z"},{"created_at":"2023-11-02T18:54:14.471840Z","id":"75f86e7a-3bc6-4192-96aa-21738d7a98de","subnet":"fd63:256c:45f7:a79::/64","updated_at":"2023-11-02T18:54:14.471840Z"}],"tags":[],"updated_at":"2023-11-02T18:54:14.471840Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:01:36.797044Z","dhcp_enabled":true,"id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:36.797044Z","id":"b4f26e69-5385-4845-9f62-eba27ada06ce","subnet":"172.16.24.0/22","updated_at":"2023-11-16T16:01:36.797044Z"},{"created_at":"2023-11-16T16:01:36.797044Z","id":"bfe8198d-37e2-4838-84e5-091c9ee4e7dd","subnet":"fd63:256c:45f7:b55c::/64","updated_at":"2023-11-16T16:01:36.797044Z"}],"tags":[],"updated_at":"2023-11-16T16:01:36.797044Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "701"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:24 GMT
+      - Thu, 16 Nov 2023 16:06:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09208ec3-d838-4daf-a63e-1217f0dc391c
+      - c3f09a44-64b6-4e3b-aece-db779c286d7d
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,19 +1500,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"797ebcf0-d894-4267-ab06-fa07cbd80186","ip":"172.16.24.4","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.4/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1447"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:24 GMT
+      - Thu, 16 Nov 2023 16:06:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f8453ab-8987-4b85-80e5-5738008add8d
+      - 9e5b602b-4a6a-4589-935d-303738df7cf7
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,19 +1533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lVUUswK3dOR2w4UEtTeGpxYU1jV1ZiNzRUTzdvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXdNakU0TlRVeU9Wb1hEVE16TVRBek1ERTROVFV5T1Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF3VDF4OHNKaVk5TVBtaGZBUklISnlsK2xRTVV1SnJhTVJ1eTRJVmMzYnlSdFVtbGRNUHlTeUlBaW51ZlYKdDRIZFFMWHNHNkkvYkZ3Y084SGJTclBMN01nRS8vbnVFSXBTRlZsSCttZWtuMXdyS0ZiVEtmU01RN0NJbkJDYQpKVVJveXh4SjhqYXJnYlhzZFM4VEhOVm13amdIQlZyRVlROFFjdGFzajFidWVlVXBSSWVoVHR1NXFLRVk0V1c4CnI4aGJHNVphcm04OXRPbWZyN3hZckxUR2NTekQ4TXY1RGkxKzNPbmtMSFZZQWRQOHd0QmVtaFFTS2ZrRXZ5SUgKaS9VT0NQVTNwQjdtUHowQ1hlK1h6eHBybUVHakpzZHIxUllVOWpyeEJuc3pweGhqVkxQS25Pdk5ROURnN0ZLcwpzUGhuZ1hkV0t3ZDRjbkNaSDZoV3JpQWVpd0lEQVFBQm8za3dkekIxQmdOVkhSRUViakJzZ2dzeE56SXVNVFl1Ck16SXVNb0lOTlRFdU1UVTVMakV3TGpJeE00SThjbmN0TWpJeVpXSTBaRE10TXprd05DMDBZbVpoTFRneE56Z3QKWkRBMk5UQTBNekkzTWpaaExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckpocWh3U3NFQ0FDaHdRegpud3JWTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTldldDliMlB4emFEaStyNm8xQTBLb21pUWVkWSt3OGNpCndEaGJKWkoxL0xGRTJQSnpSVjdWT0tFYklWbmE2eHdXaXNhRE9sNnlsQmZVR3BXdmVSWkF2VWhXTUdlTEd0UXoKNHR1cFJUckE0Z2Joem5YSkgzY01RUlkyb3JuL2orU2Raa1pDRS9nN2NmNko4QlJUalVvV0thWmprVEY5d1BlUApIYU1NZ25BMUJ4L2JCcVhSTGVoZHJtRW8rY01DN1hDcjVxODNTTThvM2hObG5vNERvdmRqSkw4bktTT2YvaWlzCjNaL1hTTHA0L2pna2FhL0VuZXlOWWlFR3E1eFN3OG5YUEcvNmpwZlpLdktYSjU3Z0prRk5qZlZYQ2NsRUx3T28KRHZ1d0JlbzVJa0NUVzBJU0NXZlhZZ2thcEwzQ0pVODdMWm4vcUdNQllsdWxPK1dwTTY4QwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVGlPTDZpU2FaZHErcGdlUVdjeU1BbXpna1Rvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEl6Ck1URXhOakUyTURVd01Wb1hEVE16TVRFeE16RTJNRFV3TVZvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUEvTTFlSXNlODAyYjNiZEppV3RDS29nOU1mR0wzRnNURXlaUzRMd004bE9nR1VGVFJtT0ZMMkhPNitCc0MKdXFhcVJ1dHJRcDc1c2ZxVm4xdHRHbzFTclowa0U4c3JTZktRRlhqRm1xZ1VjOHhKbG5wWjdEMFplR05xenljVQpVMEI1cE5jWHJacWo0QndsVXI4NGhaSHZVVWlrWkk5TVhuZVFpeEUrNlUrcEx6TTNPbm5WK1NQSFkyS3N3MXV6Ckt5bisxRSttR2oreGpHWThIZTYreEZNQU5hVENNaTVTME5yamhnaUdZRVcyRjM3TEZXYkpTczQxalVNK2E5RnQKVjNPaXVlNjg0ekhieVZIUWprRUZ6QWVDbVl3OHR4dmtkYUZTRWFTc1ZDVWZsd3ZEc0JQdFd4TjVsUGo2YS9ELwpWTjJzTXVvbW1zTzM5ajJMUmRHOHQ4UDNUd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck1qUXVNb0lPTlRFdU1UVTVMakV4TXk0eE56T0NQSEozTFdaaE5XWmpPVEptTFdKaE5qSXROREZoTkMxaFlqa3cKTFdSbE16RmtaakkxTldObU15NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFTXcrREtvY0VyQkFZQW9jRQpNNTl4clRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQXV1MVFpNlRWVTdrdXFJUWpNc0Z4R0doeno1Wm9ISmJZClY0QW9qZFVuVFhvbk9yNmhFa1NKLzB5YjV3bU5YTVZOYndqL2NPekVYcDNRbEVyUWUvdXZKY2g2R0VObnVxWEkKQ1lReENMU2JZR0ZjaU9oSEcwdTRBUFJuVjR1UCtZdlY4RjYrUFpZZzNsS2RJMmc2dERkNVFpN2l1UURXU2FpUwp4UXZZUnhKWFFhemRubVMrdERWcFcxQktIK2JLSmxhRlFGay9jcXRiYVB6SjYyMEs1bTR6U0ljaTB2ZXdFTW5XCnJTdmtkUGhxTkh6V1d2blRJTWR5RkNmUkJ3S1JHaXNCZ0l2LzVIQnVSQmJJSHZSWnp4NEVlbmx4a2xGRDd0SDMKNys2eWF0MXFML2VCa2ZLNEdtRm1nT3M4OG5YZU1hMHdNZzlrVVc2RFVaWnpyM1FPaVh1dnFnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1871"
+      - "1877"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:24 GMT
+      - Thu, 16 Nov 2023 16:06:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3410f77d-3bf3-43d6-8dc5-73eacdf3c5f0
+      - 7faf1043-55b6-4f20-b962-38aae7607e69
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"797ebcf0-d894-4267-ab06-fa07cbd80186","ip":"172.16.24.4","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.4/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1447"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:25 GMT
+      - Thu, 16 Nov 2023 16:06:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7734eeb-fc15-4f84-b89d-55079085af01
+      - 6484c46f-ef6f-4de0-bd97-065b48ec150f
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,19 +1599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"797ebcf0-d894-4267-ab06-fa07cbd80186","ip":"172.16.24.4","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.4/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1450"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:25 GMT
+      - Thu, 16 Nov 2023 16:06:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8df2d77e-7d48-460a-8bb6-eb57c6761ae1
+      - 146bc5c4-eff6-43d4-9ba1-7873752577e9
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,19 +1632,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:54:17.588248Z","endpoint":{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476},"endpoints":[{"id":"7dae7479-b9a4-459c-91c4-b2412b26e4a4","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"600f1eb9-da64-404e-bb12-feb4930dbcdb","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"0be2d1f5-c276-4bca-a164-d09e8ac3d409","ip":"51.159.10.213","load_balancer":{},"name":null,"port":15476}],"engine":"PostgreSQL-15","id":"222eb4d3-3904-4bfa-8178-d0650432726a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:39.456484Z","endpoint":{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761},"endpoints":[{"id":"797ebcf0-d894-4267-ab06-fa07cbd80186","ip":"172.16.24.4","name":null,"port":5432,"private_network":{"private_network_id":"a1c98c5c-2f7e-4b31-a5d3-df959a4396cd","service_ip":"172.16.24.4/22","zone":"fr-par-1"}},{"id":"daff30c2-f7c4-49eb-b1e3-b73eb70cb34d","ip":"51.159.113.173","load_balancer":{},"name":null,"port":20761}],"engine":"PostgreSQL-15","id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1450"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:25 GMT
+      - Thu, 16 Nov 2023 16:06:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07fc19fc-dc69-49dd-afe5-ecbf31bd65e0
+      - 5f885242-5e09-4abe-9561-ff25925df0ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,10 +1665,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"222eb4d3-3904-4bfa-8178-d0650432726a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1611,7 +1677,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:58 GMT
+      - Thu, 16 Nov 2023 16:07:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c7b40ec-dff0-4aad-b8b1-d5004dac6910
+      - 22ff951d-1964-4567-a1b6-88b19c89031d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1632,7 +1698,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/600f1eb9-da64-404e-bb12-feb4930dbcdb
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a1c98c5c-2f7e-4b31-a5d3-df959a4396cd
     method: DELETE
   response:
     body: ""
@@ -1642,7 +1708,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:59 GMT
+      - Thu, 16 Nov 2023 16:07:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1652,7 +1718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9892405a-5b13-4fcc-85f1-c9398af7bb64
+      - df7c2d02-36ce-4a8f-b8f9-7b6234961d98
     status: 204 No Content
     code: 204
     duration: ""
@@ -1663,10 +1729,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/222eb4d3-3904-4bfa-8178-d0650432726a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fa5fc92f-ba62-41a4-ab90-de31df255cf3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"222eb4d3-3904-4bfa-8178-d0650432726a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"fa5fc92f-ba62-41a4-ab90-de31df255cf3","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1675,7 +1741,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:59 GMT
+      - Thu, 16 Nov 2023 16:07:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1685,7 +1751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a8cc330-df2d-4ca0-9a05-782836e2dde4
+      - d58b4449-1cfd-465f-a94a-8e0ceab90fb3
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:34 GMT
+      - Thu, 16 Nov 2023 15:52:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc84f4a9-3dab-4f0f-a22b-28f839778f4d
+      - 4aebc58c-c386-449b-8af0-84fd3f6afed1
     status: 200 OK
     code: 200
     duration: ""
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:00:09.985180Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:04:35.454808Z","dhcp_enabled":true,"id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:04:35.454808Z","id":"7f8db8ed-f824-48b6-9b65-71b848a000e9","subnet":"172.16.4.0/22","updated_at":"2023-11-16T16:04:35.454808Z"},{"created_at":"2023-11-16T16:04:35.454808Z","id":"0035eb7c-49b0-4c15-9c10-bd05364f8dc7","subnet":"fd68:d440:21c4:853::/64","updated_at":"2023-11-16T16:04:35.454808Z"}],"tags":[],"updated_at":"2023-11-16T16:04:35.454808Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "701"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:12 GMT
+      - Thu, 16 Nov 2023 16:04:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fc8a27f-7cef-4fd4-b4b9-f83ac7f86e0c
+      - 659857ac-f814-4596-a85d-140797ef88eb
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/30c49e55-33fc-46fb-a9cd-c3ee2a607920
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:00:09.985180Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:04:35.454808Z","dhcp_enabled":true,"id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:04:35.454808Z","id":"7f8db8ed-f824-48b6-9b65-71b848a000e9","subnet":"172.16.4.0/22","updated_at":"2023-11-16T16:04:35.454808Z"},{"created_at":"2023-11-16T16:04:35.454808Z","id":"0035eb7c-49b0-4c15-9c10-bd05364f8dc7","subnet":"fd68:d440:21c4:853::/64","updated_at":"2023-11-16T16:04:35.454808Z"}],"tags":[],"updated_at":"2023-11-16T16:04:35.454808Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "701"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:12 GMT
+      - Thu, 16 Nov 2023 16:04:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 093f1c48-b25f-4c65-8fe1-54cb5b8352c3
+      - 5b4d3245-3e9b-4cce-9cae-899b39164855
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/30c49e55-33fc-46fb-a9cd-c3ee2a607920
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:00:09.985180Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:04:35.454808Z","dhcp_enabled":true,"id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:04:35.454808Z","id":"7f8db8ed-f824-48b6-9b65-71b848a000e9","subnet":"172.16.4.0/22","updated_at":"2023-11-16T16:04:35.454808Z"},{"created_at":"2023-11-16T16:04:35.454808Z","id":"0035eb7c-49b0-4c15-9c10-bd05364f8dc7","subnet":"fd68:d440:21c4:853::/64","updated_at":"2023-11-16T16:04:35.454808Z"}],"tags":[],"updated_at":"2023-11-16T16:04:35.454808Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "701"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:12 GMT
+      - Thu, 16 Nov 2023 16:04:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad36840a-e87c-48d8-88d5-ffccaf0f5d65
+      - 1094f37e-9f7a-44fa-8650-29b629f2cac4
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/30c49e55-33fc-46fb-a9cd-c3ee2a607920
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:00:09.985180Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:04:35.454808Z","dhcp_enabled":true,"id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:04:35.454808Z","id":"7f8db8ed-f824-48b6-9b65-71b848a000e9","subnet":"172.16.4.0/22","updated_at":"2023-11-16T16:04:35.454808Z"},{"created_at":"2023-11-16T16:04:35.454808Z","id":"0035eb7c-49b0-4c15-9c10-bd05364f8dc7","subnet":"fd68:d440:21c4:853::/64","updated_at":"2023-11-16T16:04:35.454808Z"}],"tags":[],"updated_at":"2023-11-16T16:04:35.454808Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "701"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:13 GMT
+      - Thu, 16 Nov 2023 16:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,12 +462,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fe50a81-bfe4-4640-9a48-88155e3dd438
+      - 382c7c83-b881-4781-94d8-74ebe7b6169f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24"}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24"}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -478,16 +478,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":null,"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "1011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:14 GMT
+      - Thu, 16 Nov 2023 16:04:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 475c3ffa-8ca5-423b-8b49-6fd954d23f2e
+      - 789abbf1-559f-403b-a9d5-d2c9eab91d75
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":null,"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "1011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:14 GMT
+      - Thu, 16 Nov 2023 16:04:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02676ba6-4730-4e8c-a130-0f090204ae8f
+      - 9820191f-7238-4287-813a-b070f6b6d18b
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":null,"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "1011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:44 GMT
+      - Thu, 16 Nov 2023 16:05:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a549c27-bc9a-443b-bf48-92458dc31b7b
+      - 0cc47fe7-8c7e-4156-a77f-ccd11c9a4148
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":null,"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "1011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:14 GMT
+      - Thu, 16 Nov 2023 16:05:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f6d2a26-a7e4-444d-a636-cb76745da74c
+      - 4828986d-3033-4701-aa83-f2c9c3aaa69d
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":null,"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "1011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:44 GMT
+      - Thu, 16 Nov 2023 16:06:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29bfd35b-e653-4ff3-9f99-2a59e20440bc
+      - bda925d4-26f9-43dc-996f-9638cfffb47f
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":null,"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "1011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:15 GMT
+      - Thu, 16 Nov 2023 16:06:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 307d307d-2920-499c-998a-f627c3c855c3
+      - 849d1173-1092-4e77-95a7-137c47b53db7
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":null,"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":null,"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "1011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:45 GMT
+      - Thu, 16 Nov 2023 16:07:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4776ccd-412f-4081-8d34-df9b983751c0
+      - 224f91e5-c25e-4c37-857c-9361f977bb58
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":null,"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1286"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:15 GMT
+      - Thu, 16 Nov 2023 16:07:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d361efe6-5238-4a57-807e-b848e25864a3
+      - 39e4aa30-248f-4e41-a63f-0a9314143c58
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1879"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:15 GMT
+      - Thu, 16 Nov 2023 16:08:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8dc0744e-f1a1-441d-9c7f-9339e1f23544
+      - e4eb7e7d-f6d8-4ad5-bece-866ae9b3ce78
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVS0pKM01lenBUSGswN3diTTFoRkhNNXpod2xrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNVFl4TmpBM016SmFGdzB6TXpFeE1UTXhOakEzTXpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURJNzVzcjdvVm5OM05BRFl5aFpYVDdld1A0bnQyNkpWZUN1TU1SeTdSZVh1U2xyYllyYTlmYWN3d3UKY2VML1cxRmpGaVdvSTJmb1diZ2tKdG81ZFdhR2tUUlJyWnVtYWw1K0plWVg5UEMzdDV6L0VFUFFRTUJhRnN3NQpNQVIrV0pHSkZCQzl3MWlQUEZlMlpuSmVta2toUXY4SkZxUDBhUW5QMGFGaUVRUERnaS9lZlY3TG1zejBzeGlaCkxJY043ZkoyT0hUVHBsRCtYNjJwSkJWSmhnMXUxT0ZnZlJvZFlnMXlpZVhyZmxxRGx5cnJ0NG9QZjZkblRiMm8KVmZ3VlE0T2JhNWZoNDdRMnRiWDNwME9ZdXQyV3ZKMlZLOWNFajRBeU1ZcVJ0bHdES3k4Q1BSVVdqNXU1TnpjWQpLWE9iWmF5cFg0cnRHTW9iZ0hRSWcyNVhISVMzQWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpJeE1DNHlNem1DUEhKM0xUaGpOamM1TlRCbExXWTFaRFV0TkRJeE5pMWkKTVRWaUxXWTFObVE1TWprM09EZ3pPUzV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OXBKWWNFd0tnQgpLb2NFTTU3Uzd6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFmQXdJUDZ3a0FLam1BTERLMGxlZW55Q21iWTczCjY2ekRKditQWVFpbDhxUTdubkdBQy96RVhQaTdHekxFaTl5bnhRODlPNW1iZklocWFJUjFaeUpVU0xyVGFqRlYKZGt5WkJ0RzZrRGRnWUYzMlhLZExVY2E1dHVxQTFqZERJTkdRUVdjK0RFZVVaNUNwbC85UWF0dnYrNUV1YmMxKwovTGV5RXgzSW9yYjM5L05EL2pDQlpIYzgyaTU1Z3UreVBTVWlITk15RmZOTEZ1alB0VnY3cGZuMXZsYktvcmplCjM2SHdTdkVRbjlCWVRxaWNyUm9vNDdIOEZpL2dJbU41YjlKeGxHNHJzQ0pWYVhTNFo3QVZpSUdBNjZxT2xNMHQKckU3ZEwxRkhuWDl2YnFwNWVCb2ZtM1l0UHltc2lWb2pDbUw2bEJNYmVOUXIrblgzSEFmVFhRcm9Odz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1451"
+      - "1881"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:15 GMT
+      - Thu, 16 Nov 2023 16:08:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e8bfae5-69b4-4b11-b881-2835373a7aea
+      - e9e9582e-7658-4c8c-b518-0d23a1a3fc30
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:00:09.985180Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "701"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:16 GMT
+      - Thu, 16 Nov 2023 16:08:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 019adcf1-7095-4638-92f3-8000a71d7ef2
+      - a4bb0ed7-9713-4eaf-8a59-febf6fdd83db
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/30c49e55-33fc-46fb-a9cd-c3ee2a607920
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2023-11-16T16:04:35.454808Z","dhcp_enabled":true,"id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:04:35.454808Z","id":"7f8db8ed-f824-48b6-9b65-71b848a000e9","subnet":"172.16.4.0/22","updated_at":"2023-11-16T16:04:35.454808Z"},{"created_at":"2023-11-16T16:04:35.454808Z","id":"0035eb7c-49b0-4c15-9c10-bd05364f8dc7","subnet":"fd68:d440:21c4:853::/64","updated_at":"2023-11-16T16:04:35.454808Z"}],"tags":[],"updated_at":"2023-11-16T16:04:35.454808Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "1451"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:16 GMT
+      - Thu, 16 Nov 2023 16:08:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd9e8206-776a-4adc-9690-b7e0e72c3ace
+      - d1a63e5b-6b8e-4c16-9e49-7123ccb0657a
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1879"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:16 GMT
+      - Thu, 16 Nov 2023 16:08:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb3fe9e3-3ad7-478e-a8df-8793bdc93f93
+      - 7eb3d9ae-1a47-476e-9659-6a1242d0e970
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839/certificate
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:00:09.985180Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVS0pKM01lenBUSGswN3diTTFoRkhNNXpod2xrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNVFl4TmpBM016SmFGdzB6TXpFeE1UTXhOakEzTXpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURJNzVzcjdvVm5OM05BRFl5aFpYVDdld1A0bnQyNkpWZUN1TU1SeTdSZVh1U2xyYllyYTlmYWN3d3UKY2VML1cxRmpGaVdvSTJmb1diZ2tKdG81ZFdhR2tUUlJyWnVtYWw1K0plWVg5UEMzdDV6L0VFUFFRTUJhRnN3NQpNQVIrV0pHSkZCQzl3MWlQUEZlMlpuSmVta2toUXY4SkZxUDBhUW5QMGFGaUVRUERnaS9lZlY3TG1zejBzeGlaCkxJY043ZkoyT0hUVHBsRCtYNjJwSkJWSmhnMXUxT0ZnZlJvZFlnMXlpZVhyZmxxRGx5cnJ0NG9QZjZkblRiMm8KVmZ3VlE0T2JhNWZoNDdRMnRiWDNwME9ZdXQyV3ZKMlZLOWNFajRBeU1ZcVJ0bHdES3k4Q1BSVVdqNXU1TnpjWQpLWE9iWmF5cFg0cnRHTW9iZ0hRSWcyNVhISVMzQWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpJeE1DNHlNem1DUEhKM0xUaGpOamM1TlRCbExXWTFaRFV0TkRJeE5pMWkKTVRWaUxXWTFObVE1TWprM09EZ3pPUzV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OXBKWWNFd0tnQgpLb2NFTTU3Uzd6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFmQXdJUDZ3a0FLam1BTERLMGxlZW55Q21iWTczCjY2ekRKditQWVFpbDhxUTdubkdBQy96RVhQaTdHekxFaTl5bnhRODlPNW1iZklocWFJUjFaeUpVU0xyVGFqRlYKZGt5WkJ0RzZrRGRnWUYzMlhLZExVY2E1dHVxQTFqZERJTkdRUVdjK0RFZVVaNUNwbC85UWF0dnYrNUV1YmMxKwovTGV5RXgzSW9yYjM5L05EL2pDQlpIYzgyaTU1Z3UreVBTVWlITk15RmZOTEZ1alB0VnY3cGZuMXZsYktvcmplCjM2SHdTdkVRbjlCWVRxaWNyUm9vNDdIOEZpL2dJbU41YjlKeGxHNHJzQ0pWYVhTNFo3QVZpSUdBNjZxT2xNMHQKckU3ZEwxRkhuWDl2YnFwNWVCb2ZtM1l0UHltc2lWb2pDbUw2bEJNYmVOUXIrblgzSEFmVFhRcm9Odz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "701"
+      - "1881"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:16 GMT
+      - Thu, 16 Nov 2023 16:08:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9262c74a-7a63-469a-86d3-817ca7da6e96
+      - 4d529e55-190b-4f3a-9ccd-6f00b510cce5
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/30c49e55-33fc-46fb-a9cd-c3ee2a607920
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2023-11-16T16:04:35.454808Z","dhcp_enabled":true,"id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:04:35.454808Z","id":"7f8db8ed-f824-48b6-9b65-71b848a000e9","subnet":"172.16.4.0/22","updated_at":"2023-11-16T16:04:35.454808Z"},{"created_at":"2023-11-16T16:04:35.454808Z","id":"0035eb7c-49b0-4c15-9c10-bd05364f8dc7","subnet":"fd68:d440:21c4:853::/64","updated_at":"2023-11-16T16:04:35.454808Z"}],"tags":[],"updated_at":"2023-11-16T16:04:35.454808Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "1451"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:16 GMT
+      - Thu, 16 Nov 2023 16:08:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03a60499-b5f7-4463-ac06-6f9aa68dfca5
+      - f6564476-faf1-4ab0-ac66-10bb828d2116
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1879"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:17 GMT
+      - Thu, 16 Nov 2023 16:08:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +992,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 738433db-62d4-4fa8-8e28-d5b0ba48c228
+      - bf19776f-1053-4cfc-9ecf-73d8b1d617d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVS0pKM01lenBUSGswN3diTTFoRkhNNXpod2xrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNVFl4TmpBM016SmFGdzB6TXpFeE1UTXhOakEzTXpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURJNzVzcjdvVm5OM05BRFl5aFpYVDdld1A0bnQyNkpWZUN1TU1SeTdSZVh1U2xyYllyYTlmYWN3d3UKY2VML1cxRmpGaVdvSTJmb1diZ2tKdG81ZFdhR2tUUlJyWnVtYWw1K0plWVg5UEMzdDV6L0VFUFFRTUJhRnN3NQpNQVIrV0pHSkZCQzl3MWlQUEZlMlpuSmVta2toUXY4SkZxUDBhUW5QMGFGaUVRUERnaS9lZlY3TG1zejBzeGlaCkxJY043ZkoyT0hUVHBsRCtYNjJwSkJWSmhnMXUxT0ZnZlJvZFlnMXlpZVhyZmxxRGx5cnJ0NG9QZjZkblRiMm8KVmZ3VlE0T2JhNWZoNDdRMnRiWDNwME9ZdXQyV3ZKMlZLOWNFajRBeU1ZcVJ0bHdES3k4Q1BSVVdqNXU1TnpjWQpLWE9iWmF5cFg0cnRHTW9iZ0hRSWcyNVhISVMzQWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpJeE1DNHlNem1DUEhKM0xUaGpOamM1TlRCbExXWTFaRFV0TkRJeE5pMWkKTVRWaUxXWTFObVE1TWprM09EZ3pPUzV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OXBKWWNFd0tnQgpLb2NFTTU3Uzd6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFmQXdJUDZ3a0FLam1BTERLMGxlZW55Q21iWTczCjY2ekRKditQWVFpbDhxUTdubkdBQy96RVhQaTdHekxFaTl5bnhRODlPNW1iZklocWFJUjFaeUpVU0xyVGFqRlYKZGt5WkJ0RzZrRGRnWUYzMlhLZExVY2E1dHVxQTFqZERJTkdRUVdjK0RFZVVaNUNwbC85UWF0dnYrNUV1YmMxKwovTGV5RXgzSW9yYjM5L05EL2pDQlpIYzgyaTU1Z3UreVBTVWlITk15RmZOTEZ1alB0VnY3cGZuMXZsYktvcmplCjM2SHdTdkVRbjlCWVRxaWNyUm9vNDdIOEZpL2dJbU41YjlKeGxHNHJzQ0pWYVhTNFo3QVZpSUdBNjZxT2xNMHQKckU3ZEwxRkhuWDl2YnFwNWVCb2ZtM1l0UHltc2lWb2pDbUw2bEJNYmVOUXIrblgzSEFmVFhRcm9Odz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1881"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb131e58-058e-49fb-a2a6-d8a635fda468
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/30c49e55-33fc-46fb-a9cd-c3ee2a607920
     method: PATCH
   response:
-    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.581461Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:04:35.454808Z","dhcp_enabled":true,"id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:04:35.454808Z","id":"7f8db8ed-f824-48b6-9b65-71b848a000e9","subnet":"172.16.4.0/22","updated_at":"2023-11-16T16:04:35.454808Z"},{"created_at":"2023-11-16T16:04:35.454808Z","id":"0035eb7c-49b0-4c15-9c10-bd05364f8dc7","subnet":"fd68:d440:21c4:853::/64","updated_at":"2023-11-16T16:04:35.454808Z"}],"tags":[],"updated_at":"2023-11-16T16:08:12.873746Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "716"
+      - "732"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:17 GMT
+      - Thu, 16 Nov 2023 16:08:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07c8c750-6736-43a3-93cb-ce302c19bac0
+      - ae7fad2d-539b-4747-b5a0-1e7b31334459
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/30c49e55-33fc-46fb-a9cd-c3ee2a607920
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.581461Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:04:35.454808Z","dhcp_enabled":true,"id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:04:35.454808Z","id":"7f8db8ed-f824-48b6-9b65-71b848a000e9","subnet":"172.16.4.0/22","updated_at":"2023-11-16T16:04:35.454808Z"},{"created_at":"2023-11-16T16:04:35.454808Z","id":"0035eb7c-49b0-4c15-9c10-bd05364f8dc7","subnet":"fd68:d440:21c4:853::/64","updated_at":"2023-11-16T16:04:35.454808Z"}],"tags":[],"updated_at":"2023-11-16T16:08:12.873746Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "716"
+      - "732"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:17 GMT
+      - Thu, 16 Nov 2023 16:08:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9c1d018-59f3-4545-b222-b4990c73f64f
+      - dde0f1b2-9531-462f-8a07-afe9bf500269
     status: 200 OK
     code: 200
     duration: ""
@@ -1076,16 +1109,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"172.16.8.0/22","updated_at":"2023-11-02T19:03:17.580618Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:03:17.580618Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.580618Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:08:12.887358Z","dhcp_enabled":true,"id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:08:12.887358Z","id":"badd3afb-5653-498a-8886-4d016b465ea2","subnet":"172.16.8.0/22","updated_at":"2023-11-16T16:08:12.887358Z"},{"created_at":"2023-11-16T16:08:12.887358Z","id":"4dc7cced-46d6-41e8-9630-42b23ed46fd0","subnet":"fd68:d440:21c4:e7d7::/64","updated_at":"2023-11-16T16:08:12.887358Z"}],"tags":[],"updated_at":"2023-11-16T16:08:12.887358Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "701"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:18 GMT
+      - Thu, 16 Nov 2023 16:08:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1095,7 +1128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0252d964-c5a0-4211-89dc-446c8cf839c0
+      - 035d8f40-369c-4c85-bf41-bb217257ef77
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,19 +1139,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e1c1cc9f-8250-4b9a-ab3e-d0797377830d
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"172.16.8.0/22","updated_at":"2023-11-02T19:03:17.580618Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:03:17.580618Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.580618Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:08:12.887358Z","dhcp_enabled":true,"id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:08:12.887358Z","id":"badd3afb-5653-498a-8886-4d016b465ea2","subnet":"172.16.8.0/22","updated_at":"2023-11-16T16:08:12.887358Z"},{"created_at":"2023-11-16T16:08:12.887358Z","id":"4dc7cced-46d6-41e8-9630-42b23ed46fd0","subnet":"fd68:d440:21c4:e7d7::/64","updated_at":"2023-11-16T16:08:12.887358Z"}],"tags":[],"updated_at":"2023-11-16T16:08:12.887358Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "701"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:18 GMT
+      - Thu, 16 Nov 2023 16:08:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1128,7 +1161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 896c5911-8daf-4779-8b23-bc0ff2b62467
+      - f19846f7-4401-4c5a-b70f-db91129fd045
     status: 200 OK
     code: 200
     duration: ""
@@ -1139,19 +1172,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:18 GMT
+      - Thu, 16 Nov 2023 16:08:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1161,7 +1194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9aec3db7-72b5-4c93-92e4-d65bd4ff407c
+      - 6b33a704-b06b-4a91-a48c-09c7011078c6
     status: 200 OK
     code: 200
     duration: ""
@@ -1172,19 +1205,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:18 GMT
+      - Thu, 16 Nov 2023 16:08:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1194,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c1168e5-bfff-4c9b-86c3-60cc3397b6a3
+      - f69644ec-5198-45f3-9bfd-7418f06528d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1207,19 +1240,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:18 GMT
+      - Thu, 16 Nov 2023 16:08:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1229,7 +1262,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83ad6fde-2ef9-4f10-9c67-37d0305fd290
+      - a5c9f678-152c-42c4-9202-05e8a4e582ad
     status: 200 OK
     code: 200
     duration: ""
@@ -1240,19 +1273,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:18 GMT
+      - Thu, 16 Nov 2023 16:08:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1262,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63461722-bd41-4da6-8f9f-da02b694af58
+      - 0c86a035-ffa1-40ec-9317-b57c7d9158ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1273,7 +1306,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/d2f13d77-2ae7-4ae8-be59-e0617730bfdb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/29e07304-c1bc-4798-8ac2-2798808c5491
     method: DELETE
   response:
     body: ""
@@ -1283,7 +1316,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:19 GMT
+      - Thu, 16 Nov 2023 16:08:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5977552f-9d74-4f7b-b12b-7a077bd9cb47
+      - 025b4ff8-6345-4a7e-bf2f-0c4424cdbc2a
     status: 204 No Content
     code: 204
     duration: ""
@@ -1304,19 +1337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"d2f13d77-2ae7-4ae8-be59-e0617730bfdb","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"ea0854da-211d-4cca-b625-68104d98a8d0","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"29e07304-c1bc-4798-8ac2-2798808c5491","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1457"
+      - "1511"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:19 GMT
+      - Thu, 16 Nov 2023 16:08:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1f92114-6572-4f68-89b3-fa96114a5f6f
+      - b0d64f84-e91d-4f73-9744-b535254f604f
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,19 +1370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1279"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:49 GMT
+      - Thu, 16 Nov 2023 16:08:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,12 +1392,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86a5e859-9e0d-44aa-b9e1-59f7258c8719
+      - bc5d11fa-5995-40fc-b702-fc07012e9504
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":{"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24"}}}'
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24"}}}'
     form: {}
     headers:
       Content-Type:
@@ -1372,19 +1405,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839/endpoints
     method: POST
   response:
-    body: '{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}'
+    body: '{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}'
     headers:
       Content-Length:
-      - "220"
+      - "226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:50 GMT
+      - Thu, 16 Nov 2023 16:08:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1394,7 +1427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23dbb035-00b1-4c8e-afc8-7f8d7aa2cba1
+      - bd1e9647-a4c4-4d77-96fd-6ef1ea23835f
     status: 200 OK
     code: 200
     duration: ""
@@ -1405,19 +1438,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1460"
+      - "1514"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:50 GMT
+      - Thu, 16 Nov 2023 16:08:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1427,7 +1460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83a2bd9d-8d2d-4f2f-b7c8-f3966f3670a6
+      - 3f90efd1-59c6-4082-96e4-e3d69635d6a2
     status: 200 OK
     code: 200
     duration: ""
@@ -1438,19 +1471,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:20 GMT
+      - Thu, 16 Nov 2023 16:09:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1460,7 +1493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 800dae7d-2ade-4c30-a78c-4796dd1d659f
+      - d96fc97f-2227-4d15-a667-48252ea451ef
     status: 200 OK
     code: 200
     duration: ""
@@ -1471,19 +1504,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVS0pKM01lenBUSGswN3diTTFoRkhNNXpod2xrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNVFl4TmpBM016SmFGdzB6TXpFeE1UTXhOakEzTXpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURJNzVzcjdvVm5OM05BRFl5aFpYVDdld1A0bnQyNkpWZUN1TU1SeTdSZVh1U2xyYllyYTlmYWN3d3UKY2VML1cxRmpGaVdvSTJmb1diZ2tKdG81ZFdhR2tUUlJyWnVtYWw1K0plWVg5UEMzdDV6L0VFUFFRTUJhRnN3NQpNQVIrV0pHSkZCQzl3MWlQUEZlMlpuSmVta2toUXY4SkZxUDBhUW5QMGFGaUVRUERnaS9lZlY3TG1zejBzeGlaCkxJY043ZkoyT0hUVHBsRCtYNjJwSkJWSmhnMXUxT0ZnZlJvZFlnMXlpZVhyZmxxRGx5cnJ0NG9QZjZkblRiMm8KVmZ3VlE0T2JhNWZoNDdRMnRiWDNwME9ZdXQyV3ZKMlZLOWNFajRBeU1ZcVJ0bHdES3k4Q1BSVVdqNXU1TnpjWQpLWE9iWmF5cFg0cnRHTW9iZ0hRSWcyNVhISVMzQWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpJeE1DNHlNem1DUEhKM0xUaGpOamM1TlRCbExXWTFaRFV0TkRJeE5pMWkKTVRWaUxXWTFObVE1TWprM09EZ3pPUzV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OXBKWWNFd0tnQgpLb2NFTTU3Uzd6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFmQXdJUDZ3a0FLam1BTERLMGxlZW55Q21iWTczCjY2ekRKditQWVFpbDhxUTdubkdBQy96RVhQaTdHekxFaTl5bnhRODlPNW1iZklocWFJUjFaeUpVU0xyVGFqRlYKZGt5WkJ0RzZrRGRnWUYzMlhLZExVY2E1dHVxQTFqZERJTkdRUVdjK0RFZVVaNUNwbC85UWF0dnYrNUV1YmMxKwovTGV5RXgzSW9yYjM5L05EL2pDQlpIYzgyaTU1Z3UreVBTVWlITk15RmZOTEZ1alB0VnY3cGZuMXZsYktvcmplCjM2SHdTdkVRbjlCWVRxaWNyUm9vNDdIOEZpL2dJbU41YjlKeGxHNHJzQ0pWYVhTNFo3QVZpSUdBNjZxT2xNMHQKckU3ZEwxRkhuWDl2YnFwNWVCb2ZtM1l0UHltc2lWb2pDbUw2bEJNYmVOUXIrblgzSEFmVFhRcm9Odz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1879"
+      - "1881"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:20 GMT
+      - Thu, 16 Nov 2023 16:09:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1493,7 +1526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc41b402-40cd-4f96-ace8-20871e2f2d4c
+      - 028ae72b-0a2f-4170-979b-d5e04af6d607
     status: 200 OK
     code: 200
     duration: ""
@@ -1504,19 +1537,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:20 GMT
+      - Thu, 16 Nov 2023 16:09:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1526,7 +1559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d36ad7bb-de0b-4cf8-b171-34862f897131
+      - eaeb4864-00ee-4edf-a580-5dde76549e0a
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,19 +1570,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e1c1cc9f-8250-4b9a-ab3e-d0797377830d
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"172.16.8.0/22","updated_at":"2023-11-02T19:03:17.580618Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:03:17.580618Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.580618Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:08:12.887358Z","dhcp_enabled":true,"id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:08:12.887358Z","id":"badd3afb-5653-498a-8886-4d016b465ea2","subnet":"172.16.8.0/22","updated_at":"2023-11-16T16:08:12.887358Z"},{"created_at":"2023-11-16T16:08:12.887358Z","id":"4dc7cced-46d6-41e8-9630-42b23ed46fd0","subnet":"fd68:d440:21c4:e7d7::/64","updated_at":"2023-11-16T16:08:12.887358Z"}],"tags":[],"updated_at":"2023-11-16T16:08:12.887358Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "701"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:21 GMT
+      - Thu, 16 Nov 2023 16:09:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1559,7 +1592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28a3a615-e75e-4fc8-ab40-2b9bc0cbe8f2
+      - 8bf32684-bf57-462e-b60b-fe95c546cce8
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,19 +1603,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/30c49e55-33fc-46fb-a9cd-c3ee2a607920
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.581461Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:04:35.454808Z","dhcp_enabled":true,"id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:04:35.454808Z","id":"7f8db8ed-f824-48b6-9b65-71b848a000e9","subnet":"172.16.4.0/22","updated_at":"2023-11-16T16:04:35.454808Z"},{"created_at":"2023-11-16T16:04:35.454808Z","id":"0035eb7c-49b0-4c15-9c10-bd05364f8dc7","subnet":"fd68:d440:21c4:853::/64","updated_at":"2023-11-16T16:04:35.454808Z"}],"tags":[],"updated_at":"2023-11-16T16:08:12.873746Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "716"
+      - "732"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:21 GMT
+      - Thu, 16 Nov 2023 16:09:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1592,7 +1625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16f9f1fa-c4d7-4dd9-a317-4a38e95f81b9
+      - d0845c2e-deb1-4b30-9fa2-e9c512c9cc19
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,19 +1636,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:21 GMT
+      - Thu, 16 Nov 2023 16:09:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1625,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d14e1e5c-4342-4ac8-baaa-51621550d977
+      - 1c1c5dbe-40d6-46e5-b82b-3c2ee1f3afc5
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,19 +1669,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVS0pKM01lenBUSGswN3diTTFoRkhNNXpod2xrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNVFl4TmpBM016SmFGdzB6TXpFeE1UTXhOakEzTXpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURJNzVzcjdvVm5OM05BRFl5aFpYVDdld1A0bnQyNkpWZUN1TU1SeTdSZVh1U2xyYllyYTlmYWN3d3UKY2VML1cxRmpGaVdvSTJmb1diZ2tKdG81ZFdhR2tUUlJyWnVtYWw1K0plWVg5UEMzdDV6L0VFUFFRTUJhRnN3NQpNQVIrV0pHSkZCQzl3MWlQUEZlMlpuSmVta2toUXY4SkZxUDBhUW5QMGFGaUVRUERnaS9lZlY3TG1zejBzeGlaCkxJY043ZkoyT0hUVHBsRCtYNjJwSkJWSmhnMXUxT0ZnZlJvZFlnMXlpZVhyZmxxRGx5cnJ0NG9QZjZkblRiMm8KVmZ3VlE0T2JhNWZoNDdRMnRiWDNwME9ZdXQyV3ZKMlZLOWNFajRBeU1ZcVJ0bHdES3k4Q1BSVVdqNXU1TnpjWQpLWE9iWmF5cFg0cnRHTW9iZ0hRSWcyNVhISVMzQWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpJeE1DNHlNem1DUEhKM0xUaGpOamM1TlRCbExXWTFaRFV0TkRJeE5pMWkKTVRWaUxXWTFObVE1TWprM09EZ3pPUzV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OXBKWWNFd0tnQgpLb2NFTTU3Uzd6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFmQXdJUDZ3a0FLam1BTERLMGxlZW55Q21iWTczCjY2ekRKditQWVFpbDhxUTdubkdBQy96RVhQaTdHekxFaTl5bnhRODlPNW1iZklocWFJUjFaeUpVU0xyVGFqRlYKZGt5WkJ0RzZrRGRnWUYzMlhLZExVY2E1dHVxQTFqZERJTkdRUVdjK0RFZVVaNUNwbC85UWF0dnYrNUV1YmMxKwovTGV5RXgzSW9yYjM5L05EL2pDQlpIYzgyaTU1Z3UreVBTVWlITk15RmZOTEZ1alB0VnY3cGZuMXZsYktvcmplCjM2SHdTdkVRbjlCWVRxaWNyUm9vNDdIOEZpL2dJbU41YjlKeGxHNHJzQ0pWYVhTNFo3QVZpSUdBNjZxT2xNMHQKckU3ZEwxRkhuWDl2YnFwNWVCb2ZtM1l0UHltc2lWb2pDbUw2bEJNYmVOUXIrblgzSEFmVFhRcm9Odz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1879"
+      - "1881"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:21 GMT
+      - Thu, 16 Nov 2023 16:09:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1658,7 +1691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cec31fb6-9366-413b-8a8e-d5814603bcb6
+      - c409432f-a0e6-4278-8279-74636aaccd19
     status: 200 OK
     code: 200
     duration: ""
@@ -1669,19 +1702,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/30c49e55-33fc-46fb-a9cd-c3ee2a607920
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"172.16.8.0/22","updated_at":"2023-11-02T19:03:17.580618Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:03:17.580618Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.580618Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:04:35.454808Z","dhcp_enabled":true,"id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:04:35.454808Z","id":"7f8db8ed-f824-48b6-9b65-71b848a000e9","subnet":"172.16.4.0/22","updated_at":"2023-11-16T16:04:35.454808Z"},{"created_at":"2023-11-16T16:04:35.454808Z","id":"0035eb7c-49b0-4c15-9c10-bd05364f8dc7","subnet":"fd68:d440:21c4:853::/64","updated_at":"2023-11-16T16:04:35.454808Z"}],"tags":[],"updated_at":"2023-11-16T16:08:12.873746Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "701"
+      - "732"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:22 GMT
+      - Thu, 16 Nov 2023 16:09:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1691,7 +1724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99e4aa36-4692-4eb2-9f9c-0ec201e2bcf3
+      - 4f259c73-9cbc-4f7d-a700-105400367bf5
     status: 200 OK
     code: 200
     duration: ""
@@ -1702,19 +1735,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e1c1cc9f-8250-4b9a-ab3e-d0797377830d
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.581461Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:08:12.887358Z","dhcp_enabled":true,"id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:08:12.887358Z","id":"badd3afb-5653-498a-8886-4d016b465ea2","subnet":"172.16.8.0/22","updated_at":"2023-11-16T16:08:12.887358Z"},{"created_at":"2023-11-16T16:08:12.887358Z","id":"4dc7cced-46d6-41e8-9630-42b23ed46fd0","subnet":"fd68:d440:21c4:e7d7::/64","updated_at":"2023-11-16T16:08:12.887358Z"}],"tags":[],"updated_at":"2023-11-16T16:08:12.887358Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "716"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:22 GMT
+      - Thu, 16 Nov 2023 16:09:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1724,7 +1757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa65f4cc-3f5f-4a05-810b-c1cca397cf1d
+      - 0f665769-0fbf-4490-826c-e9f5af1cd728
     status: 200 OK
     code: 200
     duration: ""
@@ -1735,19 +1768,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:22 GMT
+      - Thu, 16 Nov 2023 16:09:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1757,7 +1790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f119dcba-3d94-4ea2-a35c-f53533d63385
+      - 5be240bf-f54d-4e35-80b7-e19c09f60c64
     status: 200 OK
     code: 200
     duration: ""
@@ -1768,19 +1801,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVS0pKM01lenBUSGswN3diTTFoRkhNNXpod2xrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNVFl4TmpBM016SmFGdzB6TXpFeE1UTXhOakEzTXpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURJNzVzcjdvVm5OM05BRFl5aFpYVDdld1A0bnQyNkpWZUN1TU1SeTdSZVh1U2xyYllyYTlmYWN3d3UKY2VML1cxRmpGaVdvSTJmb1diZ2tKdG81ZFdhR2tUUlJyWnVtYWw1K0plWVg5UEMzdDV6L0VFUFFRTUJhRnN3NQpNQVIrV0pHSkZCQzl3MWlQUEZlMlpuSmVta2toUXY4SkZxUDBhUW5QMGFGaUVRUERnaS9lZlY3TG1zejBzeGlaCkxJY043ZkoyT0hUVHBsRCtYNjJwSkJWSmhnMXUxT0ZnZlJvZFlnMXlpZVhyZmxxRGx5cnJ0NG9QZjZkblRiMm8KVmZ3VlE0T2JhNWZoNDdRMnRiWDNwME9ZdXQyV3ZKMlZLOWNFajRBeU1ZcVJ0bHdES3k4Q1BSVVdqNXU1TnpjWQpLWE9iWmF5cFg0cnRHTW9iZ0hRSWcyNVhISVMzQWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpJeE1DNHlNem1DUEhKM0xUaGpOamM1TlRCbExXWTFaRFV0TkRJeE5pMWkKTVRWaUxXWTFObVE1TWprM09EZ3pPUzV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OXBKWWNFd0tnQgpLb2NFTTU3Uzd6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFmQXdJUDZ3a0FLam1BTERLMGxlZW55Q21iWTczCjY2ekRKditQWVFpbDhxUTdubkdBQy96RVhQaTdHekxFaTl5bnhRODlPNW1iZklocWFJUjFaeUpVU0xyVGFqRlYKZGt5WkJ0RzZrRGRnWUYzMlhLZExVY2E1dHVxQTFqZERJTkdRUVdjK0RFZVVaNUNwbC85UWF0dnYrNUV1YmMxKwovTGV5RXgzSW9yYjM5L05EL2pDQlpIYzgyaTU1Z3UreVBTVWlITk15RmZOTEZ1alB0VnY3cGZuMXZsYktvcmplCjM2SHdTdkVRbjlCWVRxaWNyUm9vNDdIOEZpL2dJbU41YjlKeGxHNHJzQ0pWYVhTNFo3QVZpSUdBNjZxT2xNMHQKckU3ZEwxRkhuWDl2YnFwNWVCb2ZtM1l0UHltc2lWb2pDbUw2bEJNYmVOUXIrblgzSEFmVFhRcm9Odz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1879"
+      - "1881"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:22 GMT
+      - Thu, 16 Nov 2023 16:09:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1790,7 +1823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06abfcf0-5b22-406b-975c-0c37533b6b1e
+      - 3b13740d-fa04-475f-9e84-a7ed11092701
     status: 200 OK
     code: 200
     duration: ""
@@ -1806,16 +1839,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:23 GMT
+      - Thu, 16 Nov 2023 16:09:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1825,7 +1858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7501cfd3-b9ce-4d78-a012-b07ddc6834bd
+      - 0e606d95-bb2b-4f59-b919-6563c21dd2fa
     status: 200 OK
     code: 200
     duration: ""
@@ -1836,19 +1869,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/9a82af0b-34a4-4749-ab14-189473b39511
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/a4e8afef-1cbb-4a94-b1ce-0311aa373f0c
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:23 GMT
+      - Thu, 16 Nov 2023 16:09:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1858,7 +1891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bb65c58-65a8-43f9-80cc-489f7eeca57d
+      - f1b7adc4-9cfc-4e23-b426-ba9cef16d8de
     status: 200 OK
     code: 200
     duration: ""
@@ -1874,16 +1907,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
     method: POST
   response:
-    body: '{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":null,"id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":null,"id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "356"
+      - "369"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:24 GMT
+      - Thu, 16 Nov 2023 16:09:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1893,7 +1926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 931998d3-ac6a-4fb5-ab31-ba673d4b406f
+      - 956bae8f-0e6b-45e2-b41f-4b54fe0d35ef
     status: 200 OK
     code: 200
     duration: ""
@@ -1904,19 +1937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/a85bcd79-4ee5-4871-b63e-1abd0fae407c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/2b85bdad-4619-44b8-8daf-9f00058635ee
     method: GET
   response:
-    body: '{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":null,"id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":null,"id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "356"
+      - "369"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:24 GMT
+      - Thu, 16 Nov 2023 16:09:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1926,12 +1959,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c8f4dc0-0679-4882-a81e-15308561407a
+      - 63c39761-ba5b-4d5c-ba0f-5cfba8926cd3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","enable_smtp":false,"enable_bastion":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"2b85bdad-4619-44b8-8daf-9f00058635ee","enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
@@ -1942,16 +1975,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:24.389160Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:20.414356Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:24 GMT
+      - Thu, 16 Nov 2023 16:09:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1961,7 +1994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d3ec1cb-4cfb-43d8-b194-546383564cf9
+      - 84681654-87d8-46b9-9b8f-915b49ca4919
     status: 200 OK
     code: 200
     duration: ""
@@ -1972,19 +2005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:24.460270Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:20.479854Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "941"
+      - "974"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:24 GMT
+      - Thu, 16 Nov 2023 16:09:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1994,7 +2027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f20612d-5d83-4a5d-abc1-25ddafa5a94f
+      - 84c78a6f-f914-4894-8e45-4c5e0ce3318c
     status: 200 OK
     code: 200
     duration: ""
@@ -2005,19 +2038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:25.143008Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:21.187235Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:29 GMT
+      - Thu, 16 Nov 2023 16:09:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2027,7 +2060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50f3f045-dd62-4890-974a-f593e9f4a193
+      - 4d310232-9e70-4d75-8673-406f50e09690
     status: 200 OK
     code: 200
     duration: ""
@@ -2038,19 +2071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:25.143008Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:21.187235Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:29 GMT
+      - Thu, 16 Nov 2023 16:09:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2060,7 +2093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 305e4372-f5ec-49df-9643-c37a725a7575
+      - 765b4018-89c2-442c-8f63-c51f41bfadeb
     status: 200 OK
     code: 200
     duration: ""
@@ -2071,19 +2104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:25.143008Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:21.187235Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "971"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:29 GMT
+      - Thu, 16 Nov 2023 16:09:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2093,12 +2126,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db33b62d-2ca4-425a-93c9-0c20d49db128
+      - 04fa5e78-4339-4e27-a8fe-b1333ce155df
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"9a82af0b-34a4-4749-ab14-189473b39511"}'
+    body: '{"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c"}'
     form: {}
     headers:
       Content-Type:
@@ -2109,16 +2142,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":null,"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"created","updated_at":"2023-11-02T19:04:31.839577Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":null,"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"created","updated_at":"2023-11-16T16:09:26.751469Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "953"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:32 GMT
+      - Thu, 16 Nov 2023 16:09:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2128,7 +2161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61856ad0-35dc-4bce-8f71-ef7e080ea104
+      - 22f8069b-ba74-4cc7-a0cc-3d64b918f7ff
     status: 200 OK
     code: 200
     duration: ""
@@ -2139,19 +2172,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":null,"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"created","updated_at":"2023-11-02T19:04:31.839577Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:32.023648Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":null,"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"created","updated_at":"2023-11-16T16:09:26.751469Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:26.945697Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1894"
+      - "1957"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:32 GMT
+      - Thu, 16 Nov 2023 16:09:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2161,7 +2194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca3ddeac-0b87-47fc-b9fd-2db9f010d573
+      - 194d7f34-f83e-490f-8c3c-d5151d6e67e2
     status: 200 OK
     code: 200
     duration: ""
@@ -2172,19 +2205,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":null,"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"created","updated_at":"2023-11-02T19:04:31.839577Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:32.023648Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":null,"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"created","updated_at":"2023-11-16T16:09:26.751469Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:26.945697Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1894"
+      - "1957"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:37 GMT
+      - Thu, 16 Nov 2023 16:09:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2194,7 +2227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd8d024a-d091-4a07-beb8-688fdc960187
+      - 4d2437b1-be06-4680-a5b2-79e5c0e8fd31
     status: 200 OK
     code: 200
     duration: ""
@@ -2205,19 +2238,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:42 GMT
+      - Thu, 16 Nov 2023 16:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2227,7 +2260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ba8ac74-c0e0-4de3-96eb-5a136c8c1b33
+      - 792fe3fe-9462-485b-8b54-acc05ed8ed2c
     status: 200 OK
     code: 200
     duration: ""
@@ -2238,19 +2271,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/de5320ad-a47d-40e5-8d39-a96716925d78
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:42 GMT
+      - Thu, 16 Nov 2023 16:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2260,7 +2293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96cdd6c2-a8a9-4d36-874b-5c2d7304ef1e
+      - e52d4cf8-d34e-4705-a8f6-9bbb6d885769
     status: 200 OK
     code: 200
     duration: ""
@@ -2271,19 +2304,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/de5320ad-a47d-40e5-8d39-a96716925d78
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:42 GMT
+      - Thu, 16 Nov 2023 16:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2293,7 +2326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26e7b735-0c07-44b3-a11d-7dba3230a727
+      - 32f33c69-7c25-440a-bc78-b820b1cc67d7
     status: 200 OK
     code: 200
     duration: ""
@@ -2304,19 +2337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:42 GMT
+      - Thu, 16 Nov 2023 16:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2326,7 +2359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ffffb14-fef3-4c25-8a0e-d689e2210e27
+      - 2fa219be-9abe-461c-9c75-e20279e38c46
     status: 200 OK
     code: 200
     duration: ""
@@ -2337,19 +2370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/de5320ad-a47d-40e5-8d39-a96716925d78
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:42 GMT
+      - Thu, 16 Nov 2023 16:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2359,7 +2392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0eea8b7b-ba41-4748-a366-6e55fcf982e5
+      - c3db0353-63c2-464c-98cc-c3c24b05a0b5
     status: 200 OK
     code: 200
     duration: ""
@@ -2370,19 +2403,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:42 GMT
+      - Thu, 16 Nov 2023 16:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2392,7 +2425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49a76c0a-53f4-4955-908f-cab9b53ab4ed
+      - 3eb9f0d8-6d0f-4a1e-9820-597c5fa52cf1
     status: 200 OK
     code: 200
     duration: ""
@@ -2403,19 +2436,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:42 GMT
+      - Thu, 16 Nov 2023 16:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2425,12 +2458,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eba47e98-bc1f-4211-9d80-0a64e2bb1eb5
+      - e8815328-2ddf-469b-a510-a1e05f064035
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
+    body: '{"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
     form: {}
     headers:
       Content-Type:
@@ -2441,16 +2474,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2023-11-02T19:04:42.717872Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"030551cf-3765-4015-8cdd-5387f1c19d34","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:04:42.717872Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-16T16:09:37.797098Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"add96378-fd5e-461f-a654-92d297747e27","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-16T16:09:37.797098Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:42 GMT
+      - Thu, 16 Nov 2023 16:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2460,7 +2493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 167606c9-e986-41d6-b19c-6b2fb90496a2
+      - dff4f4cc-0566-47b9-9954-48760fef05e3
     status: 200 OK
     code: 200
     duration: ""
@@ -2471,19 +2504,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:42 GMT
+      - Thu, 16 Nov 2023 16:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2493,7 +2526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8a33d2b-ea38-405c-a7f6-8598c0c8464a
+      - 95006c65-be75-4945-8414-3a894b4c0023
     status: 200 OK
     code: 200
     duration: ""
@@ -2504,19 +2537,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/030551cf-3765-4015-8cdd-5387f1c19d34
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/add96378-fd5e-461f-a654-92d297747e27
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:04:42.717872Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"030551cf-3765-4015-8cdd-5387f1c19d34","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:04:42.717872Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-16T16:09:37.797098Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"add96378-fd5e-461f-a654-92d297747e27","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-16T16:09:37.797098Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:42 GMT
+      - Thu, 16 Nov 2023 16:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2526,7 +2559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e5243e4-4351-4861-835a-235c79e53f19
+      - 6fddb08f-f8d4-4620-aace-c64648300838
     status: 200 OK
     code: 200
     duration: ""
@@ -2537,19 +2570,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:43 GMT
+      - Thu, 16 Nov 2023 16:09:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2559,7 +2592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 475218fb-4aa9-4a3b-805b-946270372649
+      - 27b39277-8671-4266-83c1-eb41177c40f6
     status: 200 OK
     code: 200
     duration: ""
@@ -2570,19 +2603,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/a85bcd79-4ee5-4871-b63e-1abd0fae407c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/a4e8afef-1cbb-4a94-b1ce-0311aa373f0c
     method: GET
   response:
-    body: '{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "390"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:44 GMT
+      - Thu, 16 Nov 2023 16:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2592,7 +2625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f04f954-8c38-4058-8ecb-241c01bd5ff0
+      - 853c10c3-084b-487c-aae5-d6258fa753f4
     status: 200 OK
     code: 200
     duration: ""
@@ -2603,19 +2636,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/9a82af0b-34a4-4749-ab14-189473b39511
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/2b85bdad-4619-44b8-8daf-9f00058635ee
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:44 GMT
+      - Thu, 16 Nov 2023 16:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2625,7 +2658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2060c6d-159c-4362-bcb1-fe5ec91985dd
+      - 9d91c522-0d01-409f-9577-d05eb5a51beb
     status: 200 OK
     code: 200
     duration: ""
@@ -2636,19 +2669,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/30c49e55-33fc-46fb-a9cd-c3ee2a607920
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:30.346920Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:04:30.349838Z"}],"tags":[],"updated_at":"2023-11-02T19:04:38.949487Z","vpc_id":"f24e24ff-e35b-4e4c-8e20-22beb977d3ef"}'
+    body: '{"created_at":"2023-11-16T16:04:35.454808Z","dhcp_enabled":true,"id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:04:35.454808Z","id":"7f8db8ed-f824-48b6-9b65-71b848a000e9","subnet":"172.16.4.0/22","updated_at":"2023-11-16T16:04:35.454808Z"},{"created_at":"2023-11-16T16:04:35.454808Z","id":"0035eb7c-49b0-4c15-9c10-bd05364f8dc7","subnet":"fd68:d440:21c4:853::/64","updated_at":"2023-11-16T16:04:35.454808Z"}],"tags":[],"updated_at":"2023-11-16T16:08:12.873746Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "702"
+      - "732"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:44 GMT
+      - Thu, 16 Nov 2023 16:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2658,7 +2691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbd676e4-ba74-4798-aad8-148d9ff386f4
+      - bb52807e-a11d-4ea5-9348-5c7f6c1a061b
     status: 200 OK
     code: 200
     duration: ""
@@ -2669,19 +2702,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e1c1cc9f-8250-4b9a-ab3e-d0797377830d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-16T16:08:12.887358Z","dhcp_enabled":true,"id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:08:12.887358Z","id":"badd3afb-5653-498a-8886-4d016b465ea2","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:26.225795Z"},{"created_at":"2023-11-16T16:08:12.887358Z","id":"4dc7cced-46d6-41e8-9630-42b23ed46fd0","subnet":"fd68:d440:21c4:e7d7::/64","updated_at":"2023-11-16T16:09:26.229980Z"}],"tags":[],"updated_at":"2023-11-16T16:09:33.221064Z","vpc_id":"0515194e-6e9b-4c7e-bda9-abcb50625b14"}'
     headers:
       Content-Length:
-      - "1903"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:44 GMT
+      - Thu, 16 Nov 2023 16:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2691,7 +2724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c90645fc-0f1f-4b06-ab65-e1b7c510580b
+      - b6745311-0e6e-40c1-829f-f879e6c1514c
     status: 200 OK
     code: 200
     duration: ""
@@ -2702,19 +2735,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.581461Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "716"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:44 GMT
+      - Thu, 16 Nov 2023 16:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2724,7 +2757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d61298a-fde9-4fb0-917f-26285f5241d9
+      - 74d9b322-da69-407c-b0b1-3462e86366b2
     status: 200 OK
     code: 200
     duration: ""
@@ -2735,19 +2768,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "966"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:44 GMT
+      - Thu, 16 Nov 2023 16:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2757,7 +2790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c8c9af8-0095-4d62-8373-5cd25064e4f0
+      - 94cc50fb-992c-4685-9ea4-c333f3f8bf7a
     status: 200 OK
     code: 200
     duration: ""
@@ -2768,19 +2801,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/de5320ad-a47d-40e5-8d39-a96716925d78
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1453"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:44 GMT
+      - Thu, 16 Nov 2023 16:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2790,7 +2823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7939fe8-b92e-48ab-b09f-29f62eceae9c
+      - 70b95fa4-49a6-4709-aa1b-5f6d7b050fd8
     status: 200 OK
     code: 200
     duration: ""
@@ -2801,19 +2834,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:44 GMT
+      - Thu, 16 Nov 2023 16:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2823,7 +2856,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5551f3c-9699-4354-85b9-0eb56f22f462
+      - a9e72acb-d507-49c0-85cf-f22949620c6e
     status: 200 OK
     code: 200
     duration: ""
@@ -2834,19 +2867,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839/certificate
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVS0pKM01lenBUSGswN3diTTFoRkhNNXpod2xrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNVFl4TmpBM016SmFGdzB6TXpFeE1UTXhOakEzTXpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURJNzVzcjdvVm5OM05BRFl5aFpYVDdld1A0bnQyNkpWZUN1TU1SeTdSZVh1U2xyYllyYTlmYWN3d3UKY2VML1cxRmpGaVdvSTJmb1diZ2tKdG81ZFdhR2tUUlJyWnVtYWw1K0plWVg5UEMzdDV6L0VFUFFRTUJhRnN3NQpNQVIrV0pHSkZCQzl3MWlQUEZlMlpuSmVta2toUXY4SkZxUDBhUW5QMGFGaUVRUERnaS9lZlY3TG1zejBzeGlaCkxJY043ZkoyT0hUVHBsRCtYNjJwSkJWSmhnMXUxT0ZnZlJvZFlnMXlpZVhyZmxxRGx5cnJ0NG9QZjZkblRiMm8KVmZ3VlE0T2JhNWZoNDdRMnRiWDNwME9ZdXQyV3ZKMlZLOWNFajRBeU1ZcVJ0bHdES3k4Q1BSVVdqNXU1TnpjWQpLWE9iWmF5cFg0cnRHTW9iZ0hRSWcyNVhISVMzQWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpJeE1DNHlNem1DUEhKM0xUaGpOamM1TlRCbExXWTFaRFV0TkRJeE5pMWkKTVRWaUxXWTFObVE1TWprM09EZ3pPUzV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OXBKWWNFd0tnQgpLb2NFTTU3Uzd6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFmQXdJUDZ3a0FLam1BTERLMGxlZW55Q21iWTczCjY2ekRKditQWVFpbDhxUTdubkdBQy96RVhQaTdHekxFaTl5bnhRODlPNW1iZklocWFJUjFaeUpVU0xyVGFqRlYKZGt5WkJ0RzZrRGRnWUYzMlhLZExVY2E1dHVxQTFqZERJTkdRUVdjK0RFZVVaNUNwbC85UWF0dnYrNUV1YmMxKwovTGV5RXgzSW9yYjM5L05EL2pDQlpIYzgyaTU1Z3UreVBTVWlITk15RmZOTEZ1alB0VnY3cGZuMXZsYktvcmplCjM2SHdTdkVRbjlCWVRxaWNyUm9vNDdIOEZpL2dJbU41YjlKeGxHNHJzQ0pWYVhTNFo3QVZpSUdBNjZxT2xNMHQKckU3ZEwxRkhuWDl2YnFwNWVCb2ZtM1l0UHltc2lWb2pDbUw2bEJNYmVOUXIrblgzSEFmVFhRcm9Odz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "966"
+      - "1881"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:44 GMT
+      - Thu, 16 Nov 2023 16:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2856,7 +2889,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f167cbc-f70e-46ab-aeaf-2039a067dfb3
+      - cdec8740-8baa-4908-84a7-aaa62544f777
     status: 200 OK
     code: 200
     duration: ""
@@ -2867,19 +2900,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/de5320ad-a47d-40e5-8d39-a96716925d78
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1879"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:44 GMT
+      - Thu, 16 Nov 2023 16:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2889,7 +2922,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3358d9d-2e9f-47a3-8775-a969250660cc
+      - 3d6c08fd-539a-4dd5-bc2c-63b1e46ae100
     status: 200 OK
     code: 200
     duration: ""
@@ -2900,19 +2933,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/030551cf-3765-4015-8cdd-5387f1c19d34
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/add96378-fd5e-461f-a654-92d297747e27
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:04:42.717872Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"030551cf-3765-4015-8cdd-5387f1c19d34","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:04:42.717872Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-16T16:09:37.797098Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"add96378-fd5e-461f-a654-92d297747e27","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-16T16:09:37.797098Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:44 GMT
+      - Thu, 16 Nov 2023 16:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2922,7 +2955,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d047633c-bad9-48fe-9787-635e8590893e
+      - d4151c2c-db2f-43d6-af10-46c3f64bb801
     status: 200 OK
     code: 200
     duration: ""
@@ -2933,19 +2966,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/030551cf-3765-4015-8cdd-5387f1c19d34
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/add96378-fd5e-461f-a654-92d297747e27
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:04:42.717872Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"030551cf-3765-4015-8cdd-5387f1c19d34","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:04:42.717872Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-16T16:09:37.797098Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"add96378-fd5e-461f-a654-92d297747e27","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-16T16:09:37.797098Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:45 GMT
+      - Thu, 16 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2955,7 +2988,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9253227f-6e8e-4b3e-84c9-133471cab5e1
+      - 71080587-6f4f-422c-84d0-9aa145140945
     status: 200 OK
     code: 200
     duration: ""
@@ -2966,19 +2999,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/a85bcd79-4ee5-4871-b63e-1abd0fae407c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/a4e8afef-1cbb-4a94-b1ce-0311aa373f0c
     method: GET
   response:
-    body: '{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "390"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:45 GMT
+      - Thu, 16 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2988,7 +3021,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03f290d0-96e0-470a-a574-ab5394a38a9e
+      - 9f27e045-8501-4f8c-a600-de02e6945f44
     status: 200 OK
     code: 200
     duration: ""
@@ -2999,19 +3032,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/9a82af0b-34a4-4749-ab14-189473b39511
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/2b85bdad-4619-44b8-8daf-9f00058635ee
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:45 GMT
+      - Thu, 16 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3021,7 +3054,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a444d14b-8999-407e-88c6-4b2b95d84b6a
+      - 946004f4-c63f-4aa4-b449-3f62d5a544d6
     status: 200 OK
     code: 200
     duration: ""
@@ -3032,19 +3065,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:45 GMT
+      - Thu, 16 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3054,7 +3087,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11a0499f-f2c3-4564-bfdd-d62d1af2d32b
+      - acb161d8-d641-4fc7-829b-c5509f503e85
     status: 200 OK
     code: 200
     duration: ""
@@ -3065,19 +3098,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/30c49e55-33fc-46fb-a9cd-c3ee2a607920
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:00:09.985180Z","dhcp_enabled":true,"id":"ea0854da-211d-4cca-b625-68104d98a8d0","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:00:09.985180Z","id":"da788da6-f5bd-4e90-a4ff-1298b12a0607","subnet":"172.16.12.0/22","updated_at":"2023-11-02T19:00:09.985180Z"},{"created_at":"2023-11-02T19:00:09.985180Z","id":"82bb0bb2-1d6f-403c-baf1-a56fedb113f9","subnet":"fd68:d440:21c4:b13::/64","updated_at":"2023-11-02T19:00:09.985180Z"}],"tags":[],"updated_at":"2023-11-02T19:03:17.581461Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-16T16:04:35.454808Z","dhcp_enabled":true,"id":"30c49e55-33fc-46fb-a9cd-c3ee2a607920","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:04:35.454808Z","id":"7f8db8ed-f824-48b6-9b65-71b848a000e9","subnet":"172.16.4.0/22","updated_at":"2023-11-16T16:04:35.454808Z"},{"created_at":"2023-11-16T16:04:35.454808Z","id":"0035eb7c-49b0-4c15-9c10-bd05364f8dc7","subnet":"fd68:d440:21c4:853::/64","updated_at":"2023-11-16T16:04:35.454808Z"}],"tags":[],"updated_at":"2023-11-16T16:08:12.873746Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "716"
+      - "732"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:45 GMT
+      - Thu, 16 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3087,7 +3120,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee8ebee9-f325-4a3a-a9e5-3f52505020f1
+      - 6cefeb6a-9328-4cb5-9ae2-6d9bb20463ab
     status: 200 OK
     code: 200
     duration: ""
@@ -3098,19 +3131,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e1c1cc9f-8250-4b9a-ab3e-d0797377830d
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:30.346920Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:04:30.349838Z"}],"tags":[],"updated_at":"2023-11-02T19:04:38.949487Z","vpc_id":"f24e24ff-e35b-4e4c-8e20-22beb977d3ef"}'
+    body: '{"created_at":"2023-11-16T16:08:12.887358Z","dhcp_enabled":true,"id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:08:12.887358Z","id":"badd3afb-5653-498a-8886-4d016b465ea2","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:26.225795Z"},{"created_at":"2023-11-16T16:08:12.887358Z","id":"4dc7cced-46d6-41e8-9630-42b23ed46fd0","subnet":"fd68:d440:21c4:e7d7::/64","updated_at":"2023-11-16T16:09:26.229980Z"}],"tags":[],"updated_at":"2023-11-16T16:09:33.221064Z","vpc_id":"0515194e-6e9b-4c7e-bda9-abcb50625b14"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:45 GMT
+      - Thu, 16 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3120,7 +3153,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b66df8aa-732e-42d7-a62b-3acf03f41fa3
+      - 12584e37-a405-401c-b13b-140277979395
     status: 200 OK
     code: 200
     duration: ""
@@ -3131,19 +3164,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/de5320ad-a47d-40e5-8d39-a96716925d78
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:45 GMT
+      - Thu, 16 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3153,7 +3186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae08b4db-8a14-4527-9367-23e92c6f0e0e
+      - f620bb52-b0fa-4227-9ac1-912f41014b08
     status: 200 OK
     code: 200
     duration: ""
@@ -3164,19 +3197,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:45 GMT
+      - Thu, 16 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3186,7 +3219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 000bedc4-5562-40a6-b081-4769638b2606
+      - f2758c3b-e592-4d91-b3ac-a151eee7660e
     status: 200 OK
     code: 200
     duration: ""
@@ -3197,19 +3230,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:45 GMT
+      - Thu, 16 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3219,7 +3252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50402085-3051-4f89-93b4-b1adb573cebd
+      - 314797ad-4bf8-42e9-9e13-109039065b1b
     status: 200 OK
     code: 200
     duration: ""
@@ -3230,19 +3263,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/de5320ad-a47d-40e5-8d39-a96716925d78
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:45 GMT
+      - Thu, 16 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3252,7 +3285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2f4b79d-f611-4ae5-b7dc-25994b4d2d29
+      - 23ad9be6-d6bd-4792-874f-5084a80ddef8
     status: 200 OK
     code: 200
     duration: ""
@@ -3263,19 +3296,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVS0pKM01lenBUSGswN3diTTFoRkhNNXpod2xrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNVFl4TmpBM016SmFGdzB6TXpFeE1UTXhOakEzTXpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURJNzVzcjdvVm5OM05BRFl5aFpYVDdld1A0bnQyNkpWZUN1TU1SeTdSZVh1U2xyYllyYTlmYWN3d3UKY2VML1cxRmpGaVdvSTJmb1diZ2tKdG81ZFdhR2tUUlJyWnVtYWw1K0plWVg5UEMzdDV6L0VFUFFRTUJhRnN3NQpNQVIrV0pHSkZCQzl3MWlQUEZlMlpuSmVta2toUXY4SkZxUDBhUW5QMGFGaUVRUERnaS9lZlY3TG1zejBzeGlaCkxJY043ZkoyT0hUVHBsRCtYNjJwSkJWSmhnMXUxT0ZnZlJvZFlnMXlpZVhyZmxxRGx5cnJ0NG9QZjZkblRiMm8KVmZ3VlE0T2JhNWZoNDdRMnRiWDNwME9ZdXQyV3ZKMlZLOWNFajRBeU1ZcVJ0bHdES3k4Q1BSVVdqNXU1TnpjWQpLWE9iWmF5cFg0cnRHTW9iZ0hRSWcyNVhISVMzQWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpJeE1DNHlNem1DUEhKM0xUaGpOamM1TlRCbExXWTFaRFV0TkRJeE5pMWkKTVRWaUxXWTFObVE1TWprM09EZ3pPUzV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OXBKWWNFd0tnQgpLb2NFTTU3Uzd6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFmQXdJUDZ3a0FLam1BTERLMGxlZW55Q21iWTczCjY2ekRKditQWVFpbDhxUTdubkdBQy96RVhQaTdHekxFaTl5bnhRODlPNW1iZklocWFJUjFaeUpVU0xyVGFqRlYKZGt5WkJ0RzZrRGRnWUYzMlhLZExVY2E1dHVxQTFqZERJTkdRUVdjK0RFZVVaNUNwbC85UWF0dnYrNUV1YmMxKwovTGV5RXgzSW9yYjM5L05EL2pDQlpIYzgyaTU1Z3UreVBTVWlITk15RmZOTEZ1alB0VnY3cGZuMXZsYktvcmplCjM2SHdTdkVRbjlCWVRxaWNyUm9vNDdIOEZpL2dJbU41YjlKeGxHNHJzQ0pWYVhTNFo3QVZpSUdBNjZxT2xNMHQKckU3ZEwxRkhuWDl2YnFwNWVCb2ZtM1l0UHltc2lWb2pDbUw2bEJNYmVOUXIrblgzSEFmVFhRcm9Odz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1879"
+      - "1881"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:45 GMT
+      - Thu, 16 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3285,7 +3318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fee6384e-7ac1-4ff4-9b4e-bdfb85073c13
+      - e6df4dd1-bfcf-4046-9ae6-448de3cf948e
     status: 200 OK
     code: 200
     duration: ""
@@ -3296,19 +3329,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/030551cf-3765-4015-8cdd-5387f1c19d34
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/add96378-fd5e-461f-a654-92d297747e27
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:04:42.717872Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"030551cf-3765-4015-8cdd-5387f1c19d34","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-02T19:04:42.717872Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-11-16T16:09:37.797098Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"add96378-fd5e-461f-a654-92d297747e27","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-16T16:09:37.797098Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:46 GMT
+      - Thu, 16 Nov 2023 16:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3318,7 +3351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d348d86-4911-4526-bb85-24a0964ae261
+      - 0d333387-4f42-4cc7-ac55-b0e5996a6221
     status: 200 OK
     code: 200
     duration: ""
@@ -3329,19 +3362,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:46 GMT
+      - Thu, 16 Nov 2023 16:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3351,7 +3384,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 032c4ada-49d6-4a47-980b-64babb95c679
+      - 0d5266b0-d5a1-4a81-9aeb-9ccc1489e86a
     status: 200 OK
     code: 200
     duration: ""
@@ -3362,7 +3395,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/030551cf-3765-4015-8cdd-5387f1c19d34
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/add96378-fd5e-461f-a654-92d297747e27
     method: DELETE
   response:
     body: ""
@@ -3372,7 +3405,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:46 GMT
+      - Thu, 16 Nov 2023 16:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3382,7 +3415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 865ff78a-e65b-4a36-8fa5-41f0a5e7f6ed
+      - 754f53cb-48f5-4257-8ed5-284d5393401b
     status: 204 No Content
     code: 204
     duration: ""
@@ -3393,19 +3426,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:46 GMT
+      - Thu, 16 Nov 2023 16:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3415,7 +3448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f29d6de8-0e9b-4238-936d-66ae6ffcc913
+      - 6d45eacd-c7a7-418f-8693-0bb2d459a416
     status: 200 OK
     code: 200
     duration: ""
@@ -3426,19 +3459,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/de5320ad-a47d-40e5-8d39-a96716925d78
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"ready","updated_at":"2023-11-02T19:04:39.322434Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"ready","updated_at":"2023-11-16T16:09:36.427810Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:46 GMT
+      - Thu, 16 Nov 2023 16:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3448,7 +3481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e96401c7-ace4-4c86-9bc1-505fc40efe68
+      - f90d4223-62fa-444b-b7ff-531cc0c6e83c
     status: 200 OK
     code: 200
     duration: ""
@@ -3459,19 +3492,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:46 GMT
+      - Thu, 16 Nov 2023 16:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3481,7 +3514,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4155031-ddaa-4161-8883-fab51d4e0181
+      - d43f051b-4463-4f53-97fa-424ec0dd96aa
     status: 200 OK
     code: 200
     duration: ""
@@ -3492,7 +3525,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/de5320ad-a47d-40e5-8d39-a96716925d78?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -3502,7 +3535,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:46 GMT
+      - Thu, 16 Nov 2023 16:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3512,7 +3545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 871f3f8b-94b3-45c5-8eda-cb613b081390
+      - 5d269eec-4258-44ca-ab26-8a09ca9e14e4
     status: 204 No Content
     code: 204
     duration: ""
@@ -3523,19 +3556,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/de5320ad-a47d-40e5-8d39-a96716925d78
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-02T19:04:31.839577Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-02T19:04:23.705273Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a82af0b-34a4-4749-ab14-189473b39511","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:23.705273Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","ipam_config":null,"mac_address":"02:00:00:11:E4:7E","private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","status":"detaching","updated_at":"2023-11-02T19:04:46.495890Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-11-16T16:09:26.751469Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-16T16:09:19.561563Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:19.561563Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"de5320ad-a47d-40e5-8d39-a96716925d78","ipam_config":null,"mac_address":"02:00:00:11:F7:AE","private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","status":"detaching","updated_at":"2023-11-16T16:09:41.587094Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "970"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:46 GMT
+      - Thu, 16 Nov 2023 16:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3545,7 +3578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc336bf5-43da-4731-87d8-8423fc4e3051
+      - aceac461-314e-4c66-8b13-16c7edc618e7
     status: 200 OK
     code: 200
     duration: ""
@@ -3556,19 +3589,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:46 GMT
+      - Thu, 16 Nov 2023 16:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3578,40 +3611,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d126815-83f4-455f-a4d5-0c0c6b3dbf1a
+      - 3e35d2f7-c420-457f-a97d-c4e5c969d43c
     status: 200 OK
     code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea0854da-211d-4cca-b625-68104d98a8d0
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 19:04:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a98e57ce-8ae1-40fc-8a67-565fdc9f7a63
-    status: 204 No Content
-    code: 204
     duration: ""
 - request:
     body: '{}'
@@ -3622,19 +3624,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:46 GMT
+      - Thu, 16 Nov 2023 16:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3644,7 +3646,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbe17f8c-88a8-4cd4-bbff-2b3d5d8d352e
+      - 9b9317c9-7a62-494f-bfed-9efbf87ad5d3
     status: 200 OK
     code: 200
     duration: ""
@@ -3655,40 +3657,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1453"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 19:04:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a29d2cbd-8b48-43bb-966d-dd0778e29af5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/12092b19-c7b9-4e52-b1d4-571b56c675a6
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/30c49e55-33fc-46fb-a9cd-c3ee2a607920
     method: DELETE
   response:
     body: ""
@@ -3698,7 +3667,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:47 GMT
+      - Thu, 16 Nov 2023 16:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3708,7 +3677,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d25eb68-41a7-43c6-b70d-b8f97291c939
+      - 45b00fb9-f4da-4f18-9255-0b03f35021ca
     status: 204 No Content
     code: 204
     duration: ""
@@ -3719,19 +3688,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"12092b19-c7b9-4e52-b1d4-571b56c675a6","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1459"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:47 GMT
+      - Thu, 16 Nov 2023 16:09:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3741,7 +3710,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cafe6355-3d2a-449a-8d22-ad78cdbf75b8
+      - cdf75869-fa79-44fb-a382-6801d79fc474
     status: 200 OK
     code: 200
     duration: ""
@@ -3752,10 +3721,74 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/7bbfa405-73e7-4b9d-8f74-8024b0c07147
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/b631c620-93f7-4b49-92e4-432265f98519
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:09:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - af848cb9-0a80-49eb-8a10-edd9b531dfb4
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"7bbfa405-73e7-4b9d-8f74-8024b0c07147","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b631c620-93f7-4b49-92e4-432265f98519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1513"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:09:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 57934319-496f-4f51-b9cb-d106aac4a488
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/de5320ad-a47d-40e5-8d39-a96716925d78
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"de5320ad-a47d-40e5-8d39-a96716925d78","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3764,7 +3797,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:51 GMT
+      - Thu, 16 Nov 2023 16:09:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3774,7 +3807,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f51bb2a-17fa-4b08-bd4e-6b6a1b77d2fc
+      - 78f12ea6-708e-4278-9271-c7a194c0128c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3785,19 +3818,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "937"
+      - "970"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:51 GMT
+      - Thu, 16 Nov 2023 16:09:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3807,7 +3840,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23057c48-2a20-468e-85fa-614dca4b35b7
+      - 303af3b9-63cb-417e-91d9-b53bd1beb792
     status: 200 OK
     code: 200
     duration: ""
@@ -3818,10 +3851,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/9a82af0b-34a4-4749-ab14-189473b39511
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/a4e8afef-1cbb-4a94-b1ce-0311aa373f0c
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"9a82af0b-34a4-4749-ab14-189473b39511","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"a4e8afef-1cbb-4a94-b1ce-0311aa373f0c","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3830,7 +3863,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:51 GMT
+      - Thu, 16 Nov 2023 16:09:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3840,7 +3873,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6d5cd25-8ce1-48de-acfa-a6104ba200a3
+      - c1a022c7-43b4-4850-a5a3-53a99ea533d9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3851,19 +3884,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-02T19:04:24.389160Z","gateway_networks":[],"id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","ip":{"address":"51.15.111.89","created_at":"2023-11-02T19:04:24.135579Z","gateway_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","id":"a85bcd79-4ee5-4871-b63e-1abd0fae407c","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-02T19:04:24.135579Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-02T19:04:39.438685Z","upstream_dns_servers":[],"version":"0.6.0","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-16T16:09:20.414356Z","gateway_networks":[],"id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","ip":{"address":"51.158.184.172","created_at":"2023-11-16T16:09:20.244253Z","gateway_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","id":"2b85bdad-4619-44b8-8daf-9f00058635ee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"172-184-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-16T16:09:20.244253Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-16T16:09:36.555202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "937"
+      - "970"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:51 GMT
+      - Thu, 16 Nov 2023 16:09:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3873,7 +3906,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86f54794-abed-44ce-ad5e-474ef37bb6c5
+      - bb827224-14bb-4a0a-8a87-528f9acd9df0
     status: 200 OK
     code: 200
     duration: ""
@@ -3884,7 +3917,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3894,7 +3927,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:51 GMT
+      - Thu, 16 Nov 2023 16:09:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3904,7 +3937,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a18e950-0e66-4b99-adcd-f27925157a8d
+      - 3fc040f9-b3a1-4e39-831b-188fc639f6da
     status: 204 No Content
     code: 204
     duration: ""
@@ -3915,10 +3948,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/a4b3d7c6-6294-42a1-84a8-39a2bce0aa93
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"a4b3d7c6-6294-42a1-84a8-39a2bce0aa93","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"c7c5316d-1dd7-4fdb-8e38-859c2dc2f0ab","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3927,7 +3960,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:51 GMT
+      - Thu, 16 Nov 2023 16:09:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3937,7 +3970,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b0aebf5-b4d5-4cd7-b7ba-963f3998ac26
+      - 9fc5d779-226e-4d3e-85fb-3946273e64fc
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3948,7 +3981,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/a85bcd79-4ee5-4871-b63e-1abd0fae407c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/2b85bdad-4619-44b8-8daf-9f00058635ee
     method: DELETE
   response:
     body: ""
@@ -3958,7 +3991,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:52 GMT
+      - Thu, 16 Nov 2023 16:09:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3968,7 +4001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da68a5b0-7b5f-4b35-9bbe-d8d69ef417ec
+      - 5bd1b9e5-18d0-456a-b738-c46cddf6e990
     status: 204 No Content
     code: 204
     duration: ""
@@ -3979,19 +4012,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1279"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:17 GMT
+      - Thu, 16 Nov 2023 16:10:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4001,7 +4034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e1fd8f9-bd09-4e48-834b-5c33826f261f
+      - 79409454-3a64-46ef-9cc3-79d546040c22
     status: 200 OK
     code: 200
     duration: ""
@@ -4012,19 +4045,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1279"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:17 GMT
+      - Thu, 16 Nov 2023 16:10:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4034,7 +4067,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a123d7d-3ce9-4dda-8ea1-d4898252111e
+      - a1a83c5e-e776-4813-b1b1-e16364e0f862
     status: 200 OK
     code: 200
     duration: ""
@@ -4045,19 +4078,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVS0pKM01lenBUSGswN3diTTFoRkhNNXpod2xrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNVFl4TmpBM016SmFGdzB6TXpFeE1UTXhOakEzTXpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURJNzVzcjdvVm5OM05BRFl5aFpYVDdld1A0bnQyNkpWZUN1TU1SeTdSZVh1U2xyYllyYTlmYWN3d3UKY2VML1cxRmpGaVdvSTJmb1diZ2tKdG81ZFdhR2tUUlJyWnVtYWw1K0plWVg5UEMzdDV6L0VFUFFRTUJhRnN3NQpNQVIrV0pHSkZCQzl3MWlQUEZlMlpuSmVta2toUXY4SkZxUDBhUW5QMGFGaUVRUERnaS9lZlY3TG1zejBzeGlaCkxJY043ZkoyT0hUVHBsRCtYNjJwSkJWSmhnMXUxT0ZnZlJvZFlnMXlpZVhyZmxxRGx5cnJ0NG9QZjZkblRiMm8KVmZ3VlE0T2JhNWZoNDdRMnRiWDNwME9ZdXQyV3ZKMlZLOWNFajRBeU1ZcVJ0bHdES3k4Q1BSVVdqNXU1TnpjWQpLWE9iWmF5cFg0cnRHTW9iZ0hRSWcyNVhISVMzQWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpJeE1DNHlNem1DUEhKM0xUaGpOamM1TlRCbExXWTFaRFV0TkRJeE5pMWkKTVRWaUxXWTFObVE1TWprM09EZ3pPUzV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OXBKWWNFd0tnQgpLb2NFTTU3Uzd6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFmQXdJUDZ3a0FLam1BTERLMGxlZW55Q21iWTczCjY2ekRKditQWVFpbDhxUTdubkdBQy96RVhQaTdHekxFaTl5bnhRODlPNW1iZklocWFJUjFaeUpVU0xyVGFqRlYKZGt5WkJ0RzZrRGRnWUYzMlhLZExVY2E1dHVxQTFqZERJTkdRUVdjK0RFZVVaNUNwbC85UWF0dnYrNUV1YmMxKwovTGV5RXgzSW9yYjM5L05EL2pDQlpIYzgyaTU1Z3UreVBTVWlITk15RmZOTEZ1alB0VnY3cGZuMXZsYktvcmplCjM2SHdTdkVRbjlCWVRxaWNyUm9vNDdIOEZpL2dJbU41YjlKeGxHNHJzQ0pWYVhTNFo3QVZpSUdBNjZxT2xNMHQKckU3ZEwxRkhuWDl2YnFwNWVCb2ZtM1l0UHltc2lWb2pDbUw2bEJNYmVOUXIrblgzSEFmVFhRcm9Odz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1879"
+      - "1881"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:17 GMT
+      - Thu, 16 Nov 2023 16:10:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4067,7 +4100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c7ee21f-19b4-4b41-b12e-fca6dee74d7a
+      - be547e09-5ddf-44ec-befd-0d736029546c
     status: 200 OK
     code: 200
     duration: ""
@@ -4078,19 +4111,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e1c1cc9f-8250-4b9a-ab3e-d0797377830d
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T19:03:17.580618Z","dhcp_enabled":true,"id":"8c96124f-20c2-42fa-a66f-60a0387ec4c9","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-02T19:03:17.580618Z","id":"5fac6309-5b9e-410a-99b1-d941ca004f0c","subnet":"192.168.1.0/24","updated_at":"2023-11-02T19:04:30.346920Z"},{"created_at":"2023-11-02T19:03:17.580618Z","id":"bc28f882-eca4-4c8f-abe0-df520e71f3a7","subnet":"fd68:d440:21c4:65b5::/64","updated_at":"2023-11-02T19:04:30.349838Z"}],"tags":[],"updated_at":"2023-11-02T19:04:46.677701Z","vpc_id":"f24e24ff-e35b-4e4c-8e20-22beb977d3ef"}'
+    body: '{"created_at":"2023-11-16T16:08:12.887358Z","dhcp_enabled":true,"id":"e1c1cc9f-8250-4b9a-ab3e-d0797377830d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-16T16:08:12.887358Z","id":"badd3afb-5653-498a-8886-4d016b465ea2","subnet":"192.168.1.0/24","updated_at":"2023-11-16T16:09:26.225795Z"},{"created_at":"2023-11-16T16:08:12.887358Z","id":"4dc7cced-46d6-41e8-9630-42b23ed46fd0","subnet":"fd68:d440:21c4:e7d7::/64","updated_at":"2023-11-16T16:09:26.229980Z"}],"tags":[],"updated_at":"2023-11-16T16:09:41.749873Z","vpc_id":"0515194e-6e9b-4c7e-bda9-abcb50625b14"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:18 GMT
+      - Thu, 16 Nov 2023 16:10:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4100,7 +4133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c47f419-3aed-45af-8ce1-f0b0d8b3b448
+      - afb9d6fb-f4f5-47ae-87c8-4b428d091549
     status: 200 OK
     code: 200
     duration: ""
@@ -4111,19 +4144,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1279"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:18 GMT
+      - Thu, 16 Nov 2023 16:10:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4133,7 +4166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fcd03b3-30c9-4beb-bddb-a274077ef815
+      - ea09ba34-c09b-42dd-80d4-a586998c31d0
     status: 200 OK
     code: 200
     duration: ""
@@ -4144,19 +4177,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVTjJad2xMZWlGQ25MT1VXejJDNEZVYXFmazlvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNREl4T1RBeE1qRmFGdzB6TXpFd016QXhPVEF4TWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ3RVBzS3RSOElEMFJWbXJYSjNoVWh6S0kva0JpajJIWnRIZGFya2dWclJ2SytEei9vTkVrK25DV1gKdUhwK3ZwdGtQY25LWTlPekpnaXBIc0xZQ21mdmFZellOeFJnZWZ6Y3lwSDZzaVZPM3BZSklpWWtCcFRGZ3Z0OQpOeWQ4YlJvSXgxR0tBdUtiOVFvcUJ5eGZTZmNEdzBUZUFCUFZMR1JRMnB0OVJaV0lJSEtJdVFUdHJwVWhaczB3CkZBclFYZnQ5TnVmMDVwdFpGWEJ1TVpNb0s5NzlJQktJdkRyejgvZHJabVJZSC9ZemF6NVQxZUhxUGhMZjJIRkoKN3VVZ0VVc2NxMStCdjVMV2JBMlR6ZERCQXppaVk4VktwUXVNamZCeHlJOWxSZ2lnQ213T2tTbnNDOW1Dazk0aQo5UkVBS0pReFV5bllKUjRRNks5QWMwaWZBaDl4QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1DNHlNREtDUEhKM0xURmlNelpsWldRMExUQmlPV1l0TkRSbE1TMDUKT1RRM0xUaGtZelF4TldFNFpqTmpNeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OVdqSWNFd0tnQgpLb2NFTTU2Q3lqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF5M29OOENveWJGWXRFdHcwOW9ZZXIxMzFMU2ZYCnkvQ1MzaEV2MFZEZWVZaDZBMUgzcFAxSXJoRzR4bVdjcDV0VE41d0o1bGdJODRzR3M1REJURG9USHE3bXFJU3AKb2lXM3N5bEp1T1NGVHAwekJBVFM1aEJaZ3FWTS9PalN0eHZQK1hpVkxSdVkxa0kzNDUvbGZuMmxoUVZ0TUxROApoNlVsczc4bHljMGdxalBVSklJWElFN2Y1RklJT0MwYm1ubjZPSk1qV0QzMTBoMURYWFpLaExEd3d5a3ZrdHN1CmJwbEZTWm96TzBIN1ZJa3ZxSmFxUHdRM1JielFzQitBaC90OGNkbmwzdGtqNzJmVWszbVRnZVovRDRybm1vT04KZUhDNCtHd0dBSzhQbDROV1huVUV4bmhYYTEveXdMeU9FV3YvekdBMzZJZXd6MzJQSnJwRklFWEYwZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVS0pKM01lenBUSGswN3diTTFoRkhNNXpod2xrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNVFl4TmpBM016SmFGdzB6TXpFeE1UTXhOakEzTXpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURJNzVzcjdvVm5OM05BRFl5aFpYVDdld1A0bnQyNkpWZUN1TU1SeTdSZVh1U2xyYllyYTlmYWN3d3UKY2VML1cxRmpGaVdvSTJmb1diZ2tKdG81ZFdhR2tUUlJyWnVtYWw1K0plWVg5UEMzdDV6L0VFUFFRTUJhRnN3NQpNQVIrV0pHSkZCQzl3MWlQUEZlMlpuSmVta2toUXY4SkZxUDBhUW5QMGFGaUVRUERnaS9lZlY3TG1zejBzeGlaCkxJY043ZkoyT0hUVHBsRCtYNjJwSkJWSmhnMXUxT0ZnZlJvZFlnMXlpZVhyZmxxRGx5cnJ0NG9QZjZkblRiMm8KVmZ3VlE0T2JhNWZoNDdRMnRiWDNwME9ZdXQyV3ZKMlZLOWNFajRBeU1ZcVJ0bHdES3k4Q1BSVVdqNXU1TnpjWQpLWE9iWmF5cFg0cnRHTW9iZ0hRSWcyNVhISVMzQWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpJeE1DNHlNem1DUEhKM0xUaGpOamM1TlRCbExXWTFaRFV0TkRJeE5pMWkKTVRWaUxXWTFObVE1TWprM09EZ3pPUzV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OXBKWWNFd0tnQgpLb2NFTTU3Uzd6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFmQXdJUDZ3a0FLam1BTERLMGxlZW55Q21iWTczCjY2ekRKditQWVFpbDhxUTdubkdBQy96RVhQaTdHekxFaTl5bnhRODlPNW1iZklocWFJUjFaeUpVU0xyVGFqRlYKZGt5WkJ0RzZrRGRnWUYzMlhLZExVY2E1dHVxQTFqZERJTkdRUVdjK0RFZVVaNUNwbC85UWF0dnYrNUV1YmMxKwovTGV5RXgzSW9yYjM5L05EL2pDQlpIYzgyaTU1Z3UreVBTVWlITk15RmZOTEZ1alB0VnY3cGZuMXZsYktvcmplCjM2SHdTdkVRbjlCWVRxaWNyUm9vNDdIOEZpL2dJbU41YjlKeGxHNHJzQ0pWYVhTNFo3QVZpSUdBNjZxT2xNMHQKckU3ZEwxRkhuWDl2YnFwNWVCb2ZtM1l0UHltc2lWb2pDbUw2bEJNYmVOUXIrblgzSEFmVFhRcm9Odz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1879"
+      - "1881"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:18 GMT
+      - Thu, 16 Nov 2023 16:10:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4166,7 +4199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8bde147-c958-4d28-a7df-b9c557307ec9
+      - a45b6c0d-0110-48be-bf37-475ec2e84fd2
     status: 200 OK
     code: 200
     duration: ""
@@ -4177,19 +4210,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1279"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:19 GMT
+      - Thu, 16 Nov 2023 16:10:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4199,7 +4232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3005a59-3c6a-49d4-b885-cdb80addc1d8
+      - d46c0b45-be13-4f34-8dcf-6956d3a28e2d
     status: 200 OK
     code: 200
     duration: ""
@@ -4210,7 +4243,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8c96124f-20c2-42fa-a66f-60a0387ec4c9
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e1c1cc9f-8250-4b9a-ab3e-d0797377830d
     method: DELETE
   response:
     body: ""
@@ -4220,7 +4253,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:19 GMT
+      - Thu, 16 Nov 2023 16:10:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4230,7 +4263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b77b80cc-a9ba-4713-a837-ab9a400f9163
+      - 92ccdad7-475c-40aa-8930-ec5a68e1d76a
     status: 204 No Content
     code: 204
     duration: ""
@@ -4241,19 +4274,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1235"
+      - "1282"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:19 GMT
+      - Thu, 16 Nov 2023 16:10:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4263,7 +4296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79587adf-76df-4119-833f-3aa6f72378a2
+      - 560fb612-5015-4d70-881f-0716e933fbbb
     status: 200 OK
     code: 200
     duration: ""
@@ -4274,19 +4307,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T19:00:13.911090Z","endpoint":{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166},"endpoints":[{"id":"5b5a19db-acf4-4983-bbf4-b7851e1e2ea2","ip":"51.158.130.202","load_balancer":{},"name":null,"port":14166}],"engine":"PostgreSQL-15","id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:38.147667Z","endpoint":{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214},"endpoints":[{"id":"b38d85e3-e930-4caf-9f51-48f047ffb248","ip":"51.158.210.239","load_balancer":{},"name":null,"port":9214}],"engine":"PostgreSQL-15","id":"8c67950e-f5d5-4216-b15b-f56d92978839","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1235"
+      - "1282"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:19 GMT
+      - Thu, 16 Nov 2023 16:10:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4296,7 +4329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bccb242-0577-45c6-8e68-bc31243d6531
+      - 8ba0600a-a07f-4cd9-8d2a-7411ff93ac1f
     status: 200 OK
     code: 200
     duration: ""
@@ -4307,10 +4340,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"8c67950e-f5d5-4216-b15b-f56d92978839","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4319,7 +4352,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:49 GMT
+      - Thu, 16 Nov 2023 16:10:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4329,7 +4362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15a35d07-9681-4c92-a56f-33b17d99cadb
+      - 2ddb075b-d3da-4f9e-a811-ac5f3d3f3697
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4340,10 +4373,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/1b36eed4-0b9f-44e1-9947-8dc415a8f3c3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8c67950e-f5d5-4216-b15b-f56d92978839
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"1b36eed4-0b9f-44e1-9947-8dc415a8f3c3","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"8c67950e-f5d5-4216-b15b-f56d92978839","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4352,7 +4385,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:49 GMT
+      - Thu, 16 Nov 2023 16:10:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4362,7 +4395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58e2531e-efb8-45d7-9260-8f80dd03fb11
+      - d8119ef4-85be-487c-b4c7-0184d6ec41ee
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-settings.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-settings.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:33 GMT
+      - Thu, 16 Nov 2023 15:52:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f99d100a-ac02-4232-ad44-202e4f1e672f
+      - 99ecf773-d9f1-4c2d-ab2b-ce7b2714513c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 16:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75e063ee-e5e5-45ed-b2d9-1f2e17de135a
+      - 4f8a630b-620d-4702-9fb2-7f23651b51d7
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 16:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dbcaba0-59f3-40f8-bfbf-a489cd55fc2c
+      - 3f224518-1e08-42d3-8fdf-d743cd7afbf7
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:08 GMT
+      - Thu, 16 Nov 2023 16:02:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5012c664-0808-4cae-a6f9-4e43535ae2f7
+      - 79645e26-2d3f-48ab-8d8d-89f79fde6337
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:38 GMT
+      - Thu, 16 Nov 2023 16:02:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26c02aa8-3b9b-4053-94dd-0659a05a7075
+      - a46b5381-5511-46cb-8e16-0e373e470924
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:08 GMT
+      - Thu, 16 Nov 2023 16:03:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ec3c935-fc90-4cb2-a944-c5890709da48
+      - d947dcb0-ca7d-4522-99ed-aba25dfcbf43
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:38 GMT
+      - Thu, 16 Nov 2023 16:03:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9188c0d0-0758-4741-8011-e636410f07b2
+      - a084ef5e-24e0-4676-9b91-683ccfb10e72
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:08 GMT
+      - Thu, 16 Nov 2023 16:04:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c1ed8f4-c34f-4313-a383-a78864a29cdb
+      - 3f2a6a18-c7f3-4787-836d-6a1f160a4723
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 16:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f72aa5c6-057d-461d-8472-b61430e83ddf
+      - a128eba7-e599-4c29-adc2-60f30c5ab6b4
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155},"endpoints":[{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155}],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1171"
+      - "1219"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
+      - Thu, 16 Nov 2023 16:05:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,12 +627,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5b22eba-5eef-4dbe-b34d-92cbeb862dd2
+      - 230fd812-6c02-4eb9-a388-a621c13d8e3e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"settings":[{"name":"max_connections","value":"200"},{"name":"effective_cache_size","value":"1300"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"max_parallel_workers","value":"2"},{"name":"work_mem","value":"4"},{"name":"maintenance_work_mem","value":"150"}]}'
+    body: '{"settings":[{"name":"maintenance_work_mem","value":"150"},{"name":"work_mem","value":"4"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"effective_cache_size","value":"1300"},{"name":"max_parallel_workers","value":"2"}]}'
     form: {}
     headers:
       Content-Type:
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e/settings
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec/settings
     method: PUT
   response:
-    body: '{"settings":[{"name":"max_connections","value":"200"},{"name":"effective_cache_size","value":"1300"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"max_parallel_workers","value":"2"},{"name":"work_mem","value":"4"},{"name":"maintenance_work_mem","value":"150"}]}'
+    body: '{"settings":[{"name":"maintenance_work_mem","value":"150"},{"name":"work_mem","value":"4"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"effective_cache_size","value":"1300"},{"name":"max_parallel_workers","value":"2"}]}'
     headers:
       Content-Length:
-      - "279"
+      - "290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
+      - Thu, 16 Nov 2023 16:05:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a130894-a996-41bd-81c5-6b70b5b05817
+      - d010246e-c064-4456-a6bd-e74d3894bb5c
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155},"endpoints":[{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155}],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1177"
+      - "1225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:09 GMT
+      - Thu, 16 Nov 2023 16:05:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0def05ad-f43e-4a40-892d-74b941ed41e2
+      - a917b576-51e9-4ab3-a2e6-66892fc603ea
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155},"endpoints":[{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155}],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1177"
+      - "1219"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:39 GMT
+      - Thu, 16 Nov 2023 16:05:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1dd23861-0499-4aa9-808e-fe83b42e3e4d
+      - 8824150a-3497-41be-948c-1d32164ba7d1
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVYVVWSFVsdit1dTNCU1ZhSUdCcW1Gd0tGdWpZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EUTBPRm9YRFRNek1URXhNekUyTURRME9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXF3T3J1YUdkSVhxT0dOM0VnVTcyTWN6WTZsSzh4TkYwTTMzTkkzdi9NdkptZE5maDN3TysKRHVjMm4va0gyeHhzR29PYTVDQlNjTFpYS2pqdndBM3g5ZnhWVldtN21mZk5jRUFaTW1JaVVEVC8wV01neU1rSgoxcFI5VWwvbVlDazkrNitJV3o4VEVySXBZUi9xTndEeGoreTRzQ3V0WDlvdEtsWFRVTUlMZDIxekZMRTU3d3BxClp3eUdIYUJOZFJUK3VsdEZsdGZnVklkVStrdTlYbWdmQ25tckpOQ1g2UDlveVJSR3JkaTN0T3kyNDBTQS9FKzkKU0hMdXcrMnk1UGFVOVpDVjcycUN4VmxXb3hyVjJ3dnIrTklWRnY5d2xjeDY4ZGVQZ0NERThQcFdSRVpydE4xVAp4U0ZsMUlSMFJYY3N5SmNKNHRTZHUxL2xOdllSZGNKeldRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE56bGtOMkZoTVRndE56Y3daaTAwTldZMkxXSmhabUl0T0dGbU1EbGgKWmpNNU0yVmpMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNoakpub1ZsY3hzUkhRWm9qTk5pY1hYdHVCa0VSTjZSZUNVVEtIbEN6dDVqOWVaVGRnCmUvRTZXNkNyZnRZTDhOV2QzcVV4R0RTN3BmY2VlTEhsZ280L2xpLzJTWEk1M0o3TGpIcWQzSEhLcERyZEk0clIKWnpLWm56a2M1RkFQOC9JVW13QXBJVktCNkZJTlZ1NHZvNGo3cmdEKzlpSW4xaytlWmZTa3lQQXE1b1RIM1FjLwpicHJXcWJ3NUVTaC9CdFpxT1JiVEtRVkgzQVFuUCtBNTBOVG1YdWZCTThKTk1IZWRJangzMkxkanllNVlPTHdlCjExV1NHK2FwcXlPRkJQTVJHM1AxVTJqSlBpMVRwMzV6cW5HU3JEK0JVSS9BdHVwc3NJQXdDK0ZJSXAwS0tQT0MKSVBaZ3JmRzZRVnIzRndmV1hQODgrdzJwVWc5NzFqWG4wUkh3Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1171"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:09 GMT
+      - Thu, 16 Nov 2023 16:05:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23245b39-7676-4712-b82a-ef73868427df
+      - f3303a7e-b7f4-44cd-abda-1440699c1094
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVVmVDcDJabDM4Q0trWElZVGhZWW9JaFFXdHhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXdXaGNOTXpNeE1ETXdNVGcwTnpJd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtHaHhoUkRYdThYRXg2MjhDam90WFczOEs5NVFzT2VxM2pNZHZLVmxKVkl4TWNuQXZxeGhibloKd3d0cllJS1hrOXF3ZGJWK1dCQzhLbG52OWlMM0RNV0pibk1zd04wazBDaVZlaythazMrcnFiWHZHWllJTnVnWAo4NTNzWFhjNThSbU1CcTR4NzhqSWRhOHNyOE1FdE9MOUFqZ3VMUkhKRjhtLzhLQzdBQjJtYmxESFo4U0tXZ0xhCkkxRDMrKzZwaGVJUWlNaHMxYVBKbVEveXdWaWRpL0lHbGtGKzMyamlnVGZrWElScnVuZ3FXMC94ZmJUcnhWQWMKUHhTaUFJVHJTQzVsYjRzaU1GUGVHRlVvcitPcmRiQU41ZTY1S2lScUdhL2hNYXNvYW9hajdYK1M0aTY3Mi9DOAppdEdNMDF1Q2hTTEF2MlVyZndNa0FvMFJEY3l3VURjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0T1RKbE9XUmpZbVl0TlRGbU1TMDBOVGsxTFdFM01HSXRZVFl6TVRWbVkyUXgKTnpabExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDROWWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQTV6a0xXc1hsaGVGcUx4U3NxQWlqVzVaZHk3OENGNFZmVzFCalFpYTNncXppOHVTSWo2cDNkCkc0TUlkVE1jMWd2Qkhic29TZ3Nid2pjVVgzRGNHZGNOb2gxOFZyaGx5TUFrYVVDbVl3Nm1vZjVpaTU4WjNFM0sKeHgxeHdPazBaWUtzWU9DbDJyZ3ViZVVTSlVNZjV1ckMrQzJYcmhqeHJ3eERjTkdmSnZKbC9hbXVxMzJxZ3RYVgpsMkowMFA0Qjc0dzNJdFpab1dyNW1DZTJGb1JoUzZVbktxMTB6TDlRcVBQV1hjcEk5UHp5bi9Nb1gzb2dwS3RhCkxiMVpDejM0d0pCNTZKNm80TGE0cmRpZkoyaGJwWlBmWS9yMGdJcTQ2STc4UlZla3RWMXJVZFBYa1FZSDZqOTgKenhsbGdsY3RhV0JqbDEwbGNaU0pPK0NnWkRUV3ZBQXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155},"endpoints":[{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155}],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1219"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:10 GMT
+      - Thu, 16 Nov 2023 16:05:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a237ebe-4e3f-41e3-8314-db9acd5fca68
+      - 8cfd3af5-fd0c-4041-a7cf-bea89aeb4158
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155},"endpoints":[{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155}],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1171"
+      - "1219"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:10 GMT
+      - Thu, 16 Nov 2023 16:05:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6829876f-38c5-40c4-9271-5e9016235a5b
+      - 535d4f14-c577-4af0-8f0b-20ba480013b3
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVYVVWSFVsdit1dTNCU1ZhSUdCcW1Gd0tGdWpZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EUTBPRm9YRFRNek1URXhNekUyTURRME9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXF3T3J1YUdkSVhxT0dOM0VnVTcyTWN6WTZsSzh4TkYwTTMzTkkzdi9NdkptZE5maDN3TysKRHVjMm4va0gyeHhzR29PYTVDQlNjTFpYS2pqdndBM3g5ZnhWVldtN21mZk5jRUFaTW1JaVVEVC8wV01neU1rSgoxcFI5VWwvbVlDazkrNitJV3o4VEVySXBZUi9xTndEeGoreTRzQ3V0WDlvdEtsWFRVTUlMZDIxekZMRTU3d3BxClp3eUdIYUJOZFJUK3VsdEZsdGZnVklkVStrdTlYbWdmQ25tckpOQ1g2UDlveVJSR3JkaTN0T3kyNDBTQS9FKzkKU0hMdXcrMnk1UGFVOVpDVjcycUN4VmxXb3hyVjJ3dnIrTklWRnY5d2xjeDY4ZGVQZ0NERThQcFdSRVpydE4xVAp4U0ZsMUlSMFJYY3N5SmNKNHRTZHUxL2xOdllSZGNKeldRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE56bGtOMkZoTVRndE56Y3daaTAwTldZMkxXSmhabUl0T0dGbU1EbGgKWmpNNU0yVmpMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5rVTVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNoakpub1ZsY3hzUkhRWm9qTk5pY1hYdHVCa0VSTjZSZUNVVEtIbEN6dDVqOWVaVGRnCmUvRTZXNkNyZnRZTDhOV2QzcVV4R0RTN3BmY2VlTEhsZ280L2xpLzJTWEk1M0o3TGpIcWQzSEhLcERyZEk0clIKWnpLWm56a2M1RkFQOC9JVW13QXBJVktCNkZJTlZ1NHZvNGo3cmdEKzlpSW4xaytlWmZTa3lQQXE1b1RIM1FjLwpicHJXcWJ3NUVTaC9CdFpxT1JiVEtRVkgzQVFuUCtBNTBOVG1YdWZCTThKTk1IZWRJangzMkxkanllNVlPTHdlCjExV1NHK2FwcXlPRkJQTVJHM1AxVTJqSlBpMVRwMzV6cW5HU3JEK0JVSS9BdHVwc3NJQXdDK0ZJSXAwS0tQT0MKSVBaZ3JmRzZRVnIzRndmV1hQODgrdzJwVWc5NzFqWG4wUkh3Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1171"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:10 GMT
+      - Thu, 16 Nov 2023 16:05:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c61cd52f-e31c-455b-ba05-ce12443a1f62
+      - 19c47afe-c719-459c-8449-a5e6e6a98e04
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVVmVDcDJabDM4Q0trWElZVGhZWW9JaFFXdHhJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnME56SXdXaGNOTXpNeE1ETXdNVGcwTnpJd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtHaHhoUkRYdThYRXg2MjhDam90WFczOEs5NVFzT2VxM2pNZHZLVmxKVkl4TWNuQXZxeGhibloKd3d0cllJS1hrOXF3ZGJWK1dCQzhLbG52OWlMM0RNV0pibk1zd04wazBDaVZlaythazMrcnFiWHZHWllJTnVnWAo4NTNzWFhjNThSbU1CcTR4NzhqSWRhOHNyOE1FdE9MOUFqZ3VMUkhKRjhtLzhLQzdBQjJtYmxESFo4U0tXZ0xhCkkxRDMrKzZwaGVJUWlNaHMxYVBKbVEveXdWaWRpL0lHbGtGKzMyamlnVGZrWElScnVuZ3FXMC94ZmJUcnhWQWMKUHhTaUFJVHJTQzVsYjRzaU1GUGVHRlVvcitPcmRiQU41ZTY1S2lScUdhL2hNYXNvYW9hajdYK1M0aTY3Mi9DOAppdEdNMDF1Q2hTTEF2MlVyZndNa0FvMFJEY3l3VURjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0T1RKbE9XUmpZbVl0TlRGbU1TMDBOVGsxTFdFM01HSXRZVFl6TVRWbVkyUXgKTnpabExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDROWWh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQTV6a0xXc1hsaGVGcUx4U3NxQWlqVzVaZHk3OENGNFZmVzFCalFpYTNncXppOHVTSWo2cDNkCkc0TUlkVE1jMWd2Qkhic29TZ3Nid2pjVVgzRGNHZGNOb2gxOFZyaGx5TUFrYVVDbVl3Nm1vZjVpaTU4WjNFM0sKeHgxeHdPazBaWUtzWU9DbDJyZ3ViZVVTSlVNZjV1ckMrQzJYcmhqeHJ3eERjTkdmSnZKbC9hbXVxMzJxZ3RYVgpsMkowMFA0Qjc0dzNJdFpab1dyNW1DZTJGb1JoUzZVbktxMTB6TDlRcVBQV1hjcEk5UHp5bi9Nb1gzb2dwS3RhCkxiMVpDejM0d0pCNTZKNm80TGE0cmRpZkoyaGJwWlBmWS9yMGdJcTQ2STc4UlZla3RWMXJVZFBYa1FZSDZqOTgKenhsbGdsY3RhV0JqbDEwbGNaU0pPK0NnWkRUV3ZBQXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155},"endpoints":[{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155}],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1219"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:10 GMT
+      - Thu, 16 Nov 2023 16:05:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5442b61-64e8-4cfe-89f6-1c6aacdaca42
+      - c53c5580-bc2c-4a5f-83a2-bb3e9c863f1c
     status: 200 OK
     code: 200
     duration: ""
@@ -904,52 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1171"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:51:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 017e182c-bc59-4f99-af03-dc3132ca3820
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155},"endpoints":[{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155}],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1174"
+      - "1222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:11 GMT
+      - Thu, 16 Nov 2023 16:05:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6305d825-11bb-4a0a-a240-89f9f6dfac2d
+      - 923d0a33-e6dc-4aa8-b36d-ef4f4d7c4f81
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:46:37.746157Z","endpoint":{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974},"endpoints":[{"id":"f5273e05-fe87-45a4-82d6-c829bda88b80","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16974}],"engine":"PostgreSQL-15","id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:35.940224Z","endpoint":{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155},"endpoints":[{"id":"358eedc6-5527-4264-af80-b4d514989a94","ip":"51.159.113.173","load_balancer":{},"name":null,"port":26155}],"engine":"PostgreSQL-15","id":"79d7aa18-770f-45f6-bafb-8af09af393ec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1174"
+      - "1222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:11 GMT
+      - Thu, 16 Nov 2023 16:05:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 440a6ba6-b8aa-43e5-ad58-d65b74e7dd47
+      - 2ff834fe-b15d-4098-b04e-65d1e056bdb6
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,10 +970,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"79d7aa18-770f-45f6-bafb-8af09af393ec","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1015,7 +982,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:41 GMT
+      - Thu, 16 Nov 2023 16:06:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab4fa0e1-bb9d-4c98-8ac5-9b28a29aed5c
+      - 1111835e-e829-401b-afd6-6192082843b9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1036,10 +1003,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/92e9dcbf-51f1-4595-a70b-a6315fcd176e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/79d7aa18-770f-45f6-bafb-8af09af393ec
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"92e9dcbf-51f1-4595-a70b-a6315fcd176e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"79d7aa18-770f-45f6-bafb-8af09af393ec","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1048,7 +1015,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:41 GMT
+      - Thu, 16 Nov 2023 16:06:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 051cc551-793f-4f19-9a58-53edeb025094
+      - f7bc97f6-7e78-4435-b317-f388db2d01c9
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-volume.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-volume.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:35 GMT
+      - Thu, 16 Nov 2023 15:52:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ebfd0c7-f206-49c2-ae42-a0d8dc738a69
+      - 5d2a2bf9-1971-46cb-b601-20528d4feffd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:05 GMT
+      - Thu, 16 Nov 2023 16:05:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb10322c-2c1b-4aba-be24-12debcc8a7f8
+      - a8e4bd5f-68d1-4be2-a05b-2c74cb2eeccb
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:05 GMT
+      - Thu, 16 Nov 2023 16:05:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 412f9733-1871-40ba-9f73-b0ebb21cb8f9
+      - d3e68c4f-767c-49cf-b4c5-6004ed8dd8d5
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:35 GMT
+      - Thu, 16 Nov 2023 16:06:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bcb10774-7c6c-4da2-94d6-6341c45b935d
+      - 93aa7244-c5b3-4899-a6b8-3c06585befe2
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:05 GMT
+      - Thu, 16 Nov 2023 16:06:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39eca28e-9a6d-4045-9f63-ded5e65e26b4
+      - 5efeb35f-c25b-442d-b3fb-988a81744332
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:35 GMT
+      - Thu, 16 Nov 2023 16:07:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06053eab-f366-4672-ac87-4da5f8d362d0
+      - d7de4558-d6ec-4e86-bdad-78241370d0ea
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "776"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:06 GMT
+      - Thu, 16 Nov 2023 16:07:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94fa1739-ce3f-4bc7-bf2e-6be8254972aa
+      - af0df174-fd62-4e53-8ea4-0b4495c85234
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "1051"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:36 GMT
+      - Thu, 16 Nov 2023 16:08:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b018369c-5f40-42dc-858c-233f737f5011
+      - d7f3453f-4486-4795-aaac-a6c58b9970b6
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 16:08:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74306923-130c-4d12-8f8e-1bddcc85774b
+      - 96274713-6096-474b-a0b7-38652e3ef8fa
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWVlTbTZrcjlrSU5JQXNUUzRXQUdGNSs5VXY4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UWTBNRm9YRFRNek1UQXpNREU0TlRZME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXFzV0tPaHpITEo3ZTROMEl5SW9ycHk5WG15OHgrOFdwSU8zL0RLbmx6a000WnQ2V0RzbVgKSWczUktEU1BJNFFPQ3dkQXQ4dzQwaGNNb3RRbE1vdlRmYUlKSGM0YTFiWUIvSlpqck5ldEdSVDdkaFp2bklweQppSmcvUHNDWVg1d2tHQ3V4YmJ3QjExcjYyS2pBaU0vSjBtYktLMFVxOXdGWFZHaVRvbHA1YWxQTDQ2a25yRzlpCk5DSExzMmhxZCtyVnV6UFd0aFVDbzgxSFcvdkRVdUNrME42dGtmZzRndnp0THpPM0E3R3c3V0NPS2JUN0FwUWwKZWIvVndMcHlUS3k5UTUybFk2OVAwck5CNEN6ak5SR0tTVVp6OXorSFRvN1YxdFVZeVFlN1pYNE1Ia3FuWHdsTQpQOTdxMmN5S05TNDRIN1dPckRKRjdmQURHMDdUbVZOQnp3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdE5UVmxOVEE0WldVdFl6Sm1PUzAwTVRGbUxXSTFabUV0Wm1RM1pUUTUKWldGa1pqWmhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5xL2lod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE3cjJ6UWtIejc4c24xY2xxbysxUE5FRFFoRlZ0TEZ6ZVFvbXNiTm9UcHYxV3hiUzhoCmFqMUNxWkZRazNHY2IyclFFWUFaVzR6SVlQK2NhR3dJc3hKNDhpOFM4cHIyUy9tN3hFTW5BQUw5QnVEc2N1eFQKclQxcUNCZ2VSbWhaTFpUU3o4cHJqZEJFTlhaN1FZLzZrdktwUUxmU0grcGxaYXh3OWlhdzZhcmkrbDNjQVRIbQp0VjNjYUM1YzRiMG1WOW5lVW9DZGlHczlPcnVseEtRTE9GbkFKNitiVnZNZTZ5L0E1VzRxQXlHMGRyMno1RHBYCjdHU3o0Rkc5c1JWc21uZVN5bTg2S3dManF0amJDcU5henRyZ0hzTk5PZUJETHFNWnhvRy9HQno0bmo3MFVYMDEKVHRMNm5lZ2FtRUs4cXRtRmk5anplTmtETTlMNEN5VE9lOUFxCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVZkdVSHIyOWEwSUNoRExDTUFXZzh2YlRwSG1Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpFdU1Ua3hNQjRYCkRUSXpNVEV4TmpFMk1EZ3dNbG9YRFRNek1URXhNekUyTURnd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekV1TVRreE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTFTUlBYS1hpR2p3YUpJUjYxbUNTVjJjbDNnZlhCNndJTHJ1ZkJ6RHZyREFLNlJQS2pYRzgKTXd6eUErMVRnNTl2cDljbjhRcXdTVG45UG1GUFFEVVRYNFp0LzR2TERwdkVlclVDc1BzRWNrekFadXRPYkJodwp5VncrbU1GWXBCbmhEVVRqR1lpQjdmM3RpS2NpWFp5Zy8xRnd0Wi9PUVc5TU9Ra1psZHhHcm1ERUZ3ak1oOHNrCm5NUWg0R1cyN3I5RnN2WkY0R0ZabFVHbmg4dW1OV2VQUEdmWnRTN3F2Zmh6c3ZoenZMWmYrUUlXMjdVMnU0ZEwKTmNCUUUxY0thRStsNVRxRmZiSVk0Y09CYWpOUXJrbk9vd3o2cUxHcUJFYStFdnpXeGVDM1lGTjVnMWpGTEJvego0K2laT2JjWnZKTm9PTHcyS1Z3YUhDeSt0ZldmWHJTZkFRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNeExqRTVNWUk4Y25jdFltVmtaVGhpTW1FdE16QTNZeTAwTm1abExUazNOR1V0TmpnNFpUaGoKWVRJd09UYzBMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5yb3Rod1F6bm9PL01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF0NXJQbFBUdEJFOWJ0YnoyUjNiN3k0WjlobTRFeUc5cjVZejhyOHozbDZYTUxaUG1JClFZN1lCMTRBVVlSOW9LVjhQOExqNkdpS3dhcWZLTmhncllOTThSQnE2OUR0U1czVk1WTzh2L0ZQWTBTS3c3c0QKOUNxUzlzK3FGMU1jSWFwOE9XUW5OczNYcjVzenR2Y0ZoeVZ1OXNtdlVIYldSR1pmb0gybnMxbFdXbCs4am13QQpXcFFKWFc1dnhiVlhPOXVUbVdHMnd0NkVqekxWc0ZuYVIxdDB2OWtHZlNLQmVtVHBYMkNVT25Xb05nYnNKcGJwCnBZL2wrL1UzVFJ0WTlscGpmNTRVbkh2MVVCSDVwLytQa0k3dDhuamFsUHEzR0hOUitEeWh5TlIxY3ZQdTBRODYKTGkzN1RQa0t3YnZRTVFkWWhTcklFemlXNG1kajczUkk0ZWwyCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 16:08:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7443468-eecd-4ae8-844f-112ec690c8e1
+      - f468fd37-a28a-4717-9a2f-fedbd2cb4328
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 16:08:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d38ccb68-24eb-4e69-9c3d-4b9f054b005f
+      - 8f5e14d8-2c40-4488-ae60-3ddd48022eeb
     status: 200 OK
     code: 200
     duration: ""
@@ -671,19 +671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:07 GMT
+      - Thu, 16 Nov 2023 16:08:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -693,7 +693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9631d1d0-f9b4-4f34-8b04-9a46d6019c49
+      - a1a222e4-c4b3-4568-b766-e5cbf746c3d7
     status: 200 OK
     code: 200
     duration: ""
@@ -704,19 +704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWVlTbTZrcjlrSU5JQXNUUzRXQUdGNSs5VXY4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UWTBNRm9YRFRNek1UQXpNREU0TlRZME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXFzV0tPaHpITEo3ZTROMEl5SW9ycHk5WG15OHgrOFdwSU8zL0RLbmx6a000WnQ2V0RzbVgKSWczUktEU1BJNFFPQ3dkQXQ4dzQwaGNNb3RRbE1vdlRmYUlKSGM0YTFiWUIvSlpqck5ldEdSVDdkaFp2bklweQppSmcvUHNDWVg1d2tHQ3V4YmJ3QjExcjYyS2pBaU0vSjBtYktLMFVxOXdGWFZHaVRvbHA1YWxQTDQ2a25yRzlpCk5DSExzMmhxZCtyVnV6UFd0aFVDbzgxSFcvdkRVdUNrME42dGtmZzRndnp0THpPM0E3R3c3V0NPS2JUN0FwUWwKZWIvVndMcHlUS3k5UTUybFk2OVAwck5CNEN6ak5SR0tTVVp6OXorSFRvN1YxdFVZeVFlN1pYNE1Ia3FuWHdsTQpQOTdxMmN5S05TNDRIN1dPckRKRjdmQURHMDdUbVZOQnp3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdE5UVmxOVEE0WldVdFl6Sm1PUzAwTVRGbUxXSTFabUV0Wm1RM1pUUTUKWldGa1pqWmhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5xL2lod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE3cjJ6UWtIejc4c24xY2xxbysxUE5FRFFoRlZ0TEZ6ZVFvbXNiTm9UcHYxV3hiUzhoCmFqMUNxWkZRazNHY2IyclFFWUFaVzR6SVlQK2NhR3dJc3hKNDhpOFM4cHIyUy9tN3hFTW5BQUw5QnVEc2N1eFQKclQxcUNCZ2VSbWhaTFpUU3o4cHJqZEJFTlhaN1FZLzZrdktwUUxmU0grcGxaYXh3OWlhdzZhcmkrbDNjQVRIbQp0VjNjYUM1YzRiMG1WOW5lVW9DZGlHczlPcnVseEtRTE9GbkFKNitiVnZNZTZ5L0E1VzRxQXlHMGRyMno1RHBYCjdHU3o0Rkc5c1JWc21uZVN5bTg2S3dManF0amJDcU5henRyZ0hzTk5PZUJETHFNWnhvRy9HQno0bmo3MFVYMDEKVHRMNm5lZ2FtRUs4cXRtRmk5anplTmtETTlMNEN5VE9lOUFxCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVZkdVSHIyOWEwSUNoRExDTUFXZzh2YlRwSG1Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpFdU1Ua3hNQjRYCkRUSXpNVEV4TmpFMk1EZ3dNbG9YRFRNek1URXhNekUyTURnd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekV1TVRreE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTFTUlBYS1hpR2p3YUpJUjYxbUNTVjJjbDNnZlhCNndJTHJ1ZkJ6RHZyREFLNlJQS2pYRzgKTXd6eUErMVRnNTl2cDljbjhRcXdTVG45UG1GUFFEVVRYNFp0LzR2TERwdkVlclVDc1BzRWNrekFadXRPYkJodwp5VncrbU1GWXBCbmhEVVRqR1lpQjdmM3RpS2NpWFp5Zy8xRnd0Wi9PUVc5TU9Ra1psZHhHcm1ERUZ3ak1oOHNrCm5NUWg0R1cyN3I5RnN2WkY0R0ZabFVHbmg4dW1OV2VQUEdmWnRTN3F2Zmh6c3ZoenZMWmYrUUlXMjdVMnU0ZEwKTmNCUUUxY0thRStsNVRxRmZiSVk0Y09CYWpOUXJrbk9vd3o2cUxHcUJFYStFdnpXeGVDM1lGTjVnMWpGTEJvego0K2laT2JjWnZKTm9PTHcyS1Z3YUhDeSt0ZldmWHJTZkFRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNeExqRTVNWUk4Y25jdFltVmtaVGhpTW1FdE16QTNZeTAwTm1abExUazNOR1V0TmpnNFpUaGoKWVRJd09UYzBMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5yb3Rod1F6bm9PL01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF0NXJQbFBUdEJFOWJ0YnoyUjNiN3k0WjlobTRFeUc5cjVZejhyOHozbDZYTUxaUG1JClFZN1lCMTRBVVlSOW9LVjhQOExqNkdpS3dhcWZLTmhncllOTThSQnE2OUR0U1czVk1WTzh2L0ZQWTBTS3c3c0QKOUNxUzlzK3FGMU1jSWFwOE9XUW5OczNYcjVzenR2Y0ZoeVZ1OXNtdlVIYldSR1pmb0gybnMxbFdXbCs4am13QQpXcFFKWFc1dnhiVlhPOXVUbVdHMnd0NkVqekxWc0ZuYVIxdDB2OWtHZlNLQmVtVHBYMkNVT25Xb05nYnNKcGJwCnBZL2wrL1UzVFJ0WTlscGpmNTRVbkh2MVVCSDVwLytQa0k3dDhuamFsUHEzR0hOUitEeWh5TlIxY3ZQdTBRODYKTGkzN1RQa0t3YnZRTVFkWWhTcklFemlXNG1kajczUkk0ZWwyCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:07 GMT
+      - Thu, 16 Nov 2023 16:08:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -726,7 +726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c1ac239-c328-4388-aaed-19d6bbc8e291
+      - d64c8680-3e2e-4630-84d2-407cc790ce0a
     status: 200 OK
     code: 200
     duration: ""
@@ -737,19 +737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:08 GMT
+      - Thu, 16 Nov 2023 16:08:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -759,7 +759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb9870f6-bd7d-45f2-99ce-6189d0dced17
+      - 92777ec0-b59d-40c0-85e9-42bdaecdba3a
     status: 200 OK
     code: 200
     duration: ""
@@ -770,19 +770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWVlTbTZrcjlrSU5JQXNUUzRXQUdGNSs5VXY4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UWTBNRm9YRFRNek1UQXpNREU0TlRZME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXFzV0tPaHpITEo3ZTROMEl5SW9ycHk5WG15OHgrOFdwSU8zL0RLbmx6a000WnQ2V0RzbVgKSWczUktEU1BJNFFPQ3dkQXQ4dzQwaGNNb3RRbE1vdlRmYUlKSGM0YTFiWUIvSlpqck5ldEdSVDdkaFp2bklweQppSmcvUHNDWVg1d2tHQ3V4YmJ3QjExcjYyS2pBaU0vSjBtYktLMFVxOXdGWFZHaVRvbHA1YWxQTDQ2a25yRzlpCk5DSExzMmhxZCtyVnV6UFd0aFVDbzgxSFcvdkRVdUNrME42dGtmZzRndnp0THpPM0E3R3c3V0NPS2JUN0FwUWwKZWIvVndMcHlUS3k5UTUybFk2OVAwck5CNEN6ak5SR0tTVVp6OXorSFRvN1YxdFVZeVFlN1pYNE1Ia3FuWHdsTQpQOTdxMmN5S05TNDRIN1dPckRKRjdmQURHMDdUbVZOQnp3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdE5UVmxOVEE0WldVdFl6Sm1PUzAwTVRGbUxXSTFabUV0Wm1RM1pUUTUKWldGa1pqWmhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5xL2lod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE3cjJ6UWtIejc4c24xY2xxbysxUE5FRFFoRlZ0TEZ6ZVFvbXNiTm9UcHYxV3hiUzhoCmFqMUNxWkZRazNHY2IyclFFWUFaVzR6SVlQK2NhR3dJc3hKNDhpOFM4cHIyUy9tN3hFTW5BQUw5QnVEc2N1eFQKclQxcUNCZ2VSbWhaTFpUU3o4cHJqZEJFTlhaN1FZLzZrdktwUUxmU0grcGxaYXh3OWlhdzZhcmkrbDNjQVRIbQp0VjNjYUM1YzRiMG1WOW5lVW9DZGlHczlPcnVseEtRTE9GbkFKNitiVnZNZTZ5L0E1VzRxQXlHMGRyMno1RHBYCjdHU3o0Rkc5c1JWc21uZVN5bTg2S3dManF0amJDcU5henRyZ0hzTk5PZUJETHFNWnhvRy9HQno0bmo3MFVYMDEKVHRMNm5lZ2FtRUs4cXRtRmk5anplTmtETTlMNEN5VE9lOUFxCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVZkdVSHIyOWEwSUNoRExDTUFXZzh2YlRwSG1Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpFdU1Ua3hNQjRYCkRUSXpNVEV4TmpFMk1EZ3dNbG9YRFRNek1URXhNekUyTURnd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekV1TVRreE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTFTUlBYS1hpR2p3YUpJUjYxbUNTVjJjbDNnZlhCNndJTHJ1ZkJ6RHZyREFLNlJQS2pYRzgKTXd6eUErMVRnNTl2cDljbjhRcXdTVG45UG1GUFFEVVRYNFp0LzR2TERwdkVlclVDc1BzRWNrekFadXRPYkJodwp5VncrbU1GWXBCbmhEVVRqR1lpQjdmM3RpS2NpWFp5Zy8xRnd0Wi9PUVc5TU9Ra1psZHhHcm1ERUZ3ak1oOHNrCm5NUWg0R1cyN3I5RnN2WkY0R0ZabFVHbmg4dW1OV2VQUEdmWnRTN3F2Zmh6c3ZoenZMWmYrUUlXMjdVMnU0ZEwKTmNCUUUxY0thRStsNVRxRmZiSVk0Y09CYWpOUXJrbk9vd3o2cUxHcUJFYStFdnpXeGVDM1lGTjVnMWpGTEJvego0K2laT2JjWnZKTm9PTHcyS1Z3YUhDeSt0ZldmWHJTZkFRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNeExqRTVNWUk4Y25jdFltVmtaVGhpTW1FdE16QTNZeTAwTm1abExUazNOR1V0TmpnNFpUaGoKWVRJd09UYzBMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5yb3Rod1F6bm9PL01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF0NXJQbFBUdEJFOWJ0YnoyUjNiN3k0WjlobTRFeUc5cjVZejhyOHozbDZYTUxaUG1JClFZN1lCMTRBVVlSOW9LVjhQOExqNkdpS3dhcWZLTmhncllOTThSQnE2OUR0U1czVk1WTzh2L0ZQWTBTS3c3c0QKOUNxUzlzK3FGMU1jSWFwOE9XUW5OczNYcjVzenR2Y0ZoeVZ1OXNtdlVIYldSR1pmb0gybnMxbFdXbCs4am13QQpXcFFKWFc1dnhiVlhPOXVUbVdHMnd0NkVqekxWc0ZuYVIxdDB2OWtHZlNLQmVtVHBYMkNVT25Xb05nYnNKcGJwCnBZL2wrL1UzVFJ0WTlscGpmNTRVbkh2MVVCSDVwLytQa0k3dDhuamFsUHEzR0hOUitEeWh5TlIxY3ZQdTBRODYKTGkzN1RQa0t3YnZRTVFkWWhTcklFemlXNG1kajczUkk0ZWwyCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:08 GMT
+      - Thu, 16 Nov 2023 16:08:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -792,7 +792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2bd7728-3a6c-4b21-977c-c47ea010bd6e
+      - da259a61-9b80-4207-8165-2c4645902072
     status: 200 OK
     code: 200
     duration: ""
@@ -803,19 +803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:08 GMT
+      - Thu, 16 Nov 2023 16:08:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -825,7 +825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3222004a-e631-442f-8633-5c7367158f84
+      - bc7a1fd2-b67b-4750-9bcf-6812b4580822
     status: 200 OK
     code: 200
     duration: ""
@@ -836,19 +836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:08 GMT
+      - Thu, 16 Nov 2023 16:08:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -858,7 +858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20506ca1-db3d-44e0-9288-c25fedc317ee
+      - 189aa349-5fe7-4e02-afa8-f71eeda5eddd
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/upgrade
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974/upgrade
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:09 GMT
+      - Thu, 16 Nov 2023 16:08:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c74fa2ea-2573-4e84-8cbb-66b80fd6803a
+      - c8219c50-e298-4dc6-a205-1150969c2aee
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:09 GMT
+      - Thu, 16 Nov 2023 16:08:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c0a2412-3974-4e1e-b083-d579be4ec64e
+      - 503831f0-1abc-4bd7-83f6-78f8fe695da8
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:39 GMT
+      - Thu, 16 Nov 2023 16:09:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7344750-dd49-476d-85dd-aa5e426310e7
+      - 1df07f87-862a-4aa5-83ae-99fe2865c035
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:09 GMT
+      - Thu, 16 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2f5a7cf-4ee2-440d-b673-f440b0c4b500
+      - 6e3bf39f-d14a-4883-b802-7691ee8076b9
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:40 GMT
+      - Thu, 16 Nov 2023 16:10:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 783dccc8-0ce9-4d5f-9508-14b7cec02964
+      - e44b4ae3-cfad-444e-a938-d29426dc4007
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:10 GMT
+      - Thu, 16 Nov 2023 16:10:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b3f672f-7ef5-42e1-b7ad-c79a930e984d
+      - 1b6ad077-adf4-44d8-8804-083f14eba003
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:40 GMT
+      - Thu, 16 Nov 2023 16:11:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 983a6566-b75b-4e26-89c7-112dddbc6f64
+      - c54e0a16-8d63-4ee8-ae15-9f94b4605b6f
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:10 GMT
+      - Thu, 16 Nov 2023 16:11:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 344773a6-e266-432c-966d-6bde7eb68059
+      - 26d05fb7-9f7c-46b0-9ad1-92c1e46d6e26
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:40 GMT
+      - Thu, 16 Nov 2023 16:12:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5022f32-de3d-4936-a4ed-ce978ffe9ee7
+      - b113daa9-e5ef-4aab-ada2-2ad854b1e4a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,19 +1168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:10 GMT
+      - Thu, 16 Nov 2023 16:12:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97b7a4b2-83d8-4090-9a4f-fcf8f5a90ce7
+      - 06cd0c72-ea30-48ef-9055-11195bb1134f
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:03:41 GMT
+      - Thu, 16 Nov 2023 16:13:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6a97cdd-fb9f-4ac1-982e-eb61a0952af8
+      - 0b5683aa-a841-4835-aeb7-1e80730e51cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:11 GMT
+      - Thu, 16 Nov 2023 16:13:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e58316a-8cae-4101-873c-06e107669d0f
+      - 11690501-3e5d-4616-80eb-2b37942a209c
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,19 +1267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:04:41 GMT
+      - Thu, 16 Nov 2023 16:14:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32f9cd39-ffed-481f-b031-8ffb8771a9d2
+      - 88c323fa-f289-43a9-a4db-4b0987eb7e4f
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,19 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1275"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:11 GMT
+      - Thu, 16 Nov 2023 16:14:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e194910-86ad-4a24-9bb3-8528e0bf125c
+      - 58e4fa31-c8a8-46b2-9297-e2bc85a6156e
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,19 +1333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:05:41 GMT
+      - Thu, 16 Nov 2023 16:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b83a19e6-20e6-4ae7-aef1-98ece7c37c7c
+      - 65c097dd-f29a-423f-bfae-2eb8ac815ffe
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,19 +1366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1222"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:11 GMT
+      - Thu, 16 Nov 2023 16:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,40 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e765ddd8-c540-4b01-bc37-d7c08675d970
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1222"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 19:06:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7f6cc53c-bb28-473d-8499-5e6a06e39bcd
+      - d6c6b2ff-12fc-4985-b2e3-c915ab2379e7
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,19 +1401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/upgrade
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974/upgrade
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1230"
+      - "1276"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:12 GMT
+      - Thu, 16 Nov 2023 16:15:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 529a27bd-f27a-4cff-9cd0-a307ca014ea9
+      - e30457b8-0709-4246-afe6-e49b42f8b0a2
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,19 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1230"
+      - "1276"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:12 GMT
+      - Thu, 16 Nov 2023 16:15:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d7d822c-2e59-453b-a1e4-268a88cc458f
+      - 1e0c250b-4ff2-4220-99e6-43d0026f8aec
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1223"
+      - "1269"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:43 GMT
+      - Thu, 16 Nov 2023 16:15:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 947d62d9-53af-4be6-8599-f6ccaf69598b
+      - 9bd70354-96e4-4aaf-b4f0-bd9274aa4b6b
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,19 +1500,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1223"
+      - "1269"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:43 GMT
+      - Thu, 16 Nov 2023 16:15:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d9b0060-d94e-4905-aaeb-2fc2420fe263
+      - 08bb8c4b-d569-4961-9358-34cc4a7b5ab0
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,19 +1535,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1223"
+      - "1269"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:43 GMT
+      - Thu, 16 Nov 2023 16:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1590,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46d08415-26b3-4c49-9558-ff8fe453945a
+      - a2027c97-1329-487e-ae63-3e5c0175ec86
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,19 +1568,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1223"
+      - "1269"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:44 GMT
+      - Thu, 16 Nov 2023 16:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c04846e5-5617-4005-97aa-792fe8d0d623
+      - c805f69f-0784-4fa6-b241-28a61638e121
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,19 +1601,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWVlTbTZrcjlrSU5JQXNUUzRXQUdGNSs5VXY4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UWTBNRm9YRFRNek1UQXpNREU0TlRZME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXFzV0tPaHpITEo3ZTROMEl5SW9ycHk5WG15OHgrOFdwSU8zL0RLbmx6a000WnQ2V0RzbVgKSWczUktEU1BJNFFPQ3dkQXQ4dzQwaGNNb3RRbE1vdlRmYUlKSGM0YTFiWUIvSlpqck5ldEdSVDdkaFp2bklweQppSmcvUHNDWVg1d2tHQ3V4YmJ3QjExcjYyS2pBaU0vSjBtYktLMFVxOXdGWFZHaVRvbHA1YWxQTDQ2a25yRzlpCk5DSExzMmhxZCtyVnV6UFd0aFVDbzgxSFcvdkRVdUNrME42dGtmZzRndnp0THpPM0E3R3c3V0NPS2JUN0FwUWwKZWIvVndMcHlUS3k5UTUybFk2OVAwck5CNEN6ak5SR0tTVVp6OXorSFRvN1YxdFVZeVFlN1pYNE1Ia3FuWHdsTQpQOTdxMmN5S05TNDRIN1dPckRKRjdmQURHMDdUbVZOQnp3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdE5UVmxOVEE0WldVdFl6Sm1PUzAwTVRGbUxXSTFabUV0Wm1RM1pUUTUKWldGa1pqWmhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5xL2lod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE3cjJ6UWtIejc4c24xY2xxbysxUE5FRFFoRlZ0TEZ6ZVFvbXNiTm9UcHYxV3hiUzhoCmFqMUNxWkZRazNHY2IyclFFWUFaVzR6SVlQK2NhR3dJc3hKNDhpOFM4cHIyUy9tN3hFTW5BQUw5QnVEc2N1eFQKclQxcUNCZ2VSbWhaTFpUU3o4cHJqZEJFTlhaN1FZLzZrdktwUUxmU0grcGxaYXh3OWlhdzZhcmkrbDNjQVRIbQp0VjNjYUM1YzRiMG1WOW5lVW9DZGlHczlPcnVseEtRTE9GbkFKNitiVnZNZTZ5L0E1VzRxQXlHMGRyMno1RHBYCjdHU3o0Rkc5c1JWc21uZVN5bTg2S3dManF0amJDcU5henRyZ0hzTk5PZUJETHFNWnhvRy9HQno0bmo3MFVYMDEKVHRMNm5lZ2FtRUs4cXRtRmk5anplTmtETTlMNEN5VE9lOUFxCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVZkdVSHIyOWEwSUNoRExDTUFXZzh2YlRwSG1Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpFdU1Ua3hNQjRYCkRUSXpNVEV4TmpFMk1EZ3dNbG9YRFRNek1URXhNekUyTURnd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekV1TVRreE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTFTUlBYS1hpR2p3YUpJUjYxbUNTVjJjbDNnZlhCNndJTHJ1ZkJ6RHZyREFLNlJQS2pYRzgKTXd6eUErMVRnNTl2cDljbjhRcXdTVG45UG1GUFFEVVRYNFp0LzR2TERwdkVlclVDc1BzRWNrekFadXRPYkJodwp5VncrbU1GWXBCbmhEVVRqR1lpQjdmM3RpS2NpWFp5Zy8xRnd0Wi9PUVc5TU9Ra1psZHhHcm1ERUZ3ak1oOHNrCm5NUWg0R1cyN3I5RnN2WkY0R0ZabFVHbmg4dW1OV2VQUEdmWnRTN3F2Zmh6c3ZoenZMWmYrUUlXMjdVMnU0ZEwKTmNCUUUxY0thRStsNVRxRmZiSVk0Y09CYWpOUXJrbk9vd3o2cUxHcUJFYStFdnpXeGVDM1lGTjVnMWpGTEJvego0K2laT2JjWnZKTm9PTHcyS1Z3YUhDeSt0ZldmWHJTZkFRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNeExqRTVNWUk4Y25jdFltVmtaVGhpTW1FdE16QTNZeTAwTm1abExUazNOR1V0TmpnNFpUaGoKWVRJd09UYzBMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5yb3Rod1F6bm9PL01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF0NXJQbFBUdEJFOWJ0YnoyUjNiN3k0WjlobTRFeUc5cjVZejhyOHozbDZYTUxaUG1JClFZN1lCMTRBVVlSOW9LVjhQOExqNkdpS3dhcWZLTmhncllOTThSQnE2OUR0U1czVk1WTzh2L0ZQWTBTS3c3c0QKOUNxUzlzK3FGMU1jSWFwOE9XUW5OczNYcjVzenR2Y0ZoeVZ1OXNtdlVIYldSR1pmb0gybnMxbFdXbCs4am13QQpXcFFKWFc1dnhiVlhPOXVUbVdHMnd0NkVqekxWc0ZuYVIxdDB2OWtHZlNLQmVtVHBYMkNVT25Xb05nYnNKcGJwCnBZL2wrL1UzVFJ0WTlscGpmNTRVbkh2MVVCSDVwLytQa0k3dDhuamFsUHEzR0hOUitEeWh5TlIxY3ZQdTBRODYKTGkzN1RQa0t3YnZRTVFkWWhTcklFemlXNG1kajczUkk0ZWwyCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:44 GMT
+      - Thu, 16 Nov 2023 16:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70c47894-470f-4c44-a839-ec3b5b180626
+      - f0e3050b-72b5-4ab0-b4f9-0cf32ae46502
     status: 200 OK
     code: 200
     duration: ""
@@ -1667,19 +1634,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1223"
+      - "1269"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:44 GMT
+      - Thu, 16 Nov 2023 16:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d75956b7-9ec2-4d8e-aae4-e95063f6c27b
+      - c03b5665-0be4-46ff-98e7-29ada546ddf2
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,19 +1667,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1223"
+      - "1269"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:44 GMT
+      - Thu, 16 Nov 2023 16:15:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1722,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ebdf4de-1ff4-4055-924b-3f9b3fcfb2f8
+      - 9f7ec72c-ce22-471b-943b-247070df1793
     status: 200 OK
     code: 200
     duration: ""
@@ -1733,19 +1700,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWVlTbTZrcjlrSU5JQXNUUzRXQUdGNSs5VXY4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1qQXlNQjRYCkRUSXpNVEV3TWpFNE5UWTBNRm9YRFRNek1UQXpNREU0TlRZME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TWpBeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXFzV0tPaHpITEo3ZTROMEl5SW9ycHk5WG15OHgrOFdwSU8zL0RLbmx6a000WnQ2V0RzbVgKSWczUktEU1BJNFFPQ3dkQXQ4dzQwaGNNb3RRbE1vdlRmYUlKSGM0YTFiWUIvSlpqck5ldEdSVDdkaFp2bklweQppSmcvUHNDWVg1d2tHQ3V4YmJ3QjExcjYyS2pBaU0vSjBtYktLMFVxOXdGWFZHaVRvbHA1YWxQTDQ2a25yRzlpCk5DSExzMmhxZCtyVnV6UFd0aFVDbzgxSFcvdkRVdUNrME42dGtmZzRndnp0THpPM0E3R3c3V0NPS2JUN0FwUWwKZWIvVndMcHlUS3k5UTUybFk2OVAwck5CNEN6ak5SR0tTVVp6OXorSFRvN1YxdFVZeVFlN1pYNE1Ia3FuWHdsTQpQOTdxMmN5S05TNDRIN1dPckRKRjdmQURHMDdUbVZOQnp3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqSXdNb0k4Y25jdE5UVmxOVEE0WldVdFl6Sm1PUzAwTVRGbUxXSTFabUV0Wm1RM1pUUTUKWldGa1pqWmhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5xL2lod1F6bm9MS01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUE3cjJ6UWtIejc4c24xY2xxbysxUE5FRFFoRlZ0TEZ6ZVFvbXNiTm9UcHYxV3hiUzhoCmFqMUNxWkZRazNHY2IyclFFWUFaVzR6SVlQK2NhR3dJc3hKNDhpOFM4cHIyUy9tN3hFTW5BQUw5QnVEc2N1eFQKclQxcUNCZ2VSbWhaTFpUU3o4cHJqZEJFTlhaN1FZLzZrdktwUUxmU0grcGxaYXh3OWlhdzZhcmkrbDNjQVRIbQp0VjNjYUM1YzRiMG1WOW5lVW9DZGlHczlPcnVseEtRTE9GbkFKNitiVnZNZTZ5L0E1VzRxQXlHMGRyMno1RHBYCjdHU3o0Rkc5c1JWc21uZVN5bTg2S3dManF0amJDcU5henRyZ0hzTk5PZUJETHFNWnhvRy9HQno0bmo3MFVYMDEKVHRMNm5lZ2FtRUs4cXRtRmk5anplTmtETTlMNEN5VE9lOUFxCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVZkdVSHIyOWEwSUNoRExDTUFXZzh2YlRwSG1Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpFdU1Ua3hNQjRYCkRUSXpNVEV4TmpFMk1EZ3dNbG9YRFRNek1URXhNekUyTURnd01sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekV1TVRreE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTFTUlBYS1hpR2p3YUpJUjYxbUNTVjJjbDNnZlhCNndJTHJ1ZkJ6RHZyREFLNlJQS2pYRzgKTXd6eUErMVRnNTl2cDljbjhRcXdTVG45UG1GUFFEVVRYNFp0LzR2TERwdkVlclVDc1BzRWNrekFadXRPYkJodwp5VncrbU1GWXBCbmhEVVRqR1lpQjdmM3RpS2NpWFp5Zy8xRnd0Wi9PUVc5TU9Ra1psZHhHcm1ERUZ3ak1oOHNrCm5NUWg0R1cyN3I5RnN2WkY0R0ZabFVHbmg4dW1OV2VQUEdmWnRTN3F2Zmh6c3ZoenZMWmYrUUlXMjdVMnU0ZEwKTmNCUUUxY0thRStsNVRxRmZiSVk0Y09CYWpOUXJrbk9vd3o2cUxHcUJFYStFdnpXeGVDM1lGTjVnMWpGTEJvego0K2laT2JjWnZKTm9PTHcyS1Z3YUhDeSt0ZldmWHJTZkFRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNeExqRTVNWUk4Y25jdFltVmtaVGhpTW1FdE16QTNZeTAwTm1abExUazNOR1V0TmpnNFpUaGoKWVRJd09UYzBMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRem5yb3Rod1F6bm9PL01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUF0NXJQbFBUdEJFOWJ0YnoyUjNiN3k0WjlobTRFeUc5cjVZejhyOHozbDZYTUxaUG1JClFZN1lCMTRBVVlSOW9LVjhQOExqNkdpS3dhcWZLTmhncllOTThSQnE2OUR0U1czVk1WTzh2L0ZQWTBTS3c3c0QKOUNxUzlzK3FGMU1jSWFwOE9XUW5OczNYcjVzenR2Y0ZoeVZ1OXNtdlVIYldSR1pmb0gybnMxbFdXbCs4am13QQpXcFFKWFc1dnhiVlhPOXVUbVdHMnd0NkVqekxWc0ZuYVIxdDB2OWtHZlNLQmVtVHBYMkNVT25Xb05nYnNKcGJwCnBZL2wrL1UzVFJ0WTlscGpmNTRVbkh2MVVCSDVwLytQa0k3dDhuamFsUHEzR0hOUitEeWh5TlIxY3ZQdTBRODYKTGkzN1RQa0t3YnZRTVFkWWhTcklFemlXNG1kajczUkk0ZWwyCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:45 GMT
+      - Thu, 16 Nov 2023 16:15:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1755,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53c9d3cc-753e-486c-a6f7-cd550054498e
+      - ee77bab5-81fc-4cce-bbfd-51fe0ee9a8a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,19 +1733,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1223"
+      - "1269"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:45 GMT
+      - Thu, 16 Nov 2023 16:15:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1788,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1668828-e5e5-48d9-ace1-ef846fa9507b
+      - 44fe4243-8fb0-4cbe-8d79-43a93f5f8ec9
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,19 +1766,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:45 GMT
+      - Thu, 16 Nov 2023 16:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1821,7 +1788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2201fff6-8b4d-407c-94dc-a3f64b9621ea
+      - ad6376f9-3c8d-4226-97ac-642159f34654
     status: 200 OK
     code: 200
     duration: ""
@@ -1832,19 +1799,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:56:05.176428Z","endpoint":{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487},"endpoints":[{"id":"d8c22913-0b91-43e2-9ee0-d0c444cd4f15","ip":"51.158.130.202","load_balancer":{},"name":null,"port":29487}],"engine":"PostgreSQL-15","id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:05:35.201620Z","endpoint":{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911},"endpoints":[{"id":"3f771826-77f2-4e50-b9c2-99aa23dd078a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":1911}],"engine":"PostgreSQL-15","id":"bede8b2a-307c-46fe-974e-688e8ca20974","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1226"
+      - "1272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:06:45 GMT
+      - Thu, 16 Nov 2023 16:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1854,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c056a914-d0a4-4185-af2a-ca65ff859096
+      - 392caba7-b624-452d-b4e1-262557172a03
     status: 200 OK
     code: 200
     duration: ""
@@ -1865,10 +1832,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"bede8b2a-307c-46fe-974e-688e8ca20974","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1877,7 +1844,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:07:16 GMT
+      - Thu, 16 Nov 2023 16:16:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1887,7 +1854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8a3f847-ac04-4df9-9c68-b8a673f3e415
+      - c281fcca-190e-4de4-acd1-fbbf60af9d85
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1898,10 +1865,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/55e508ee-c2f9-411f-b5fa-fd7e49eadf6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/bede8b2a-307c-46fe-974e-688e8ca20974
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"55e508ee-c2f9-411f-b5fa-fd7e49eadf6a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"bede8b2a-307c-46fe-974e-688e8ca20974","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1910,7 +1877,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:07:16 GMT
+      - Thu, 16 Nov 2023 16:16:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1920,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3713798d-48a5-4bed-9749-28686b35805c
+      - 0ac47aa1-b0a0-4f27-9929-f8508a5d4083
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-with-cluster.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-with-cluster.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:33 GMT
+      - Thu, 16 Nov 2023 15:52:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 638fc704-f112-4c4d-8ecc-8f023d5c716e
+      - f139242c-5358-4062-a2f8-89bc7e7a1ff9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-with-cluster","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s8cret","node_type":"db-dev-m","is_ha_cluster":true,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_instance","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-with-cluster","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s8cret","node_type":"db-dev-m","is_ha_cluster":true,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_instance","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 15:52:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5647a829-039c-447c-bed7-a3cc1fa62251
+      - 8b3034c5-3aa9-40a9-b6f2-11985f6ef5d6
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:38 GMT
+      - Thu, 16 Nov 2023 15:52:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41921265-2831-45de-8991-a908e4f8c56f
+      - d03ddf5f-bb4f-4a10-8ca2-5f8c7b6c0bb0
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:08 GMT
+      - Thu, 16 Nov 2023 15:52:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b1f70d2-3f80-424d-b7b4-5994c37c9313
+      - 718d48b6-1459-4bf5-8978-742d77620290
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:47:38 GMT
+      - Thu, 16 Nov 2023 15:53:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 152e69b5-81f6-4a05-9c1b-e15ce44bd21b
+      - 65d9a02d-bfac-41d2-afbe-082f954202a5
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:08 GMT
+      - Thu, 16 Nov 2023 15:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7655966e-b82b-4a8d-9486-5207a23ea655
+      - 77f78076-3abd-40c2-b194-1f114da7c02a
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:48:39 GMT
+      - Thu, 16 Nov 2023 15:54:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7753cd69-1f41-4c2a-a7d3-17cbcee6265e
+      - 07bb5975-ce7c-4824-940d-b20075f18d2b
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:09 GMT
+      - Thu, 16 Nov 2023 15:54:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - debe5407-0086-4298-a336-32bacdad579f
+      - 7c470430-1528-47e2-a6ca-f2c82e891adb
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1256"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f012887d-7e6b-4780-a94d-9ef273e973d5
+      - ec6f7600-cfb5-4044-8cd4-cfa5df1c1b94
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340},"endpoints":[{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340}],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1310"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:55:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fd5f0553-fe6d-434c-8053-11b920ee0a58
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340},"endpoints":[{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340}],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1256"
+      - "1310"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bf684d9-2130-4b65-86d1-5f1b1656594a
+      - 2baee96a-4868-40a1-ab63-1df3af08c770
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340},"endpoints":[{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340}],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1256"
+      - "1310"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf6c74ca-b96f-49b8-ac74-0bf64ecd34e5
+      - 23399eb5-82b7-4cbe-b2b2-7f0b254a7d27
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVRFJMRW5qODVrQ2NwYkhqR3ZGc3g4Wkg2dXp3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RRM016UmFGdzB6TXpFd016QXhPRFEzTXpSYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURRbVZyS1pHblZKcDBkTFZNTHhyVjA3TXR4Tm1FZVY3OXpJamFaQThjcEJ0TXM1dlNFV1JvcXg4bFcKQnY2R2tCWE9HMmZaSzlmeDZPRytLVWl2UDN3THp0RkhyRThlMTVsek5lYWRCcmdQMHBHckZWbk14dVloM3dyUgo0bXlIK3JncS9RTWtHdXFRNURLWFdGdjhacWRyZDA5SVl2OFZYZWlOL1p5b2JBRm5yRVJJM0U5aEFseFZTUUlvCmRMNmluQVEyMnJIaThHenF3cFJpTDRLS2hENUxER1lxRUhWeUtFK2I5bHQ4OGdpczgrSnJXN2FodkYrY0NwUzUKZGIrMzU5dkxHVzEyRlZ0d3JvM3haVDczTVlRbmUwSVpnRUlNUHA5Z0tmZU5rMFBqVW5kWW9kbngvbENOWW5zRgpnU0tJV2hYUnJORmZWdktrQThhUkRLbnpKYlREQWdNQkFBR2phekJwTUdjR0ExVWRFUVJnTUY2Q0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RaVFZoWkRrelpXUXRaR1kxWVMwMFpqZzNMV0U1WVdJdFlqWmxZemd6Tm1OalltTmwKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3JCaHdRekQrZWhod1F6bnhsQk1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNiakxkY1hScUoveGhMcUJZR21NcitrUnJFdjkxeXlsaWVoTlA0azJjUGZGR2FlMUZWCjNhRHhZN1cvQmpPUFVNSjJnRWwrSTVtbzlnbEUzV1FVdElxN3E3dGhCZ01NTXhJTG9HRGpWT3MzSDM3cUt5THkKYkJQZDZvbkRHeXpjZDNLVjNFaUxSSmVNOE1GL3dOdXdYcVNWVlIwQ3dFTWRkdFlnOW5LQTdIdEhTZHFlY2l4cQp4RENWYnZJN204RmNkdmZHNmh6bVNWejB3ZVFaZS9MNGxteGZ2V1F0Q2pUdHRJa3V0Q1phNlRKUXpycVRIMUtxCnpiS0Z2cWxIbzc1U1FQYlhER0FUOUhaQzJkbDBaNUJnc0ZYc1E3V0RZN05aN3VKQmN2WUovRjYzU25DSG9NajIKSkVKSzYvNGVraDJ3Tys1alZ5eEk0N3c0cGVGT05obGxiNW5VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURyVENDQXBXZ0F3SUJBZ0lVVHZxT2pNNFgzSHpNVER0cXBoNW9NZy9veVY0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UVXlNMW9YRFRNek1URXhNekUxTlRVeU0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRVL3J0Y2owRDVzRksyMDJCOVo3dlJ5b2NaS0U4b3JwcWU1Q0FFUEloZ0toTmxmRXVXSUYKZG9KQWpGL3Z3SUlVenpqWU1YMWtYNDhaY2FWU0VIZUF5OUkyMFFPYVZidHJCYVFLeEM5Vm0rTGdQcFRBOUl6dwpNcUNGc1dqdWY5Njl6bzVXaFJ4RlN1R1dxdDIwUGJ1OGw4LzRCUXozS2JtWnJwdXdYSVdVZDJtOUM3blZuL3NFCnk4UG5kbEVPZlZmbjJOUzhnN0wrTVRlV3Vacmx4QkhVSG16MEtTNW9zV1hPaTVkaDdnWDhkdkpDRU4wOTlycGIKcnV2ZVB1UzR5NVVjOWhXREJVb29DVGkzVGZ1b2NCOWw4dnA0RFRNZWhhMDl3cnlRbWpjZm10ZUlUMi8wN3FHSwpKdUJtS3lYOWgzWDFvYW5aUU5WbVVHaTZ6YnVTd2R1TmFRSURBUUFCbzIwd2F6QnBCZ05WSFJFRVlqQmdnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFlqY3paRGs1TkdFdFpEYzVPUzAwT1dJeExUZ3lZamN0Tm1FeE16ZGoKTXpnM05qa3lMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQ0eHZod1F6RDRNcWh3UXpuM0d0TUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQkFRQkVFbk8yWFFicG5xdjEwRU95MTA0UFY5NUFsSmlaNitkbFp3QVNFaXZkCktSZHZVTUgrRGpwNTZFRUtjZ3ZoQ3JFL2NWOWFuOHhtZFp3TFVNTktzTmpIUkpuZ0FGd1JmK3Q4NzBxQ2I0UG0KTzNLU0pJVHJTaStiaU1EWElMSnpTNG1kUWQxbmx3NzNJcUNlVWtTTCtRdDAyZXRiZUdkLzd6K3dCRHVEN25ZSQorenpDTTFpRGNoZ2xRaFlEN09rTEl0Q1dKVHF0RENrNnRGSHNQUUNKOGYwdHdhK2V3ZzljZVQ5YmlJOWNkMkVlCnVndWtZUGNXU0tERnRZUTd5dU9aVEkwL0ZKTm1KQUdIazFIalUxb3FOdlV0MUZYMnZsT2xySjNDSXMrTnRHNisKdXVNSUd1RE5Eb0oxTVVIUnVoUHZzdS9GWGhpekVqWGUyV3kwVkNRVWR6MjEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1861"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83b71ba5-e4ae-4480-aaa1-184b4a06c93d
+      - 08a05303-7faa-43e8-993e-7fc897c1bdfa
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340},"endpoints":[{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340}],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1256"
+      - "1310"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:39 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12298d4d-b8ca-4d68-a293-d5f43ddc8c27
+      - 92faf0c1-ab9d-42d5-b045-b81fe5c4f77f
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340},"endpoints":[{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340}],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1256"
+      - "1310"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7e9b367-5d7a-4295-b958-872207294421
+      - d116294a-6e25-4776-a688-a099fa97cbb9
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVRFJMRW5qODVrQ2NwYkhqR3ZGc3g4Wkg2dXp3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RRM016UmFGdzB6TXpFd016QXhPRFEzTXpSYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURRbVZyS1pHblZKcDBkTFZNTHhyVjA3TXR4Tm1FZVY3OXpJamFaQThjcEJ0TXM1dlNFV1JvcXg4bFcKQnY2R2tCWE9HMmZaSzlmeDZPRytLVWl2UDN3THp0RkhyRThlMTVsek5lYWRCcmdQMHBHckZWbk14dVloM3dyUgo0bXlIK3JncS9RTWtHdXFRNURLWFdGdjhacWRyZDA5SVl2OFZYZWlOL1p5b2JBRm5yRVJJM0U5aEFseFZTUUlvCmRMNmluQVEyMnJIaThHenF3cFJpTDRLS2hENUxER1lxRUhWeUtFK2I5bHQ4OGdpczgrSnJXN2FodkYrY0NwUzUKZGIrMzU5dkxHVzEyRlZ0d3JvM3haVDczTVlRbmUwSVpnRUlNUHA5Z0tmZU5rMFBqVW5kWW9kbngvbENOWW5zRgpnU0tJV2hYUnJORmZWdktrQThhUkRLbnpKYlREQWdNQkFBR2phekJwTUdjR0ExVWRFUVJnTUY2Q0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RaVFZoWkRrelpXUXRaR1kxWVMwMFpqZzNMV0U1WVdJdFlqWmxZemd6Tm1OalltTmwKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3JCaHdRekQrZWhod1F6bnhsQk1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNiakxkY1hScUoveGhMcUJZR21NcitrUnJFdjkxeXlsaWVoTlA0azJjUGZGR2FlMUZWCjNhRHhZN1cvQmpPUFVNSjJnRWwrSTVtbzlnbEUzV1FVdElxN3E3dGhCZ01NTXhJTG9HRGpWT3MzSDM3cUt5THkKYkJQZDZvbkRHeXpjZDNLVjNFaUxSSmVNOE1GL3dOdXdYcVNWVlIwQ3dFTWRkdFlnOW5LQTdIdEhTZHFlY2l4cQp4RENWYnZJN204RmNkdmZHNmh6bVNWejB3ZVFaZS9MNGxteGZ2V1F0Q2pUdHRJa3V0Q1phNlRKUXpycVRIMUtxCnpiS0Z2cWxIbzc1U1FQYlhER0FUOUhaQzJkbDBaNUJnc0ZYc1E3V0RZN05aN3VKQmN2WUovRjYzU25DSG9NajIKSkVKSzYvNGVraDJ3Tys1alZ5eEk0N3c0cGVGT05obGxiNW5VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURyVENDQXBXZ0F3SUJBZ0lVVHZxT2pNNFgzSHpNVER0cXBoNW9NZy9veVY0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UVXlNMW9YRFRNek1URXhNekUxTlRVeU0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRVL3J0Y2owRDVzRksyMDJCOVo3dlJ5b2NaS0U4b3JwcWU1Q0FFUEloZ0toTmxmRXVXSUYKZG9KQWpGL3Z3SUlVenpqWU1YMWtYNDhaY2FWU0VIZUF5OUkyMFFPYVZidHJCYVFLeEM5Vm0rTGdQcFRBOUl6dwpNcUNGc1dqdWY5Njl6bzVXaFJ4RlN1R1dxdDIwUGJ1OGw4LzRCUXozS2JtWnJwdXdYSVdVZDJtOUM3blZuL3NFCnk4UG5kbEVPZlZmbjJOUzhnN0wrTVRlV3Vacmx4QkhVSG16MEtTNW9zV1hPaTVkaDdnWDhkdkpDRU4wOTlycGIKcnV2ZVB1UzR5NVVjOWhXREJVb29DVGkzVGZ1b2NCOWw4dnA0RFRNZWhhMDl3cnlRbWpjZm10ZUlUMi8wN3FHSwpKdUJtS3lYOWgzWDFvYW5aUU5WbVVHaTZ6YnVTd2R1TmFRSURBUUFCbzIwd2F6QnBCZ05WSFJFRVlqQmdnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdFlqY3paRGs1TkdFdFpEYzVPUzAwT1dJeExUZ3lZamN0Tm1FeE16ZGoKTXpnM05qa3lMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQ0eHZod1F6RDRNcWh3UXpuM0d0TUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQkFRQkVFbk8yWFFicG5xdjEwRU95MTA0UFY5NUFsSmlaNitkbFp3QVNFaXZkCktSZHZVTUgrRGpwNTZFRUtjZ3ZoQ3JFL2NWOWFuOHhtZFp3TFVNTktzTmpIUkpuZ0FGd1JmK3Q4NzBxQ2I0UG0KTzNLU0pJVHJTaStiaU1EWElMSnpTNG1kUWQxbmx3NzNJcUNlVWtTTCtRdDAyZXRiZUdkLzd6K3dCRHVEN25ZSQorenpDTTFpRGNoZ2xRaFlEN09rTEl0Q1dKVHF0RENrNnRGSHNQUUNKOGYwdHdhK2V3ZzljZVQ5YmlJOWNkMkVlCnVndWtZUGNXU0tERnRZUTd5dU9aVEkwL0ZKTm1KQUdIazFIalUxb3FOdlV0MUZYMnZsT2xySjNDSXMrTnRHNisKdXVNSUd1RE5Eb0oxTVVIUnVoUHZzdS9GWGhpekVqWGUyV3kwVkNRVWR6MjEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1861"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:40 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e3d2354-8477-40af-8624-0db28c29b20b
+      - 0cf56ef7-1ded-4c5c-9e0a-866157c913d1
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340},"endpoints":[{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340}],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1256"
+      - "1310"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d9022fd-c440-4a93-99d5-19afe3b4d3fa
+      - 121f765b-8237-400a-bbcb-a0df93b384df
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340},"endpoints":[{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340}],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1259"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
+      - Thu, 16 Nov 2023 15:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b335bfa-24f7-4232-9f53-ac8f9c553b10
+      - 041bb433-50ff-4707-83c3-53f3f808408a
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:46:37.949892Z","retention":7},"created_at":"2023-11-02T18:46:37.949892Z","endpoint":{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215},"endpoints":[{"id":"95ac1573-b771-44aa-92a0-74fa3c5e94f6","ip":"51.159.25.65","load_balancer":{},"name":null,"port":6215}],"engine":"PostgreSQL-15","id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:52:09.461061Z","retention":7},"created_at":"2023-11-16T15:52:09.461061Z","endpoint":{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340},"endpoints":[{"id":"e867430c-30dc-45b4-8a62-d43f0b26beb5","ip":"51.159.113.173","load_balancer":{},"name":null,"port":19340}],"engine":"PostgreSQL-15","id":"b73d994a-d799-49b1-82b7-6a137c387692","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1259"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:49:41 GMT
+      - Thu, 16 Nov 2023 15:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e8a458c-7440-410a-a46b-2ba42da78d66
+      - da0ff72e-4fb1-47b5-8ea8-a4bc5cd0f94a
     status: 200 OK
     code: 200
     duration: ""
@@ -904,10 +937,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"b73d994a-d799-49b1-82b7-6a137c387692","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -916,7 +949,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 15:56:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18217d22-e842-490b-8d4d-42232106b1bf
+      - 0ecede06-3efa-4956-afbf-d7f04a737a1b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -937,10 +970,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b73d994a-d799-49b1-82b7-6a137c387692
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"e5ad93ed-df5a-4f87-a9ab-b6ec836ccbce","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"b73d994a-d799-49b1-82b7-6a137c387692","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -949,7 +982,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:11 GMT
+      - Thu, 16 Nov 2023 15:56:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a86fe32-a85f-440d-9050-593ab3b0e420
+      - 9fef0e88-b99e-4c47-a3f5-e5b365d62c16
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-privilege-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-privilege-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:35 GMT
+      - Thu, 16 Nov 2023 15:52:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 722d7645-ca2b-44a2-9c5b-60cf89b7a6aa
+      - 30f048c6-a102-4ff8-bc42-e826cf57c0a4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbPrivilege_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbPrivilege_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "795"
+      - "824"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:51 GMT
+      - Thu, 16 Nov 2023 16:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa1e9414-147a-4f65-8bf9-46c8174ccf2a
+      - 55d5f5b3-6815-4daf-aa92-dd6cc2a4aabf
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "795"
+      - "824"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:50:51 GMT
+      - Thu, 16 Nov 2023 16:04:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 092e481f-0f5a-4339-aa29-875ab4d24382
+      - e945abe8-1dad-4b79-8cab-9e9f550df765
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "795"
+      - "824"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:21 GMT
+      - Thu, 16 Nov 2023 16:05:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a10c4f4-7f60-479d-b88b-264db2d6ccf1
+      - 4d155a4d-a22e-4644-93d7-753644374190
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "795"
+      - "824"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:52 GMT
+      - Thu, 16 Nov 2023 16:05:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48fb480b-370d-40b7-8e34-7f959bf5f00d
+      - 2c37cc27-bd12-4371-a5e3-00f5b1ce77a4
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "795"
+      - "824"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:22 GMT
+      - Thu, 16 Nov 2023 16:06:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 402decd5-cdd1-438a-8a3b-70b637a5ee29
+      - 68cf81d1-6b14-4abc-b550-3d79e4d7a1c5
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "795"
+      - "824"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 16:06:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4774675e-2033-492b-9c48-dde2c66a8c59
+      - fc81364c-7ba6-4daf-a475-82ae78bf6f65
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1099"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:22 GMT
+      - Thu, 16 Nov 2023 16:07:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e1159e2-920a-4619-83b0-ef842ae90e0b
+      - 6bcb2930-8a23-44ea-92c6-fa02a3a0f8c8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:07:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df831565-b8a8-495a-9a02-e82eef9026a3
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:22 GMT
+      - Thu, 16 Nov 2023 16:07:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98c8f3c7-cef4-41de-a999-ef8c9efa0ca7
+      - 2d1838c3-f337-4b92-962d-ac2fb8a44982
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:23 GMT
+      - Thu, 16 Nov 2023 16:07:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbdad24d-a190-4d36-ab42-a28dd7dedb50
+      - bf1470c9-bab8-428c-a4cc-b32dd96eab8b
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTVRIM1R0Rk84N3NvNURydENXSkRXbUpQVGo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1UTXdXaGNOTXpNeE1ETXdNVGcxTVRNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt5WW9PNGNIZ0tKVmVuY0xpL1FLMTlHcTBzTzczL1BMRy91QU1IMkJXMXB5THNXbkphRWZKRUgKbUpuTTNQOTdhVGJVZkwzQUYyOXVEaEhqMWI0ZHMyLzA0RWQ3SmgvaXhUQnE4WXRwc3dtVmZCcTBkTWJYTkVXZApjRlpYdERxbHExOGhuc1JJS2VMNEVpQ21KWHRxS0dnNk1KQm44ejNiTkREZk1QOWFtZUFVMFJuVkk5U1N0Q1hiCmFJN2N6eDY3L2lkRXdzT2NkWXdLYTlxTEZNdjBzL25WRWZIdXdkc2RLaEhBOC9Ub3dOSEVHMElYSFN5ay9JcHAKdkxWeENQNGtwN0VsSnpwZnFJZkxUV3hhQlV6cDZadWxHZy9RNlBtTm1VMVZPelFaUnYxMXJZbytVYk9YMUFLWgpyVmRaRTJkbnVTUC9UNlN6UXhuQlc5VVE1TmtjSzBzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TldKbE1URm1NelF0Wm1Nek9TMDBOell3TFdJME5qRXROV1l5WW1FM1lXVTMKTmpNMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1N5RXZjNDArczdzRk0rdlNCN05OWGV6ZFo3eFRlZVZjYmhFTVJMY0xaK2VNN0VRK1NaT1BaCnhzZjhXejh2Zk5RQ2lwWEttQ0ZCZjhnaFFnVE85djVzTi9aK0xhZ1FpV1o1VlNhNzI0dTMySkMzWTdQV3ExWC8KT1V6RWJXeFJxL2ZDUmhhcFNYUzJGbmUycDJsVVBTV3hic2YzZlJ1azBtNVk4dzZaSVJnOGRUN1ptcVd3Y1pJRgoxQmVlTDdWOVd0QWd4QitIMjNvZG1FZVNFTnlrVDF2eXB5Rk4wSjkvVXNKN2QxTDNrNTUrOXlXbkVpaC9lbHdHCk00Y1NYRWgyOHQ0YjM5eklJT2MyNEVJTXRwV1JnQ3owVG4rOE5PTml3RkRBcTNjcU5POWhGK2VtOHZud2RuRVAKY1ZHZHU0SXFKdFpMZ0t2ZkpCVTBmQ3FsUThIRmVGWXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWjR6ZlNtN1V3VHpOcXNBTDNyRXJIa3MrUDVRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EY3lNRm9YRFRNek1URXhNekUyTURjeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTVHUzZyY3Z2RDNYd25BNU5hbW5sd2pmSnRiUG1FbVdydnozRE5tTThKcjkya2ttNEdpTVYKQ0dYR3RHK25POVlTRWl0clFXNHhkbnhCNDV3VTJCbzgxR2JsVHVBM1BIMXBwV1JpdVlxOGdYWVBJQ1ZCZ1p6SQpidEl2ajdIbE9qSUt3YmJoTW9BSWh2Wm0yZTluUlRGZ3VHOVpyRWtYbnVVayt2QjFHcTVwOHBXVGNTZ3FrR3A0ClpVa2paQUlXR3l3cGtpUXJKanFFVlYydmltUC9zRisvTVVjenRFY0RaNURQKy9mNGpwZGJJb1liYklNWVlIV0gKQ2dxNVVFYnI2dVI5OGtPdlk0cVJ3YXI5NXk5NWs0TzJWV00rd3RPcFBWbzhwNVdEaUlGRVh0M2FUUWF6cTBpcQp1ZW9zSlRZaVl3WVBUKzdkcVFsbUozUW1XVXhneTA4TnZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1EWXhNR05pWkRZdFpqRTBNQzAwWm1ZeExXSmlPRFl0TkdJM1pXSmgKTmpBNU5UY3hMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5raTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNpbWJHaTk0WEhSZ0J5b3NXa0dpNkZ1ZkczKy9wL3FRbTRjTWUwVysxRFNBOVhRT0FCCklWWDFBSTU4cm1lYUtOMTdJcm5qYnRFckk1eDJNcm9WWXBEN2tvOUlBMTZYQ0hFSEtaMWZLUGFPSnpyWXcwNCsKTUVVamVEMVBCRWZUb0lwMFRSZUkyZitVUEcyRkJuMmMyaUpoemI1dmtZRzRJTEhXc3pZYURSVDIvQnU5ZDlZSQpYdk5LaG80R3F4MlNXVGVOZ3luR2QwMDBpZHYycW96VDRYUzNWaGRXMENkN2dMVWQ1YURDVTdRR1ZaTHlhOTZ0Cm94QUc3a3BwVHp3bTNuY0UrT1NzVVlzM1N1dGtBTmppZXNtcytiVWM1dnlWT0ZzcW5abGVZSk9lTHFtVkRadGIKeTRZcElzTWNKV21UakErd1Q4RXh2QkpHN29ZMytCbm1mcjRmCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:23 GMT
+      - Thu, 16 Nov 2023 16:07:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd615584-849f-4000-88df-f6098e1b01be
+      - 723a911c-3c1c-4fd5-9f7d-cd3f9f3dd307
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:23 GMT
+      - Thu, 16 Nov 2023 16:07:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82f198ac-65f3-429a-a01a-7949a2736f9a
+      - 7c4e8bd5-c435-4a84-830b-fa6ed7ff4225
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:23 GMT
+      - Thu, 16 Nov 2023 16:07:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6338c314-734f-4380-974c-6f2ae979b3db
+      - a85ee874-e800-4427-95ed-48de3cfc1e08
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users
     method: POST
   response:
     body: '{"is_admin":true,"name":"user_01"}'
     headers:
       Content-Length:
-      - "34"
+      - "35"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:23 GMT
+      - Thu, 16 Nov 2023 16:07:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33e33823-9889-46df-bf8e-7a6187f423ab
+      - f7119db6-ff77-46c6-a480-d657b58128bc
     status: 200 OK
     code: 200
     duration: ""
@@ -776,19 +809,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
     headers:
       Content-Length:
-      - "49"
+      - "52"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:23 GMT
+      - Thu, 16 Nov 2023 16:07:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -798,7 +831,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4c883ac-5e3f-486e-a5e5-eedbba9626bf
+      - ba4eeb76-3160-414c-9d8a-3acacce655c6
     status: 200 OK
     code: 200
     duration: ""
@@ -809,19 +842,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:23 GMT
+      - Thu, 16 Nov 2023 16:07:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -831,7 +864,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7efd763c-c2ec-4582-9393-07368ea29ab2
+      - 5f35a272-cd23-4d00-8211-87cdb117d38a
     status: 200 OK
     code: 200
     duration: ""
@@ -842,19 +875,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:23 GMT
+      - Thu, 16 Nov 2023 16:07:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -864,7 +897,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98af6a3e-282c-43b4-856f-1ec60fdf6841
+      - 2f29e487-347e-40de-91a3-5069917aacb9
     status: 200 OK
     code: 200
     duration: ""
@@ -875,52 +908,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "102"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7306f016-d1fd-4777-8b3e-d096f19afff1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "62"
+      - "64"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:23 GMT
+      - Thu, 16 Nov 2023 16:07:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -930,7 +930,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebed79ee-df68-4ff9-9c39-c56eb4a4ac6f
+      - 57662675-ed95-4031-99a5-64a091e08ced
     status: 200 OK
     code: 200
     duration: ""
@@ -941,19 +941,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "1266"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:24 GMT
+      - Thu, 16 Nov 2023 16:07:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -963,7 +963,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2488d07d-30bb-4fd5-8ef5-0ea01ca29c4b
+      - 8f6ceb3b-0cfc-44c4-89b7-0fbb6300c84d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:07:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5af3ba8a-60dc-4390-88ca-d404aa098edb
     status: 200 OK
     code: 200
     duration: ""
@@ -976,10 +1009,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"all","user_name":"user_01"}'
+    headers:
+      Content-Length:
+      - "66"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:07:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3a55a1c2-a3c2-4ddb-91ee-e0e47bcad9e5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:07:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4cef5603-70aa-4fbf-ba1e-dea020101786
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:07:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1b8111fc-0ebc-4fb8-8122-41343b13fb78
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
       - "64"
@@ -988,7 +1120,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:24 GMT
+      - Thu, 16 Nov 2023 16:07:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -998,7 +1130,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f7e5c54-2d60-473c-ac3a-e2d87412e070
+      - a2911aa5-6774-42d1-86bf-e8b0f77cb9dc
     status: 200 OK
     code: 200
     duration: ""
@@ -1009,19 +1141,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1266"
+      - "100"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:24 GMT
+      - Thu, 16 Nov 2023 16:07:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1031,7 +1163,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2280cdc0-85ed-40bf-add9-211060371ca2
+      - f758f931-9bbd-4fc6-b96c-aff8b794ac17
     status: 200 OK
     code: 200
     duration: ""
@@ -1042,19 +1174,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1266"
+      - "100"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:24 GMT
+      - Thu, 16 Nov 2023 16:07:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1064,7 +1196,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbf6a1c0-67fc-4d38-ad36-6cdc518b351f
+      - d3c76eea-7fc0-4abb-a52b-fb37df115f35
     status: 200 OK
     code: 200
     duration: ""
@@ -1075,19 +1207,118 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:07:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d6653435-748e-470a-8d2d-7d44ff2ed32b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWjR6ZlNtN1V3VHpOcXNBTDNyRXJIa3MrUDVRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EY3lNRm9YRFRNek1URXhNekUyTURjeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTVHUzZyY3Z2RDNYd25BNU5hbW5sd2pmSnRiUG1FbVdydnozRE5tTThKcjkya2ttNEdpTVYKQ0dYR3RHK25POVlTRWl0clFXNHhkbnhCNDV3VTJCbzgxR2JsVHVBM1BIMXBwV1JpdVlxOGdYWVBJQ1ZCZ1p6SQpidEl2ajdIbE9qSUt3YmJoTW9BSWh2Wm0yZTluUlRGZ3VHOVpyRWtYbnVVayt2QjFHcTVwOHBXVGNTZ3FrR3A0ClpVa2paQUlXR3l3cGtpUXJKanFFVlYydmltUC9zRisvTVVjenRFY0RaNURQKy9mNGpwZGJJb1liYklNWVlIV0gKQ2dxNVVFYnI2dVI5OGtPdlk0cVJ3YXI5NXk5NWs0TzJWV00rd3RPcFBWbzhwNVdEaUlGRVh0M2FUUWF6cTBpcQp1ZW9zSlRZaVl3WVBUKzdkcVFsbUozUW1XVXhneTA4TnZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1EWXhNR05pWkRZdFpqRTBNQzAwWm1ZeExXSmlPRFl0TkdJM1pXSmgKTmpBNU5UY3hMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5raTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNpbWJHaTk0WEhSZ0J5b3NXa0dpNkZ1ZkczKy9wL3FRbTRjTWUwVysxRFNBOVhRT0FCCklWWDFBSTU4cm1lYUtOMTdJcm5qYnRFckk1eDJNcm9WWXBEN2tvOUlBMTZYQ0hFSEtaMWZLUGFPSnpyWXcwNCsKTUVVamVEMVBCRWZUb0lwMFRSZUkyZitVUEcyRkJuMmMyaUpoemI1dmtZRzRJTEhXc3pZYURSVDIvQnU5ZDlZSQpYdk5LaG80R3F4MlNXVGVOZ3luR2QwMDBpZHYycW96VDRYUzNWaGRXMENkN2dMVWQ1YURDVTdRR1ZaTHlhOTZ0Cm94QUc3a3BwVHp3bTNuY0UrT1NzVVlzM1N1dGtBTmppZXNtcytiVWM1dnlWT0ZzcW5abGVZSk9lTHFtVkRadGIKeTRZcElzTWNKV21UakErd1Q4RXh2QkpHN29ZMytCbm1mcjRmCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1849"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:07:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c6060a0c-1a6f-4848-9c48-dfe2008c8f62
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:07:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2bf63d02-846b-464f-947a-da2f5b1c25c4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "62"
+      - "64"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:24 GMT
+      - Thu, 16 Nov 2023 16:07:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1097,7 +1328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ebfecab-f324-45a4-b6cb-8aacf703ab89
+      - fc475003-cf19-400e-b14b-dc2bc2f9119d
     status: 200 OK
     code: 200
     duration: ""
@@ -1108,184 +1339,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
-    method: GET
-  response:
-    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "97"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0403963b-ac13-4eb9-860a-1879cbcb48bb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
-    method: GET
-  response:
-    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "97"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1a4dc32b-a641-409e-975c-45293517abb4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4aba7612-5bc3-4a35-aa72-f91553c3b986
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTVRIM1R0Rk84N3NvNURydENXSkRXbUpQVGo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1UTXdXaGNOTXpNeE1ETXdNVGcxTVRNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt5WW9PNGNIZ0tKVmVuY0xpL1FLMTlHcTBzTzczL1BMRy91QU1IMkJXMXB5THNXbkphRWZKRUgKbUpuTTNQOTdhVGJVZkwzQUYyOXVEaEhqMWI0ZHMyLzA0RWQ3SmgvaXhUQnE4WXRwc3dtVmZCcTBkTWJYTkVXZApjRlpYdERxbHExOGhuc1JJS2VMNEVpQ21KWHRxS0dnNk1KQm44ejNiTkREZk1QOWFtZUFVMFJuVkk5U1N0Q1hiCmFJN2N6eDY3L2lkRXdzT2NkWXdLYTlxTEZNdjBzL25WRWZIdXdkc2RLaEhBOC9Ub3dOSEVHMElYSFN5ay9JcHAKdkxWeENQNGtwN0VsSnpwZnFJZkxUV3hhQlV6cDZadWxHZy9RNlBtTm1VMVZPelFaUnYxMXJZbytVYk9YMUFLWgpyVmRaRTJkbnVTUC9UNlN6UXhuQlc5VVE1TmtjSzBzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TldKbE1URm1NelF0Wm1Nek9TMDBOell3TFdJME5qRXROV1l5WW1FM1lXVTMKTmpNMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1N5RXZjNDArczdzRk0rdlNCN05OWGV6ZFo3eFRlZVZjYmhFTVJMY0xaK2VNN0VRK1NaT1BaCnhzZjhXejh2Zk5RQ2lwWEttQ0ZCZjhnaFFnVE85djVzTi9aK0xhZ1FpV1o1VlNhNzI0dTMySkMzWTdQV3ExWC8KT1V6RWJXeFJxL2ZDUmhhcFNYUzJGbmUycDJsVVBTV3hic2YzZlJ1azBtNVk4dzZaSVJnOGRUN1ptcVd3Y1pJRgoxQmVlTDdWOVd0QWd4QitIMjNvZG1FZVNFTnlrVDF2eXB5Rk4wSjkvVXNKN2QxTDNrNTUrOXlXbkVpaC9lbHdHCk00Y1NYRWgyOHQ0YjM5eklJT2MyNEVJTXRwV1JnQ3owVG4rOE5PTml3RkRBcTNjcU5POWhGK2VtOHZud2RuRVAKY1ZHZHU0SXFKdFpMZ0t2ZkpCVTBmQ3FsUThIRmVGWXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1843"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 95ff7b51-843d-432c-b3e5-bfb7d5737e10
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5e729bde-d091-4f10-bde0-fda5f2ef533d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:26 GMT
+      - Thu, 16 Nov 2023 16:08:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1295,7 +1361,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c92363bc-18be-48b1-b9eb-5d434d641e3f
+      - 76236613-3afa-48b8-afe5-e4b5b867d828
     status: 200 OK
     code: 200
     duration: ""
@@ -1306,19 +1372,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08f86ca4-0f00-4fb0-8454-db388d1a00b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "62"
+      - "64"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:27 GMT
+      - Thu, 16 Nov 2023 16:08:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1328,7 +1427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f5cc41b-d8ed-4579-9f51-c11929aaa00c
+      - 70841f36-13a4-46dc-9669-f3faf3471182
     status: 200 OK
     code: 200
     duration: ""
@@ -1339,85 +1438,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fda2252f-5f43-4257-9e2f-73eb0c521035
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 796b6e03-8525-43a1-bbd6-94ec8c2a1fc4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "97"
+      - "100"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:27 GMT
+      - Thu, 16 Nov 2023 16:08:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1427,7 +1460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2403594-5dd0-4533-bc08-2fded96b8f99
+      - e544559a-4903-4c86-be91-e60953f29a92
     status: 200 OK
     code: 200
     duration: ""
@@ -1438,19 +1471,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:28 GMT
+      - Thu, 16 Nov 2023 16:08:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1460,7 +1493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e89816f5-919d-4f70-8352-884bbba8f427
+      - 183546ae-7409-45fb-8836-f1eacb9d4551
     status: 200 OK
     code: 200
     duration: ""
@@ -1471,19 +1504,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTVRIM1R0Rk84N3NvNURydENXSkRXbUpQVGo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1UTXdXaGNOTXpNeE1ETXdNVGcxTVRNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt5WW9PNGNIZ0tKVmVuY0xpL1FLMTlHcTBzTzczL1BMRy91QU1IMkJXMXB5THNXbkphRWZKRUgKbUpuTTNQOTdhVGJVZkwzQUYyOXVEaEhqMWI0ZHMyLzA0RWQ3SmgvaXhUQnE4WXRwc3dtVmZCcTBkTWJYTkVXZApjRlpYdERxbHExOGhuc1JJS2VMNEVpQ21KWHRxS0dnNk1KQm44ejNiTkREZk1QOWFtZUFVMFJuVkk5U1N0Q1hiCmFJN2N6eDY3L2lkRXdzT2NkWXdLYTlxTEZNdjBzL25WRWZIdXdkc2RLaEhBOC9Ub3dOSEVHMElYSFN5ay9JcHAKdkxWeENQNGtwN0VsSnpwZnFJZkxUV3hhQlV6cDZadWxHZy9RNlBtTm1VMVZPelFaUnYxMXJZbytVYk9YMUFLWgpyVmRaRTJkbnVTUC9UNlN6UXhuQlc5VVE1TmtjSzBzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TldKbE1URm1NelF0Wm1Nek9TMDBOell3TFdJME5qRXROV1l5WW1FM1lXVTMKTmpNMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1N5RXZjNDArczdzRk0rdlNCN05OWGV6ZFo3eFRlZVZjYmhFTVJMY0xaK2VNN0VRK1NaT1BaCnhzZjhXejh2Zk5RQ2lwWEttQ0ZCZjhnaFFnVE85djVzTi9aK0xhZ1FpV1o1VlNhNzI0dTMySkMzWTdQV3ExWC8KT1V6RWJXeFJxL2ZDUmhhcFNYUzJGbmUycDJsVVBTV3hic2YzZlJ1azBtNVk4dzZaSVJnOGRUN1ptcVd3Y1pJRgoxQmVlTDdWOVd0QWd4QitIMjNvZG1FZVNFTnlrVDF2eXB5Rk4wSjkvVXNKN2QxTDNrNTUrOXlXbkVpaC9lbHdHCk00Y1NYRWgyOHQ0YjM5eklJT2MyNEVJTXRwV1JnQ3owVG4rOE5PTml3RkRBcTNjcU5POWhGK2VtOHZud2RuRVAKY1ZHZHU0SXFKdFpMZ0t2ZkpCVTBmQ3FsUThIRmVGWXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWjR6ZlNtN1V3VHpOcXNBTDNyRXJIa3MrUDVRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EY3lNRm9YRFRNek1URXhNekUyTURjeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTVHUzZyY3Z2RDNYd25BNU5hbW5sd2pmSnRiUG1FbVdydnozRE5tTThKcjkya2ttNEdpTVYKQ0dYR3RHK25POVlTRWl0clFXNHhkbnhCNDV3VTJCbzgxR2JsVHVBM1BIMXBwV1JpdVlxOGdYWVBJQ1ZCZ1p6SQpidEl2ajdIbE9qSUt3YmJoTW9BSWh2Wm0yZTluUlRGZ3VHOVpyRWtYbnVVayt2QjFHcTVwOHBXVGNTZ3FrR3A0ClpVa2paQUlXR3l3cGtpUXJKanFFVlYydmltUC9zRisvTVVjenRFY0RaNURQKy9mNGpwZGJJb1liYklNWVlIV0gKQ2dxNVVFYnI2dVI5OGtPdlk0cVJ3YXI5NXk5NWs0TzJWV00rd3RPcFBWbzhwNVdEaUlGRVh0M2FUUWF6cTBpcQp1ZW9zSlRZaVl3WVBUKzdkcVFsbUozUW1XVXhneTA4TnZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1EWXhNR05pWkRZdFpqRTBNQzAwWm1ZeExXSmlPRFl0TkdJM1pXSmgKTmpBNU5UY3hMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5raTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNpbWJHaTk0WEhSZ0J5b3NXa0dpNkZ1ZkczKy9wL3FRbTRjTWUwVysxRFNBOVhRT0FCCklWWDFBSTU4cm1lYUtOMTdJcm5qYnRFckk1eDJNcm9WWXBEN2tvOUlBMTZYQ0hFSEtaMWZLUGFPSnpyWXcwNCsKTUVVamVEMVBCRWZUb0lwMFRSZUkyZitVUEcyRkJuMmMyaUpoemI1dmtZRzRJTEhXc3pZYURSVDIvQnU5ZDlZSQpYdk5LaG80R3F4MlNXVGVOZ3luR2QwMDBpZHYycW96VDRYUzNWaGRXMENkN2dMVWQ1YURDVTdRR1ZaTHlhOTZ0Cm94QUc3a3BwVHp3bTNuY0UrT1NzVVlzM1N1dGtBTmppZXNtcytiVWM1dnlWT0ZzcW5abGVZSk9lTHFtVkRadGIKeTRZcElzTWNKV21UakErd1Q4RXh2QkpHN29ZMytCbm1mcjRmCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:28 GMT
+      - Thu, 16 Nov 2023 16:08:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1493,7 +1526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3d479d5-837e-41fd-a015-0678ceb53833
+      - 9431c94c-22e4-4717-b26a-30105a5dd172
     status: 200 OK
     code: 200
     duration: ""
@@ -1504,52 +1537,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d1ef8b05-bc38-40c0-bd55-16dbee2a643e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:28 GMT
+      - Thu, 16 Nov 2023 16:08:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1559,7 +1559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c5060eb-3374-4731-84a1-f0cec64782ff
+      - 5f2c03d2-24a1-40c9-bcfc-971955ab04d6
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,19 +1570,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9c2d99be-732d-486f-b137-d1fa4e823a98
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "62"
+      - "64"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:28 GMT
+      - Thu, 16 Nov 2023 16:08:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1592,7 +1625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd18335e-58c2-41d9-a914-a44c8ad853e2
+      - a7743d66-cf0e-4494-be06-849caeae6df4
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,19 +1636,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:28 GMT
+      - Thu, 16 Nov 2023 16:08:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1625,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4dfeb65f-6b7c-427a-80e6-e40b0d0e416a
+      - b0129afa-21e0-4a94-97ad-b80a1dcb0947
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,19 +1669,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "62"
+      - "64"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:29 GMT
+      - Thu, 16 Nov 2023 16:08:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1658,7 +1691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33bbecff-4c2f-48f3-afdc-7a5bb70700f6
+      - 412f77d7-c7d0-4752-b248-82329f92d159
     status: 200 OK
     code: 200
     duration: ""
@@ -1669,19 +1702,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "97"
+      - "100"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:29 GMT
+      - Thu, 16 Nov 2023 16:08:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1691,7 +1724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4bc5f61-f049-4d28-957f-a3a9309e852f
+      - e5addfcf-b453-4b6d-b2d7-df74169f1003
     status: 200 OK
     code: 200
     duration: ""
@@ -1702,19 +1735,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:30 GMT
+      - Thu, 16 Nov 2023 16:08:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1724,7 +1757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be1b95a4-ca62-4865-b4e7-bb5ca0aeb48c
+      - 95048876-7350-4db1-a509-c78edb9f9b75
     status: 200 OK
     code: 200
     duration: ""
@@ -1737,19 +1770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"user_02"}'
     headers:
       Content-Length:
-      - "35"
+      - "36"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:30 GMT
+      - Thu, 16 Nov 2023 16:08:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1759,7 +1792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06703ee1-9c43-4c47-b78c-3b7efd1fbfb4
+      - 368aa4f1-fe5a-4560-9fcb-1e7037622e3c
     status: 200 OK
     code: 200
     duration: ""
@@ -1770,19 +1803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:30 GMT
+      - Thu, 16 Nov 2023 16:08:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1792,7 +1825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0448a712-dade-4625-ae4b-89edfa2cc1d5
+      - 7baf4abd-f788-4a40-8b80-ee7b42beae44
     status: 200 OK
     code: 200
     duration: ""
@@ -1803,19 +1836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
-      - "63"
+      - "65"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:30 GMT
+      - Thu, 16 Nov 2023 16:08:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1825,7 +1858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 121af875-4719-4b2c-9551-cdcf00987744
+      - 15a6b5aa-5eac-4389-aeab-21cb1614c60f
     status: 200 OK
     code: 200
     duration: ""
@@ -1836,19 +1869,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:30 GMT
+      - Thu, 16 Nov 2023 16:08:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1858,7 +1891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9cbada7-6fd6-4f9c-bf06-5705fe7f043f
+      - 5d7861c7-331e-4827-abd8-88f226d60561
     status: 200 OK
     code: 200
     duration: ""
@@ -1871,19 +1904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"readwrite","user_name":"user_02"}'
     headers:
       Content-Length:
-      - "70"
+      - "72"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:31 GMT
+      - Thu, 16 Nov 2023 16:08:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1893,7 +1926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc3309d9-6567-4421-b00e-0781d63e2da5
+      - 471ca054-cf2b-4b8e-b8d9-4c1415c7990d
     status: 200 OK
     code: 200
     duration: ""
@@ -1904,19 +1937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:31 GMT
+      - Thu, 16 Nov 2023 16:08:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1926,7 +1959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2d9c780-f912-4de5-b89f-dc99e4562916
+      - 196e8d4b-c5cc-4ca0-8143-4e53860d11b8
     status: 200 OK
     code: 200
     duration: ""
@@ -1937,19 +1970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:31 GMT
+      - Thu, 16 Nov 2023 16:08:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1959,7 +1992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36ac581e-819b-4ea6-94d6-20d3cd4be2ee
+      - 244e4b92-113f-435f-9bf7-e0c531c032d6
     status: 200 OK
     code: 200
     duration: ""
@@ -1970,19 +2003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
-      - "63"
+      - "65"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:31 GMT
+      - Thu, 16 Nov 2023 16:08:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1992,7 +2025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c07f5cf7-9937-42a7-b72e-9ecd0a0c676f
+      - da2187ed-e1d3-4d24-8bcd-00eb6a858455
     status: 200 OK
     code: 200
     duration: ""
@@ -2003,19 +2036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
     headers:
       Content-Length:
-      - "103"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:31 GMT
+      - Thu, 16 Nov 2023 16:08:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2025,7 +2058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 358ce703-51f7-4a8d-a20b-d3a720144d4d
+      - b40e3cfb-bd0e-434c-84c1-1286d5d44dd1
     status: 200 OK
     code: 200
     duration: ""
@@ -2036,19 +2069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
     headers:
       Content-Length:
-      - "103"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:31 GMT
+      - Thu, 16 Nov 2023 16:08:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2058,7 +2091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cd13737-44cd-4847-911d-c6ca2eaf54d1
+      - eea7690f-fdcc-4d4c-9932-3280bf249b3c
     status: 200 OK
     code: 200
     duration: ""
@@ -2069,19 +2102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:32 GMT
+      - Thu, 16 Nov 2023 16:08:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2091,7 +2124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30e8a66e-108d-49ba-a034-bcd48311687c
+      - 1f8f880a-7dca-4bd4-8660-cc6e8e055e24
     status: 200 OK
     code: 200
     duration: ""
@@ -2102,19 +2135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTVRIM1R0Rk84N3NvNURydENXSkRXbUpQVGo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1UTXdXaGNOTXpNeE1ETXdNVGcxTVRNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt5WW9PNGNIZ0tKVmVuY0xpL1FLMTlHcTBzTzczL1BMRy91QU1IMkJXMXB5THNXbkphRWZKRUgKbUpuTTNQOTdhVGJVZkwzQUYyOXVEaEhqMWI0ZHMyLzA0RWQ3SmgvaXhUQnE4WXRwc3dtVmZCcTBkTWJYTkVXZApjRlpYdERxbHExOGhuc1JJS2VMNEVpQ21KWHRxS0dnNk1KQm44ejNiTkREZk1QOWFtZUFVMFJuVkk5U1N0Q1hiCmFJN2N6eDY3L2lkRXdzT2NkWXdLYTlxTEZNdjBzL25WRWZIdXdkc2RLaEhBOC9Ub3dOSEVHMElYSFN5ay9JcHAKdkxWeENQNGtwN0VsSnpwZnFJZkxUV3hhQlV6cDZadWxHZy9RNlBtTm1VMVZPelFaUnYxMXJZbytVYk9YMUFLWgpyVmRaRTJkbnVTUC9UNlN6UXhuQlc5VVE1TmtjSzBzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TldKbE1URm1NelF0Wm1Nek9TMDBOell3TFdJME5qRXROV1l5WW1FM1lXVTMKTmpNMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1N5RXZjNDArczdzRk0rdlNCN05OWGV6ZFo3eFRlZVZjYmhFTVJMY0xaK2VNN0VRK1NaT1BaCnhzZjhXejh2Zk5RQ2lwWEttQ0ZCZjhnaFFnVE85djVzTi9aK0xhZ1FpV1o1VlNhNzI0dTMySkMzWTdQV3ExWC8KT1V6RWJXeFJxL2ZDUmhhcFNYUzJGbmUycDJsVVBTV3hic2YzZlJ1azBtNVk4dzZaSVJnOGRUN1ptcVd3Y1pJRgoxQmVlTDdWOVd0QWd4QitIMjNvZG1FZVNFTnlrVDF2eXB5Rk4wSjkvVXNKN2QxTDNrNTUrOXlXbkVpaC9lbHdHCk00Y1NYRWgyOHQ0YjM5eklJT2MyNEVJTXRwV1JnQ3owVG4rOE5PTml3RkRBcTNjcU5POWhGK2VtOHZud2RuRVAKY1ZHZHU0SXFKdFpMZ0t2ZkpCVTBmQ3FsUThIRmVGWXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWjR6ZlNtN1V3VHpOcXNBTDNyRXJIa3MrUDVRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EY3lNRm9YRFRNek1URXhNekUyTURjeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTVHUzZyY3Z2RDNYd25BNU5hbW5sd2pmSnRiUG1FbVdydnozRE5tTThKcjkya2ttNEdpTVYKQ0dYR3RHK25POVlTRWl0clFXNHhkbnhCNDV3VTJCbzgxR2JsVHVBM1BIMXBwV1JpdVlxOGdYWVBJQ1ZCZ1p6SQpidEl2ajdIbE9qSUt3YmJoTW9BSWh2Wm0yZTluUlRGZ3VHOVpyRWtYbnVVayt2QjFHcTVwOHBXVGNTZ3FrR3A0ClpVa2paQUlXR3l3cGtpUXJKanFFVlYydmltUC9zRisvTVVjenRFY0RaNURQKy9mNGpwZGJJb1liYklNWVlIV0gKQ2dxNVVFYnI2dVI5OGtPdlk0cVJ3YXI5NXk5NWs0TzJWV00rd3RPcFBWbzhwNVdEaUlGRVh0M2FUUWF6cTBpcQp1ZW9zSlRZaVl3WVBUKzdkcVFsbUozUW1XVXhneTA4TnZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1EWXhNR05pWkRZdFpqRTBNQzAwWm1ZeExXSmlPRFl0TkdJM1pXSmgKTmpBNU5UY3hMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5raTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNpbWJHaTk0WEhSZ0J5b3NXa0dpNkZ1ZkczKy9wL3FRbTRjTWUwVysxRFNBOVhRT0FCCklWWDFBSTU4cm1lYUtOMTdJcm5qYnRFckk1eDJNcm9WWXBEN2tvOUlBMTZYQ0hFSEtaMWZLUGFPSnpyWXcwNCsKTUVVamVEMVBCRWZUb0lwMFRSZUkyZitVUEcyRkJuMmMyaUpoemI1dmtZRzRJTEhXc3pZYURSVDIvQnU5ZDlZSQpYdk5LaG80R3F4MlNXVGVOZ3luR2QwMDBpZHYycW96VDRYUzNWaGRXMENkN2dMVWQ1YURDVTdRR1ZaTHlhOTZ0Cm94QUc3a3BwVHp3bTNuY0UrT1NzVVlzM1N1dGtBTmppZXNtcytiVWM1dnlWT0ZzcW5abGVZSk9lTHFtVkRadGIKeTRZcElzTWNKV21UakErd1Q4RXh2QkpHN29ZMytCbm1mcjRmCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:32 GMT
+      - Thu, 16 Nov 2023 16:08:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2124,7 +2157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9efff1af-ee02-421d-8d0c-30240320712d
+      - 8f073c80-4726-451c-ac16-e24828e2ea59
     status: 200 OK
     code: 200
     duration: ""
@@ -2135,19 +2168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
+      - Thu, 16 Nov 2023 16:08:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2157,7 +2190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e28412db-afa8-48fb-97da-082de5831a3a
+      - 49c61b3e-509a-4234-b0c0-5562fdd71331
     status: 200 OK
     code: 200
     duration: ""
@@ -2168,52 +2201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f84d2736-194c-4dd4-83b1-7a2c5b519f42
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
+      - Thu, 16 Nov 2023 16:08:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2223,7 +2223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3050118-f0db-4160-891a-6a5f7c304ad9
+      - d12fc2b6-6d1d-411e-963e-baa15d0393f7
     status: 200 OK
     code: 200
     duration: ""
@@ -2234,19 +2234,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1838cc8a-4bd0-4994-b531-b387bb39d08a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
-      - "63"
+      - "65"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
+      - Thu, 16 Nov 2023 16:08:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2256,7 +2289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f3007c8-dc7f-4d1a-9c21-8a3af5263d47
+      - c24de36e-28c4-4b3d-b809-8d56b3e34c99
     status: 200 OK
     code: 200
     duration: ""
@@ -2267,19 +2300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "62"
+      - "64"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
+      - Thu, 16 Nov 2023 16:08:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2289,7 +2322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3221d669-aeca-491d-bc4b-d205e2bdc91b
+      - 6ad714a2-62e5-4f75-942b-5d0e342fc790
     status: 200 OK
     code: 200
     duration: ""
@@ -2300,19 +2333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
+      - Thu, 16 Nov 2023 16:08:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2322,7 +2355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4dd7f08-d357-48c9-aa4a-b0dcbd138121
+      - 5c00eea9-813a-4235-8ef9-cd0fb6c67c1d
     status: 200 OK
     code: 200
     duration: ""
@@ -2333,19 +2366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
+      - Thu, 16 Nov 2023 16:08:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2355,7 +2388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60c74cc8-aa14-411c-a5b6-b4eeede612cd
+      - d1d0977c-4dfe-4fa1-8ae3-f39bfb8a8076
     status: 200 OK
     code: 200
     duration: ""
@@ -2366,19 +2399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
-      - "63"
+      - "65"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
+      - Thu, 16 Nov 2023 16:08:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2388,7 +2421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14cdcfa4-b10a-4401-a245-825bee2a370d
+      - 285b8767-00f5-4c66-8cf9-e3b07df5ca3d
     status: 200 OK
     code: 200
     duration: ""
@@ -2399,19 +2432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "62"
+      - "64"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
+      - Thu, 16 Nov 2023 16:08:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2421,7 +2454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f15e2a8b-0313-43ea-bf67-55d9abf22459
+      - 2b4e3588-53a9-47cf-a5c0-784a5d835c3b
     status: 200 OK
     code: 200
     duration: ""
@@ -2432,19 +2465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
     headers:
       Content-Length:
-      - "103"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
+      - Thu, 16 Nov 2023 16:08:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2454,7 +2487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c761522-760f-4033-bfc0-9bd8daef2892
+      - b5053eda-456f-4274-99b7-ed02cd504a70
     status: 200 OK
     code: 200
     duration: ""
@@ -2465,19 +2498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "97"
+      - "100"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
+      - Thu, 16 Nov 2023 16:08:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2487,7 +2520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32991456-7c8f-4f52-837c-d37cf5e67054
+      - 01ca756b-cd13-4098-b727-386962f4b450
     status: 200 OK
     code: 200
     duration: ""
@@ -2498,19 +2531,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:34 GMT
+      - Thu, 16 Nov 2023 16:08:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2520,7 +2553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3704077e-7e9e-42f2-a348-c3de5909276b
+      - a77f8f4b-b913-400d-82cd-6994a44ee8f0
     status: 200 OK
     code: 200
     duration: ""
@@ -2531,19 +2564,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTVRIM1R0Rk84N3NvNURydENXSkRXbUpQVGo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1UTXdXaGNOTXpNeE1ETXdNVGcxTVRNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt5WW9PNGNIZ0tKVmVuY0xpL1FLMTlHcTBzTzczL1BMRy91QU1IMkJXMXB5THNXbkphRWZKRUgKbUpuTTNQOTdhVGJVZkwzQUYyOXVEaEhqMWI0ZHMyLzA0RWQ3SmgvaXhUQnE4WXRwc3dtVmZCcTBkTWJYTkVXZApjRlpYdERxbHExOGhuc1JJS2VMNEVpQ21KWHRxS0dnNk1KQm44ejNiTkREZk1QOWFtZUFVMFJuVkk5U1N0Q1hiCmFJN2N6eDY3L2lkRXdzT2NkWXdLYTlxTEZNdjBzL25WRWZIdXdkc2RLaEhBOC9Ub3dOSEVHMElYSFN5ay9JcHAKdkxWeENQNGtwN0VsSnpwZnFJZkxUV3hhQlV6cDZadWxHZy9RNlBtTm1VMVZPelFaUnYxMXJZbytVYk9YMUFLWgpyVmRaRTJkbnVTUC9UNlN6UXhuQlc5VVE1TmtjSzBzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TldKbE1URm1NelF0Wm1Nek9TMDBOell3TFdJME5qRXROV1l5WW1FM1lXVTMKTmpNMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1N5RXZjNDArczdzRk0rdlNCN05OWGV6ZFo3eFRlZVZjYmhFTVJMY0xaK2VNN0VRK1NaT1BaCnhzZjhXejh2Zk5RQ2lwWEttQ0ZCZjhnaFFnVE85djVzTi9aK0xhZ1FpV1o1VlNhNzI0dTMySkMzWTdQV3ExWC8KT1V6RWJXeFJxL2ZDUmhhcFNYUzJGbmUycDJsVVBTV3hic2YzZlJ1azBtNVk4dzZaSVJnOGRUN1ptcVd3Y1pJRgoxQmVlTDdWOVd0QWd4QitIMjNvZG1FZVNFTnlrVDF2eXB5Rk4wSjkvVXNKN2QxTDNrNTUrOXlXbkVpaC9lbHdHCk00Y1NYRWgyOHQ0YjM5eklJT2MyNEVJTXRwV1JnQ3owVG4rOE5PTml3RkRBcTNjcU5POWhGK2VtOHZud2RuRVAKY1ZHZHU0SXFKdFpMZ0t2ZkpCVTBmQ3FsUThIRmVGWXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWjR6ZlNtN1V3VHpOcXNBTDNyRXJIa3MrUDVRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EY3lNRm9YRFRNek1URXhNekUyTURjeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTVHUzZyY3Z2RDNYd25BNU5hbW5sd2pmSnRiUG1FbVdydnozRE5tTThKcjkya2ttNEdpTVYKQ0dYR3RHK25POVlTRWl0clFXNHhkbnhCNDV3VTJCbzgxR2JsVHVBM1BIMXBwV1JpdVlxOGdYWVBJQ1ZCZ1p6SQpidEl2ajdIbE9qSUt3YmJoTW9BSWh2Wm0yZTluUlRGZ3VHOVpyRWtYbnVVayt2QjFHcTVwOHBXVGNTZ3FrR3A0ClpVa2paQUlXR3l3cGtpUXJKanFFVlYydmltUC9zRisvTVVjenRFY0RaNURQKy9mNGpwZGJJb1liYklNWVlIV0gKQ2dxNVVFYnI2dVI5OGtPdlk0cVJ3YXI5NXk5NWs0TzJWV00rd3RPcFBWbzhwNVdEaUlGRVh0M2FUUWF6cTBpcQp1ZW9zSlRZaVl3WVBUKzdkcVFsbUozUW1XVXhneTA4TnZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1EWXhNR05pWkRZdFpqRTBNQzAwWm1ZeExXSmlPRFl0TkdJM1pXSmgKTmpBNU5UY3hMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5raTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNpbWJHaTk0WEhSZ0J5b3NXa0dpNkZ1ZkczKy9wL3FRbTRjTWUwVysxRFNBOVhRT0FCCklWWDFBSTU4cm1lYUtOMTdJcm5qYnRFckk1eDJNcm9WWXBEN2tvOUlBMTZYQ0hFSEtaMWZLUGFPSnpyWXcwNCsKTUVVamVEMVBCRWZUb0lwMFRSZUkyZitVUEcyRkJuMmMyaUpoemI1dmtZRzRJTEhXc3pZYURSVDIvQnU5ZDlZSQpYdk5LaG80R3F4MlNXVGVOZ3luR2QwMDBpZHYycW96VDRYUzNWaGRXMENkN2dMVWQ1YURDVTdRR1ZaTHlhOTZ0Cm94QUc3a3BwVHp3bTNuY0UrT1NzVVlzM1N1dGtBTmppZXNtcytiVWM1dnlWT0ZzcW5abGVZSk9lTHFtVkRadGIKeTRZcElzTWNKV21UakErd1Q4RXh2QkpHN29ZMytCbm1mcjRmCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:35 GMT
+      - Thu, 16 Nov 2023 16:08:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2553,7 +2586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e560fda6-6e2a-45c0-b40d-c61b2733329d
+      - 92450032-6afb-4832-9991-22b6b52250b0
     status: 200 OK
     code: 200
     duration: ""
@@ -2564,85 +2597,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cdcf9218-c94a-4c9d-851d-a7178b598178
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5c0a8a2f-035f-4dd1-9207-22563de6c4b2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:35 GMT
+      - Thu, 16 Nov 2023 16:08:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2652,7 +2619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d3b613b-5c5b-4224-94f2-82b4ff3e4f90
+      - 094d9859-3458-4963-be20-7d675888b533
     status: 200 OK
     code: 200
     duration: ""
@@ -2663,19 +2630,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c96fd9b1-6261-4465-8f3d-8e4b04d5ce6a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4530a320-79fe-4cdf-982b-efe948a44fcb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "62"
+      - "64"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:35 GMT
+      - Thu, 16 Nov 2023 16:08:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2685,7 +2718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30e7e348-a6e1-41cc-8a3d-78b799b28053
+      - 8b831938-b76f-4527-afe3-d641d195f1b9
     status: 200 OK
     code: 200
     duration: ""
@@ -2696,19 +2729,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
-      - "63"
+      - "65"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:35 GMT
+      - Thu, 16 Nov 2023 16:08:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2718,7 +2751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b328ba51-f2a5-4ebd-930a-ae87d277918e
+      - f4c968fe-4e8c-47cc-adcb-1716b1563cb8
     status: 200 OK
     code: 200
     duration: ""
@@ -2729,19 +2762,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:35 GMT
+      - Thu, 16 Nov 2023 16:08:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2751,7 +2784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 929bfd0d-addc-4211-833c-9470b2e5081a
+      - a7227be8-4b65-45cc-a5a6-2dea53419246
     status: 200 OK
     code: 200
     duration: ""
@@ -2762,19 +2795,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:35 GMT
+      - Thu, 16 Nov 2023 16:08:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2784,7 +2817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42fe5f65-ff19-4af2-b928-3eb7746d1483
+      - 3fc9bfa0-9156-4995-8d4b-6cb88c07105f
     status: 200 OK
     code: 200
     duration: ""
@@ -2795,19 +2828,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "65"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4aeec5f6-2c48-4995-8593-67a34bb317e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "62"
+      - "64"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:35 GMT
+      - Thu, 16 Nov 2023 16:08:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2817,7 +2883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a25e8d49-20e3-4974-b78a-22db05860ce5
+      - df2b7985-1e7b-432e-a835-fee7c1503172
     status: 200 OK
     code: 200
     duration: ""
@@ -2828,85 +2894,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c7777d57-6b4f-4d84-a984-b434e588d925
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
-    method: GET
-  response:
-    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "97"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7a0b87aa-198e-4d7b-894c-37ba0b9c2c21
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
     headers:
       Content-Length:
-      - "103"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:36 GMT
+      - Thu, 16 Nov 2023 16:08:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2916,7 +2916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dee64079-64b2-4ed8-bee2-9f9d1e351820
+      - 0c303a56-56ea-4b0a-addd-613e4a2dd77a
     status: 200 OK
     code: 200
     duration: ""
@@ -2927,19 +2927,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1266"
+      - "100"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:37 GMT
+      - Thu, 16 Nov 2023 16:08:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2949,7 +2949,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f65e28b-f406-41eb-bea9-bd4eed30ee53
+      - 099a206c-6ce8-4b58-955f-64890baf97ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 54aa6b06-60b2-4a23-bfaa-550ae83af481
     status: 200 OK
     code: 200
     duration: ""
@@ -2962,19 +2995,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"user_03"}'
     headers:
       Content-Length:
-      - "35"
+      - "36"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:37 GMT
+      - Thu, 16 Nov 2023 16:08:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2984,7 +3017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 481bc9c4-5c16-4505-b9fb-d6c38a88cac2
+      - 14ccd31f-6cbb-4f13-a222-398ef04b1af6
     status: 200 OK
     code: 200
     duration: ""
@@ -2995,19 +3028,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:37 GMT
+      - Thu, 16 Nov 2023 16:08:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3017,7 +3050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f643d9d-6493-472c-88cd-96155af4a7b8
+      - f98ae714-b7d6-495b-900d-0a2289f6f5bf
     status: 200 OK
     code: 200
     duration: ""
@@ -3028,19 +3061,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_03&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
     headers:
       Content-Length:
-      - "63"
+      - "65"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:37 GMT
+      - Thu, 16 Nov 2023 16:08:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3050,7 +3083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87983389-e461-468b-9d72-f5f816683a97
+      - df7db019-c352-4ca3-920b-a3c2aa476fa8
     status: 200 OK
     code: 200
     duration: ""
@@ -3061,19 +3094,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:37 GMT
+      - Thu, 16 Nov 2023 16:08:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3083,7 +3116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d874698-7ae3-4b3d-a140-a292e8654f43
+      - 520f28fa-1704-46e5-9af2-11c6216be926
     status: 200 OK
     code: 200
     duration: ""
@@ -3096,19 +3129,118 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"user_03"}'
     headers:
       Content-Length:
+      - "67"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cba0ad2d-6c59-462d-93df-f8ea3077df4b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99522a59-94d5-4248-9f73-c409d31ba5bb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fefc4f73-611a-4b2d-9e69-2f333f60c037
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
       - "65"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:38 GMT
+      - Thu, 16 Nov 2023 16:08:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3118,7 +3250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b8d052c-b346-4867-9801-713411da3de5
+      - 44836f0b-4c2c-48ea-b2a2-034ed2044ae9
     status: 200 OK
     code: 200
     duration: ""
@@ -3129,118 +3261,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c5962e64-005c-47a7-8eb5-9049dffe17db
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3b44f152-f325-454b-80e0-fdcf8c3c3514
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 00fbc1c3-51d6-4017-8c56-d7e3044a6e71
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
     headers:
       Content-Length:
-      - "98"
+      - "101"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:38 GMT
+      - Thu, 16 Nov 2023 16:08:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3250,7 +3283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd95e02c-1a49-46a1-bca2-f4efc024bf59
+      - 918fc116-c9ff-4ce0-a3f3-307c79c45bcc
     status: 200 OK
     code: 200
     duration: ""
@@ -3261,19 +3294,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
     headers:
       Content-Length:
-      - "98"
+      - "101"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:38 GMT
+      - Thu, 16 Nov 2023 16:08:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3283,7 +3316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1800380e-7a1d-4618-90ef-deb393c2d731
+      - 5f4c27bb-32d3-4e79-bbd9-408f6d279279
     status: 200 OK
     code: 200
     duration: ""
@@ -3294,19 +3327,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:39 GMT
+      - Thu, 16 Nov 2023 16:08:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3316,7 +3349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6306b919-f921-468d-8122-46ec5adc786d
+      - 9ed8705b-e608-4c99-9fe6-d56da27589b1
     status: 200 OK
     code: 200
     duration: ""
@@ -3327,19 +3360,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTVRIM1R0Rk84N3NvNURydENXSkRXbUpQVGo4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1UTXdXaGNOTXpNeE1ETXdNVGcxTVRNd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUt5WW9PNGNIZ0tKVmVuY0xpL1FLMTlHcTBzTzczL1BMRy91QU1IMkJXMXB5THNXbkphRWZKRUgKbUpuTTNQOTdhVGJVZkwzQUYyOXVEaEhqMWI0ZHMyLzA0RWQ3SmgvaXhUQnE4WXRwc3dtVmZCcTBkTWJYTkVXZApjRlpYdERxbHExOGhuc1JJS2VMNEVpQ21KWHRxS0dnNk1KQm44ejNiTkREZk1QOWFtZUFVMFJuVkk5U1N0Q1hiCmFJN2N6eDY3L2lkRXdzT2NkWXdLYTlxTEZNdjBzL25WRWZIdXdkc2RLaEhBOC9Ub3dOSEVHMElYSFN5ay9JcHAKdkxWeENQNGtwN0VsSnpwZnFJZkxUV3hhQlV6cDZadWxHZy9RNlBtTm1VMVZPelFaUnYxMXJZbytVYk9YMUFLWgpyVmRaRTJkbnVTUC9UNlN6UXhuQlc5VVE1TmtjSzBzQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TldKbE1URm1NelF0Wm1Nek9TMDBOell3TFdJME5qRXROV1l5WW1FM1lXVTMKTmpNMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1N5RXZjNDArczdzRk0rdlNCN05OWGV6ZFo3eFRlZVZjYmhFTVJMY0xaK2VNN0VRK1NaT1BaCnhzZjhXejh2Zk5RQ2lwWEttQ0ZCZjhnaFFnVE85djVzTi9aK0xhZ1FpV1o1VlNhNzI0dTMySkMzWTdQV3ExWC8KT1V6RWJXeFJxL2ZDUmhhcFNYUzJGbmUycDJsVVBTV3hic2YzZlJ1azBtNVk4dzZaSVJnOGRUN1ptcVd3Y1pJRgoxQmVlTDdWOVd0QWd4QitIMjNvZG1FZVNFTnlrVDF2eXB5Rk4wSjkvVXNKN2QxTDNrNTUrOXlXbkVpaC9lbHdHCk00Y1NYRWgyOHQ0YjM5eklJT2MyNEVJTXRwV1JnQ3owVG4rOE5PTml3RkRBcTNjcU5POWhGK2VtOHZud2RuRVAKY1ZHZHU0SXFKdFpMZ0t2ZkpCVTBmQ3FsUThIRmVGWXEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWjR6ZlNtN1V3VHpOcXNBTDNyRXJIa3MrUDVRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EY3lNRm9YRFRNek1URXhNekUyTURjeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTVHUzZyY3Z2RDNYd25BNU5hbW5sd2pmSnRiUG1FbVdydnozRE5tTThKcjkya2ttNEdpTVYKQ0dYR3RHK25POVlTRWl0clFXNHhkbnhCNDV3VTJCbzgxR2JsVHVBM1BIMXBwV1JpdVlxOGdYWVBJQ1ZCZ1p6SQpidEl2ajdIbE9qSUt3YmJoTW9BSWh2Wm0yZTluUlRGZ3VHOVpyRWtYbnVVayt2QjFHcTVwOHBXVGNTZ3FrR3A0ClpVa2paQUlXR3l3cGtpUXJKanFFVlYydmltUC9zRisvTVVjenRFY0RaNURQKy9mNGpwZGJJb1liYklNWVlIV0gKQ2dxNVVFYnI2dVI5OGtPdlk0cVJ3YXI5NXk5NWs0TzJWV00rd3RPcFBWbzhwNVdEaUlGRVh0M2FUUWF6cTBpcQp1ZW9zSlRZaVl3WVBUKzdkcVFsbUozUW1XVXhneTA4TnZRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE1EWXhNR05pWkRZdFpqRTBNQzAwWm1ZeExXSmlPRFl0TkdJM1pXSmgKTmpBNU5UY3hMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5raTZod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNpbWJHaTk0WEhSZ0J5b3NXa0dpNkZ1ZkczKy9wL3FRbTRjTWUwVysxRFNBOVhRT0FCCklWWDFBSTU4cm1lYUtOMTdJcm5qYnRFckk1eDJNcm9WWXBEN2tvOUlBMTZYQ0hFSEtaMWZLUGFPSnpyWXcwNCsKTUVVamVEMVBCRWZUb0lwMFRSZUkyZitVUEcyRkJuMmMyaUpoemI1dmtZRzRJTEhXc3pZYURSVDIvQnU5ZDlZSQpYdk5LaG80R3F4MlNXVGVOZ3luR2QwMDBpZHYycW96VDRYUzNWaGRXMENkN2dMVWQ1YURDVTdRR1ZaTHlhOTZ0Cm94QUc3a3BwVHp3bTNuY0UrT1NzVVlzM1N1dGtBTmppZXNtcytiVWM1dnlWT0ZzcW5abGVZSk9lTHFtVkRadGIKeTRZcElzTWNKV21UakErd1Q4RXh2QkpHN29ZMytCbm1mcjRmCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:39 GMT
+      - Thu, 16 Nov 2023 16:08:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3349,7 +3382,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a552f7c-40c4-4ed7-b731-734a41d0c4e9
+      - 1242d1c1-daa6-4724-8356-6a2108018964
     status: 200 OK
     code: 200
     duration: ""
@@ -3360,19 +3393,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:39 GMT
+      - Thu, 16 Nov 2023 16:08:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3382,7 +3415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 077648d3-c9cc-4018-87b7-7183ef85ca9b
+      - 048d97a3-6030-4f1d-a926-2db3febf09d0
     status: 200 OK
     code: 200
     duration: ""
@@ -3393,19 +3426,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
-      - "102"
+      - "106"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:39 GMT
+      - Thu, 16 Nov 2023 16:08:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3415,7 +3448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c0d70c8-d45f-4144-ab2a-439658311721
+      - d7f983a5-5087-4e11-addc-bfea1043c79d
     status: 200 OK
     code: 200
     duration: ""
@@ -3426,19 +3459,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:39 GMT
+      - Thu, 16 Nov 2023 16:08:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3448,7 +3481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a022f6d-bd81-4857-99a7-34e8277cf5ce
+      - 2b11a09a-fd25-4a5a-8716-921e2c3b337c
     status: 200 OK
     code: 200
     duration: ""
@@ -3459,19 +3492,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:39 GMT
+      - Thu, 16 Nov 2023 16:08:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3481,7 +3514,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c1918ff-34a4-45d7-9927-6f9696f57d97
+      - 1cbb3b3d-50e3-4907-b08e-c802fc45382c
     status: 200 OK
     code: 200
     duration: ""
@@ -3492,705 +3525,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ebef4a87-0a90-4277-91c4-7353a476d8e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 809416d5-9607-4d44-8c80-2eff9097cc98
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2255aa28-bb1f-4fe1-b632-6e4472bfee06
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ff6553be-1bdf-4cb2-88be-7a586e77e8f2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7a42d7a7-9423-4c63-a95b-74008f5c4ba2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ccc2e31-c89a-4e2b-8f28-ca07a70715a4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 46701dd9-66fd-429a-8fd2-83ba51cc54e8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 757bf973-7a5f-4471-9f96-8ef69c9aa8cf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
-    method: GET
-  response:
-    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "97"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9aa6149f-897d-41ed-925f-3e7a96e5ee08
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 20709132-d725-41c0-bd09-c7742033e56f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
-    method: GET
-  response:
-    body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "98"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d049d741-55c2-4204-b53f-7e6b6fea0d3e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
-    method: GET
-  response:
-    body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "103"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6e1e2603-9427-4c6c-83d2-a4fe8eb6e808
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6bee0eec-0943-4117-8916-5902f80a14e3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f3d0bb8d-b23f-47b2-a208-af068cc9641d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 477377d7-800e-4e57-83f4-752f5bc37547
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 25ae02ee-c6d1-432a-a871-8d7b79368b94
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 90e34249-033b-44be-b136-471d7bf9f9b4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 22a75ec7-5015-4cd3-adfb-f5d025b61a28
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d8abf053-d721-418d-a746-6a1697c1c97e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eac80cca-43ce-49ae-ae49-0b151741b90d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6f074872-70d3-4a0b-9e5b-8f4f30a0141c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"database_name":"foo","user_name":"user_02","permission":"none"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges
-    method: PUT
-  response:
-    body: '{"database_name":"foo","permission":"none","user_name":"user_02"}'
     headers:
       Content-Length:
       - "65"
@@ -4199,7 +3537,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
+      - Thu, 16 Nov 2023 16:08:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4209,7 +3547,702 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1916e48b-7c40-40c7-a6af-862efbe8136c
+      - 3d9661a1-18b0-4f8c-bdbb-f770ff268877
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "65"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6a645277-a02b-43aa-b89e-5005eb3ffcf1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "64"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fbec3ad8-2a48-4f63-ba1c-03a9db0ddca9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6598bf11-0216-4ae1-8838-766567bc20b1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb6dfa13-c3b4-47fe-839e-3edd5b1751be
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3c4fdf24-45f4-4862-9f60-6d1bd688e028
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "64"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8355561a-48a6-4ef1-8598-d93181640766
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "65"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b966f8fd-0b53-406a-a9c5-2cbc41a05f50
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "65"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dccd787b-5a62-4f2c-a0aa-71d8bee4c0f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    method: GET
+  response:
+    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "100"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6586edc3-504f-44dd-8e7e-4e0121a58a04
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
+    method: GET
+  response:
+    body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "101"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a0b0052b-3819-4f00-9908-ad4aa8e88ea2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    method: GET
+  response:
+    body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "106"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d3cbcef7-47c2-4b3d-b68b-e7667d7d9f2f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7f66aaaf-109a-4f1a-b9b3-e8af569abfd5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 200e2258-5506-4061-94d2-3b41c4b6bce9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a7e87caa-f017-4c3e-bf9f-b6a4243e82dc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "65"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8f9ff107-5fdd-49eb-adb2-bdd555e30789
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "65"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b0d4e8a2-04d5-4bac-b7d6-98d507058b26
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "64"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1f4abe06-7c34-4b25-ad33-ea09e0bdabd0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "65"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3c1d0011-f7ee-4c34-8853-97a021c4b81a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "65"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1c3947b7-0439-4df1-b92d-326a2427f72e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "64"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dd44c4fd-04ef-4bf3-aeec-578fdd3bde5c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"database_name":"foo","user_name":"user_03","permission":"none"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges
+    method: PUT
+  response:
+    body: '{"database_name":"foo","permission":"none","user_name":"user_03"}'
+    headers:
+      Content-Length:
+      - "67"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 801b444a-7072-404c-a769-819a9aeb08a1
     status: 200 OK
     code: 200
     duration: ""
@@ -4222,19 +4255,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"user_01"}'
     headers:
       Content-Length:
-      - "65"
+      - "67"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
+      - Thu, 16 Nov 2023 16:08:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4244,12 +4277,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b09a536a-aded-466f-9815-33dacbf7ccea
+      - 0ce41b4f-0f4c-432a-bdac-66a70f793110
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"database_name":"foo","user_name":"user_03","permission":"none"}'
+    body: '{"database_name":"foo","user_name":"user_02","permission":"none"}'
     form: {}
     headers:
       Content-Type:
@@ -4257,10 +4290,270 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges
     method: PUT
   response:
-    body: '{"database_name":"foo","permission":"none","user_name":"user_03"}'
+    body: '{"message":"Tuple concurrently updated"}'
+    headers:
+      Content-Length:
+      - "40"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d81a7cdd-4a80-4371-ac9a-090630f2663a
+    status: 409 Conflict
+    code: 409
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a55dab33-6b01-4b81-8930-7c38b124ac25
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8e7653c5-2420-4f1d-95ef-78654f017931
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7e80eed4-7621-48d0-8f5d-9f2053a39e88
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 10649b05-e730-4aa8-a18f-3ed145400cf8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f0261119-1630-4ea3-873c-3e054cc093b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users/user_03
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 391d1386-326b-419a-841f-725efbcf403f
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users/user_01
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6b88e23e-9f84-46d0-a350-480e5b0b4712
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
     headers:
       Content-Length:
       - "65"
@@ -4269,7 +4562,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
+      - Thu, 16 Nov 2023 16:08:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4279,30 +4572,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec39096c-6884-4aa3-bf0f-6730f399f03b
+      - eef697db-9cb2-4860-bbb1-833796494e93
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"database_name":"foo","user_name":"user_02","permission":"none"}'
     form: {}
     headers:
+      Content-Type:
+      - application/json
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/privileges
+    method: PUT
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"database_name":"foo","permission":"none","user_name":"user_02"}'
     headers:
       Content-Length:
-      - "1266"
+      - "67"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
+      - Thu, 16 Nov 2023 16:08:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4312,7 +4607,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98ef50d4-8986-4b26-925a-06f0ba543743
+      - 67d79468-3a44-486b-bd3a-e6c4bccee9c3
     status: 200 OK
     code: 200
     duration: ""
@@ -4323,19 +4618,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
+      - Thu, 16 Nov 2023 16:08:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4345,7 +4640,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 023bf09e-bedc-4431-a0f8-7a2e14b6fda2
+      - 3c7c465b-6693-4574-8510-530c8d219566
     status: 200 OK
     code: 200
     duration: ""
@@ -4356,19 +4651,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
+      - Thu, 16 Nov 2023 16:08:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4378,7 +4673,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 205dd890-f930-4112-b97c-e8d026541df0
+      - 240bda1b-52c9-4fe6-9255-83cea3d9dd9e
     status: 200 OK
     code: 200
     duration: ""
@@ -4389,19 +4684,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
+      - Thu, 16 Nov 2023 16:08:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4411,7 +4706,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a129ea4b-f287-46d4-9fdf-daf1a2d58306
+      - f14f5ee0-4a73-4433-bf3f-90b02c0a6edd
     status: 200 OK
     code: 200
     duration: ""
@@ -4422,106 +4717,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 67570150-7e0a-4844-bd3e-ff18bd4e8020
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bc26207f-7434-44ce-a0cf-549805fe1748
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 75927181-e3d6-45a9-8db1-51fa932ef0cb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users/user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/users/user_02
     method: DELETE
   response:
     body: ""
@@ -4531,7 +4727,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
+      - Thu, 16 Nov 2023 16:08:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4541,7 +4737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b35c887-beba-470c-a7d2-80674ed5953b
+      - b2f482a8-a44d-4c24-8f0a-7030af66d819
     status: 204 No Content
     code: 204
     duration: ""
@@ -4552,7 +4748,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users/user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571/databases/foo
     method: DELETE
   response:
     body: ""
@@ -4562,7 +4758,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
+      - Thu, 16 Nov 2023 16:08:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4572,7 +4768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61692c51-b449-4039-b7a4-a65540b1b4f8
+      - 43aa3ce7-6dac-4cbe-a35a-2eb5613fa473
     status: 204 No Content
     code: 204
     duration: ""
@@ -4583,81 +4779,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/users/user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9837b540-c08d-450e-af54-de3fbaa458dd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1318"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:08:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7b8f3227-14ad-41f8-8132-4c8765005fc8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: DELETE
   response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 56fa3998-60c3-4dc5-a1ed-a7850997911f
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635/databases/foo
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 31ac2a79-7a4a-4dc6-ade7-d2323348e6b7
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1321"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:43 GMT
+      - Thu, 16 Nov 2023 16:08:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4667,7 +4867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c96d5619-f932-4381-905e-e1c7ae88e76a
+      - 12a440a1-4c57-45e1-a82a-97634aea24d9
     status: 200 OK
     code: 200
     duration: ""
@@ -4678,19 +4878,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T16:04:42.662899Z","retention":7},"created_at":"2023-11-16T16:04:42.662899Z","endpoint":{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084},"endpoints":[{"id":"7a163e2e-7b7e-4b54-80f1-4f1b0c813e74","ip":"51.159.113.173","load_balancer":{},"name":null,"port":15084}],"engine":"PostgreSQL-15","id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1321"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:43 GMT
+      - Thu, 16 Nov 2023 16:08:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4700,7 +4900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 904439a5-085b-42fd-8e9a-48f201d59e2c
+      - 16c83543-5a2a-48f0-8494-68e047b0f0c1
     status: 200 OK
     code: 200
     duration: ""
@@ -4711,76 +4911,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1269"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3ad66ee9-88ec-400f-9259-aecd17bce26b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:50:50.935874Z","retention":7},"created_at":"2023-11-02T18:50:50.935874Z","endpoint":{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150},"endpoints":[{"id":"f6062110-5ec9-4568-897f-9bfd0e8b43dc","ip":"51.159.10.213","load_balancer":{},"name":null,"port":6150}],"engine":"PostgreSQL-15","id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1269"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d1586854-0848-43c6-ad10-0f88ac632af0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4789,7 +4923,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:13 GMT
+      - Thu, 16 Nov 2023 16:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4799,7 +4933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 660e184d-e75c-4ee2-a572-90e744248bd4
+      - 5c5f8fe9-64ab-4b42-a223-02e527f4cc81
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4810,10 +4944,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5be11f34-fc39-4760-b461-5f2ba7ae7635
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0610cbd6-f140-4ff1-bb86-4b7eba609571
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"5be11f34-fc39-4760-b461-5f2ba7ae7635","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"0610cbd6-f140-4ff1-bb86-4b7eba609571","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4822,7 +4956,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:13 GMT
+      - Thu, 16 Nov 2023 16:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4832,7 +4966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25d89a00-471f-4954-93c5-bd9b36e8de18
+      - bd91d8ab-5d5d-4acd-93c3-118d2af3f507
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:35 GMT
+      - Thu, 16 Nov 2023 15:52:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72f0c057-690f-4125-b16e-ee89cb5bee18
+      - 81346fab-6710-42e8-a550-cd678b5b3548
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:02 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72f37f5d-bfa9-4d1c-a626-3167c236f796
+      - fd344be3-fed1-483c-9f0e-27925a801996
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:02 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38dfb1fa-89a9-4ec9-9756-c5bf71a21e34
+      - d09398df-f25e-4435-a766-a14fb0ccff98
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:32 GMT
+      - Thu, 16 Nov 2023 15:52:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 490c9f98-ecb4-40a7-a505-fc96a872b1c2
+      - 53d4fc76-629e-4641-9470-b70e641329f9
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:02 GMT
+      - Thu, 16 Nov 2023 15:53:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce422b62-5327-44b3-a307-1d11b7ed084b
+      - 8ea4163f-be78-4dbf-9b14-57bf1c79eeba
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:32 GMT
+      - Thu, 16 Nov 2023 15:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c242036a-3e2a-43cd-889d-9a8f84135cce
+      - 3aa9b87a-aeea-497c-9938-8c6b39df89e8
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:02 GMT
+      - Thu, 16 Nov 2023 15:54:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08643e86-152d-4308-ad67-e30077aff338
+      - 79a52ef5-875c-4b77-990f-39ff0244cef3
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:32 GMT
+      - Thu, 16 Nov 2023 15:54:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cac49795-15ac-493a-80be-9aaa3aff8354
+      - 2dde4b1d-d4c2-4e96-a9d6-2f4260d3205d
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286},"endpoints":[{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286}],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1234"
+      - "790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:03 GMT
+      - Thu, 16 Nov 2023 15:55:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cad62a7-10ad-420d-a225-ec4847721fdc
+      - ebe9fdce-5c3b-41a4-947c-8e1579544e03
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmhOU1RDc0JCeURnb3IyZmZNT0dsYXRlRE5Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU5UUXhXaGNOTXpNeE1ETXdNVGcxTlRReFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU56K2Y0dGdFWG1tSEk1dkE3VDVZVjhHeUlMenMreWxtNzBWbnlUdll4ZUovSDhLL0ZwUXZMVmYKMFhjSEVVUHhPdDJNQXgza2dFM2RGVHFvMjUyZkswcFY5MWNFKzdnM2lYd3Nya1JzZGFNVktscHByYVhtYjRpNgpQZ1NDZ0xUcmIwMFNiVFYzMDhaNmZNY0Q1K1g2Tm1OalRBWXNhbUlSdWRzcGxwSGVHM3g5THNRZ3JMTDJNTWhMCm9wUjRnQno5Q3hyVXZZbWFnaHpUYm43NHQrZkdsLzRPUnZleWFoWUo2cSt0UEFIWHVLYnM1RDRneXAwVmF6OUoKSThXaW5MTjlkamJiYURkNXhZMllUZXA4VC9yMVZmVk9nYy8xM0pMOGpUQldFQlVYUmhKODY5QkxpQ09oOVZiZApva00zNE5ES0t6S3VkUm5hMmkzTG04NzhlWUtaWFhFQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WXpka01qRTJOamt0T1dNMU1pMDBOelUyTFRsaE4yVXRaak16WkRkak4yWmwKTURFMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1VqRXhTMWJTclNOWHEweThESUg0SDQ2Z2lWcDJyem9Ibm82N2hLUm95aXU5RWxPcGY4emR1CmdDZmFBK2UzbmVkKytPdDcwOExDNmVRelRqcVFqMG5TT1p1MmhUQjFPUSs5NjhFbWVXclJWS3ZGZ3RsYlpJZkoKVmEycXgxQzhHZnc5dURzaFZYWjFwSTk0Qm9kVm9GbVNiNnF5YmxJalp4SFBPSzcwNVBrTitvVHFINzBBeDQxZAo5UzZGK3pUamVZZnpBejVWdXBQbkNwazI5cmMwNUkxMHhFR0RjbFpxMmxEZDlDQzZFRmZjeE5ROEtrcm5peFg5CjFUbEN5alZkWTNPOERpekV2Mk4zUVZQOEE4M1NtMzZES2pHVXBPMTVCWkk1eGtibDJWS2k0Ukd1b1Y4UlhNMmEKSlgwUy8vdk9zdVRxYXNhK0ZJamlBUFBHSVRwOUpwa0MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1065"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:03 GMT
+      - Thu, 16 Nov 2023 15:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,12 +627,78 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3cea81a-fcb6-4fef-bbaa-ae753af6c0a7
+      - 1515c50b-8d44-4531-a01c-92e479cd19f1
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":{"id":"edd76979-1958-4ad9-96b5-c1556245c514","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29615},"endpoints":[{"id":"edd76979-1958-4ad9-96b5-c1556245c514","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29615}],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1284"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:56:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b83cd194-f5f1-4f14-bce5-980dfdc30e58
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVQkNxc0RldnR1dnJMK014QkNJSWxwaDUrQ05jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UVXpOVm9YRFRNek1URXhNekUxTlRVek5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXM2Z2VBNG9xeXZZdWdNY05EVjF0bURWSm53UDJCOUN2S1IzMmRQZ1M4cE5yUkRMTUIvUXcKL2hyVll1WUpvTWFVWTRNMlJSbkRhek1YS0hDWk45TkFjV2pvWmVaTm91Z2RFaE1jbHlhY3U5Zlp0ZEh3QllkOQovQWdZRjVrN1N5QS9rd0F5ZjFlYlI0QUhuM0RvdW1hV29JbFgwa3NyS3VaQ1c4ZXg2VXVwbVFTNVZkVjgzaHZTCjd4OHV6SXJCWEx4QVVnQWtSQnN3djg5NTNjeTlGcEJJTkhINGlHMDV1VHdaNVVUY0hSK1grS1NSVXhGYmp2NEQKVnhYTlVDcURNeTVOUDQvbEtXT05nNUU0bjc2MGpMcURxNlR1Tk5DR3VLbXVucUY0QVVqWmcyQ1kyMGFTeE1HcwpsK2M0OUVsWEMwMHgxaHlZQ3A0UDlqYktONWxYclZtV3F3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE56ZzJabUk1TkRBdFpEQXdPUzAwTTJWbExUZzBOelV0TnpNNE1tVXoKWW1Rd05XTXhMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJJUWVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJZVW1FcVhnU1R1WXA1VFlQYkFxZTFpQjA1YS9LOHU0K0xUWURoVVRiRHBuMGVsT3M4CjdSeFJKNVlTT1Z1bVVIeFBLZ0d3d2JQZU9uMHFwZDhVa1pTUVFVZ0gzV3Q1V015QjhvRU5LdE56dGF1b0dINHoKRmxlUWR0VXdHMG1qYVlNb2J1UDFMaUt3QUtRb1B6RmNwYXUrLzhZaXZhS2pnUXI3cFYxVGYveUh4dS84aWRKUgp6M01XRzZzNW4wNmNCNzVFbElZOXZtbC9CenZVV1luMDQ3MVlzUGlxeE1XdWhwZVZYWTJYakNRWFNycWhVRG9yCklib2FVR3Y2UTkxNVQ0cnE3QnN2N3lRSUNPRm9yOUJmeTFmdzdEeTMwTXdOd09iWkE3eWJZSGhsV0w2aHJQYzcKR24ydUNlR2dVN2dhcTdwbTd0RFRuOUMva3hRMkl4YmUvNEVtCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1849"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:56:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 481936b0-da02-4649-b88c-7a7f3339bd1b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"786fb940-d009-43ee-8475-7382e3bd05c1","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -643,16 +709,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "119"
+      - "123"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:03 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b6db845-8709-4ae6-a5b4-98bd18b0b57f
+      - fa2504ad-5e38-4679-9897-a4840021ab35
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"endpoints":[],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "119"
+      - "123"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:03 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5b127ec-c53d-4128-8e51-f93bba9f1fe1
+      - 2511f525-5958-4e0f-9c80-7f04fd12f7dd
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"endpoints":[],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "119"
+      - "123"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:33 GMT
+      - Thu, 16 Nov 2023 15:56:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1bda7af-5c33-4a6b-951a-0234a25d15bf
+      - 00e5a44c-c6df-46ef-824f-6152ad961333
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "228"
+      - "123"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:04 GMT
+      - Thu, 16 Nov 2023 15:57:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6f0c81b-dc24-4e25-9c11-052171a8dcc1
+      - 9488415a-2fa0-4d0a-a436-35a92ae15891
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"2fb59fb8-c5e2-4e2c-bda3-1783cc5825e8","ip":"51.158.68.150","name":null,"port":5432}],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "228"
+      - "236"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:34 GMT
+      - Thu, 16 Nov 2023 15:57:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b0348db-625b-4d2b-b7aa-95cf17679308
+      - 7879b13c-ea83-4cec-83be-223bc7318da6
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"2fb59fb8-c5e2-4e2c-bda3-1783cc5825e8","ip":"51.158.68.150","name":null,"port":5432}],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "228"
+      - "236"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:04 GMT
+      - Thu, 16 Nov 2023 15:58:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7201690-ed63-400f-96cc-5b466cae6369
+      - fbe591af-7e63-4a4c-876f-0205cd412c12
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"2fb59fb8-c5e2-4e2c-bda3-1783cc5825e8","ip":"51.158.68.150","name":null,"port":5432}],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "228"
+      - "236"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:34 GMT
+      - Thu, 16 Nov 2023 15:58:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77f395de-1b83-448b-9dcf-0eee413bf827
+      - db5249bd-2882-4677-9978-c66752f15669
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"2fb59fb8-c5e2-4e2c-bda3-1783cc5825e8","ip":"51.158.68.150","name":null,"port":5432}],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "221"
+      - "236"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:04 GMT
+      - Thu, 16 Nov 2023 15:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d476699a-73fc-47af-b869-3b63411f8149
+      - 7b671e91-4aff-4878-ace5-85ef2e3456ae
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"2fb59fb8-c5e2-4e2c-bda3-1783cc5825e8","ip":"51.158.68.150","name":null,"port":5432}],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "221"
+      - "229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:04 GMT
+      - Thu, 16 Nov 2023 15:59:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 748305b1-2293-4cf9-9ec8-ede408c833d8
+      - 4a81a467-2b76-4825-89c0-f1c48c9faa3a
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"2fb59fb8-c5e2-4e2c-bda3-1783cc5825e8","ip":"51.158.68.150","name":null,"port":5432}],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "221"
+      - "229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:04 GMT
+      - Thu, 16 Nov 2023 15:59:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c87c23c-3f52-4bb5-9ef4-f86960b555e7
+      - 6f0f774f-583f-4a12-991e-4a855fd9af1d
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286},"endpoints":[{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286}],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"endpoints":[{"direct_access":{},"id":"2fb59fb8-c5e2-4e2c-bda3-1783cc5825e8","ip":"51.158.68.150","name":null,"port":5432}],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1455"
+      - "229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:05 GMT
+      - Thu, 16 Nov 2023 15:59:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba99985c-1e85-4cd8-8ae7-35b537ae347b
+      - e6b75015-346f-4482-bf92-2966d25739ab
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmhOU1RDc0JCeURnb3IyZmZNT0dsYXRlRE5Fd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1qTXdIaGNOCk1qTXhNVEF5TVRnMU5UUXhXaGNOTXpNeE1ETXdNVGcxTlRReFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl5TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU56K2Y0dGdFWG1tSEk1dkE3VDVZVjhHeUlMenMreWxtNzBWbnlUdll4ZUovSDhLL0ZwUXZMVmYKMFhjSEVVUHhPdDJNQXgza2dFM2RGVHFvMjUyZkswcFY5MWNFKzdnM2lYd3Nya1JzZGFNVktscHByYVhtYjRpNgpQZ1NDZ0xUcmIwMFNiVFYzMDhaNmZNY0Q1K1g2Tm1OalRBWXNhbUlSdWRzcGxwSGVHM3g5THNRZ3JMTDJNTWhMCm9wUjRnQno5Q3hyVXZZbWFnaHpUYm43NHQrZkdsLzRPUnZleWFoWUo2cSt0UEFIWHVLYnM1RDRneXAwVmF6OUoKSThXaW5MTjlkamJiYURkNXhZMllUZXA4VC9yMVZmVk9nYy8xM0pMOGpUQldFQlVYUmhKODY5QkxpQ09oOVZiZApva00zNE5ES0t6S3VkUm5hMmkzTG04NzhlWUtaWFhFQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJeU00SThjbmN0WXpka01qRTJOamt0T1dNMU1pMDBOelUyTFRsaE4yVXRaak16WkRkak4yWmwKTURFMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDlJcGh3UXpueHJmTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ1VqRXhTMWJTclNOWHEweThESUg0SDQ2Z2lWcDJyem9Ibm82N2hLUm95aXU5RWxPcGY4emR1CmdDZmFBK2UzbmVkKytPdDcwOExDNmVRelRqcVFqMG5TT1p1MmhUQjFPUSs5NjhFbWVXclJWS3ZGZ3RsYlpJZkoKVmEycXgxQzhHZnc5dURzaFZYWjFwSTk0Qm9kVm9GbVNiNnF5YmxJalp4SFBPSzcwNVBrTitvVHFINzBBeDQxZAo5UzZGK3pUamVZZnpBejVWdXBQbkNwazI5cmMwNUkxMHhFR0RjbFpxMmxEZDlDQzZFRmZjeE5ROEtrcm5peFg5CjFUbEN5alZkWTNPOERpekV2Mk4zUVZQOEE4M1NtMzZES2pHVXBPMTVCWkk1eGtibDJWS2k0Ukd1b1Y4UlhNMmEKSlgwUy8vdk9zdVRxYXNhK0ZJamlBUFBHSVRwOUpwa0MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":{"id":"edd76979-1958-4ad9-96b5-c1556245c514","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29615},"endpoints":[{"id":"edd76979-1958-4ad9-96b5-c1556245c514","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29615}],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"2fb59fb8-c5e2-4e2c-bda3-1783cc5825e8","ip":"51.158.68.150","name":null,"port":5432}],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1513"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:05 GMT
+      - Thu, 16 Nov 2023 15:59:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2817e8f-f4d9-4195-81aa-9bbbbe8ded84
+      - da29ed3a-5f53-4499-bf49-578bab3a1306
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1/certificate
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVQkNxc0RldnR1dnJMK014QkNJSWxwaDUrQ05jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMU5UVXpOVm9YRFRNek1URXhNekUxTlRVek5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXM2Z2VBNG9xeXZZdWdNY05EVjF0bURWSm53UDJCOUN2S1IzMmRQZ1M4cE5yUkRMTUIvUXcKL2hyVll1WUpvTWFVWTRNMlJSbkRhek1YS0hDWk45TkFjV2pvWmVaTm91Z2RFaE1jbHlhY3U5Zlp0ZEh3QllkOQovQWdZRjVrN1N5QS9rd0F5ZjFlYlI0QUhuM0RvdW1hV29JbFgwa3NyS3VaQ1c4ZXg2VXVwbVFTNVZkVjgzaHZTCjd4OHV6SXJCWEx4QVVnQWtSQnN3djg5NTNjeTlGcEJJTkhINGlHMDV1VHdaNVVUY0hSK1grS1NSVXhGYmp2NEQKVnhYTlVDcURNeTVOUDQvbEtXT05nNUU0bjc2MGpMcURxNlR1Tk5DR3VLbXVucUY0QVVqWmcyQ1kyMGFTeE1HcwpsK2M0OUVsWEMwMHgxaHlZQ3A0UDlqYktONWxYclZtV3F3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE56ZzJabUk1TkRBdFpEQXdPUzAwTTJWbExUZzBOelV0TnpNNE1tVXoKWW1Rd05XTXhMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdTanJJUWVod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJZVW1FcVhnU1R1WXA1VFlQYkFxZTFpQjA1YS9LOHU0K0xUWURoVVRiRHBuMGVsT3M4CjdSeFJKNVlTT1Z1bVVIeFBLZ0d3d2JQZU9uMHFwZDhVa1pTUVFVZ0gzV3Q1V015QjhvRU5LdE56dGF1b0dINHoKRmxlUWR0VXdHMG1qYVlNb2J1UDFMaUt3QUtRb1B6RmNwYXUrLzhZaXZhS2pnUXI3cFYxVGYveUh4dS84aWRKUgp6M01XRzZzNW4wNmNCNzVFbElZOXZtbC9CenZVV1luMDQ3MVlzUGlxeE1XdWhwZVZYWTJYakNRWFNycWhVRG9yCklib2FVR3Y2UTkxNVQ0cnE3QnN2N3lRSUNPRm9yOUJmeTFmdzdEeTMwTXdOd09iWkE3eWJZSGhsV0w2aHJQYzcKR24ydUNlR2dVN2dhcTdwbTd0RFRuOUMva3hRMkl4YmUvNEVtCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "221"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:05 GMT
+      - Thu, 16 Nov 2023 15:59:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe6e9f83-9197-44ec-97b5-b58019972dec
+      - d38dd88c-9f54-4aaf-a6ea-19f62ed587f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"2fb59fb8-c5e2-4e2c-bda3-1783cc5825e8","ip":"51.158.68.150","name":null,"port":5432}],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "221"
+      - "229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:05 GMT
+      - Thu, 16 Nov 2023 15:59:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 959193e4-0f16-44dd-b297-acbc19c1f0f5
+      - ec6fa9f4-db5f-4efd-9f7d-f3d55e2d7033
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1168,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
+    method: GET
+  response:
+    body: '{"endpoints":[{"direct_access":{},"id":"2fb59fb8-c5e2-4e2c-bda3-1783cc5825e8","ip":"51.158.68.150","name":null,"port":5432}],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "229"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:59:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f60eb991-56d5-45fb-8c34-d3f07f2d5619
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: DELETE
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"2fb59fb8-c5e2-4e2c-bda3-1783cc5825e8","ip":"51.158.68.150","name":null,"port":5432}],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "224"
+      - "232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:06 GMT
+      - Thu, 16 Nov 2023 15:59:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43fcd36c-5524-4bb4-8e05-aa50f36e30aa
+      - 8ebdc93e-a8d5-4bff-9bb5-bc4a35aa839f
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"59c05898-3823-48f7-aac1-6745a5fe7a5c","ip":"51.15.228.102","name":null,"port":5432}],"id":"da662a4d-a49c-42e5-9238-c245a62bf58e","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"2fb59fb8-c5e2-4e2c-bda3-1783cc5825e8","ip":"51.158.68.150","name":null,"port":5432}],"id":"b4a8308c-2804-41c7-85d4-7c9032586811","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "224"
+      - "232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:06 GMT
+      - Thu, 16 Nov 2023 15:59:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87a3e8a8-1540-4674-b15e-6756efb39b92
+      - b4b1c0f8-f3b0-46e3-b6c5-d4ea73e7384a
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,10 +1267,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"da662a4d-a49c-42e5-9238-c245a62bf58e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"b4a8308c-2804-41c7-85d4-7c9032586811","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1180,7 +1279,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:36 GMT
+      - Thu, 16 Nov 2023 16:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ef3a16d-8e07-4edc-b205-8fc79412aafa
+      - d698428f-119f-4027-86d9-a95269d2cb59
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1201,19 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286},"endpoints":[{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286}],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":{"id":"edd76979-1958-4ad9-96b5-c1556245c514","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29615},"endpoints":[{"id":"edd76979-1958-4ad9-96b5-c1556245c514","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29615}],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1234"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:36 GMT
+      - Thu, 16 Nov 2023 16:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3f13121-038c-4174-8b27-4c043d63534e
+      - 6b77c1de-55cf-4885-b08c-8acb8346ba9c
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,19 +1333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286},"endpoints":[{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286}],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":{"id":"edd76979-1958-4ad9-96b5-c1556245c514","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29615},"endpoints":[{"id":"edd76979-1958-4ad9-96b5-c1556245c514","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29615}],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1237"
+      - "1287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:36 GMT
+      - Thu, 16 Nov 2023 16:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cbc6c75-5829-41fc-8a0c-8c2b5f86ceec
+      - cf1f1dc0-8c13-4593-9c57-b7febe611549
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,19 +1366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:55:01.860764Z","endpoint":{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286},"endpoints":[{"id":"98a23d73-ee9a-458d-b37b-9e9e859cccca","ip":"51.159.26.223","load_balancer":{},"name":null,"port":16286}],"engine":"PostgreSQL-15","id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:10.225078Z","endpoint":{"id":"edd76979-1958-4ad9-96b5-c1556245c514","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29615},"endpoints":[{"id":"edd76979-1958-4ad9-96b5-c1556245c514","ip":"51.159.113.173","load_balancer":{},"name":null,"port":29615}],"engine":"PostgreSQL-15","id":"786fb940-d009-43ee-8475-7382e3bd05c1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1237"
+      - "1287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:36 GMT
+      - Thu, 16 Nov 2023 16:00:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4ab6d64-2208-4e38-9168-745b2394f261
+      - dc2a426e-ba06-4762-af12-6a061d48e454
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,10 +1399,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"786fb940-d009-43ee-8475-7382e3bd05c1","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1312,7 +1411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:06 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81486d28-cfc1-4156-8ba2-0208d078ca0d
+      - 8e9e7bfb-feca-490c-80b4-d1c32d99d0f4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1333,10 +1432,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c7d21669-9c52-4756-9a7e-f33d7c7fe016
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/786fb940-d009-43ee-8475-7382e3bd05c1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"c7d21669-9c52-4756-9a7e-f33d7c7fe016","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"786fb940-d009-43ee-8475-7382e3bd05c1","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1345,7 +1444,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a51f780-63e0-43be-b6c9-14231bad96b6
+      - 67b8580a-c0f9-4ad7-bee9-b1d569ec2a19
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1366,10 +1465,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/da662a4d-a49c-42e5-9238-c245a62bf58e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b4a8308c-2804-41c7-85d4-7c9032586811
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"da662a4d-a49c-42e5-9238-c245a62bf58e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"b4a8308c-2804-41c7-85d4-7c9032586811","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1378,7 +1477,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:02:07 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d48c3f9-8552-40dd-ab61-7552a28b8303
+      - d48c385b-465f-4b59-b619-db6591661843
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-different-zone.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-different-zone.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-different-zone","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-different-zone","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -13,16 +13,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "883"
+      - "915"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:43 GMT
+      - Thu, 16 Nov 2023 16:01:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0ce84d2-e673-4ac7-b994-749ebe8ce612
+      - f8870139-3d0f-4f6c-a041-8355084d5c1f
     status: 200 OK
     code: 200
     duration: ""
@@ -43,19 +43,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "883"
+      - "915"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:43 GMT
+      - Thu, 16 Nov 2023 16:01:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2cabc2f-40c4-449b-9458-5351a08d827f
+      - b85a1463-7872-4677-a0d9-08968c6284eb
     status: 200 OK
     code: 200
     duration: ""
@@ -81,16 +81,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:01:37.387090Z","dhcp_enabled":true,"id":"c8e34af9-9999-4345-a14d-03cb716055fe","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:37.387090Z","id":"84306ff2-d7ae-4d62-9954-2271a5e61003","subnet":"172.16.12.0/22","updated_at":"2023-11-16T16:01:37.387090Z"},{"created_at":"2023-11-16T16:01:37.387090Z","id":"3ac4f652-890f-4758-9a84-14f065566f96","subnet":"fd63:256c:45f7:8ee9::/64","updated_at":"2023-11-16T16:01:37.387090Z"}],"tags":[],"updated_at":"2023-11-16T16:01:37.387090Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:43 GMT
+      - Thu, 16 Nov 2023 16:01:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c697b19-9b95-4ad0-9ac2-e6edbcca6cc5
+      - eca086b5-5731-4e51-8948-97028212b19e
     status: 200 OK
     code: 200
     duration: ""
@@ -111,19 +111,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e34af9-9999-4345-a14d-03cb716055fe
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:01:37.387090Z","dhcp_enabled":true,"id":"c8e34af9-9999-4345-a14d-03cb716055fe","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:37.387090Z","id":"84306ff2-d7ae-4d62-9954-2271a5e61003","subnet":"172.16.12.0/22","updated_at":"2023-11-16T16:01:37.387090Z"},{"created_at":"2023-11-16T16:01:37.387090Z","id":"3ac4f652-890f-4758-9a84-14f065566f96","subnet":"fd63:256c:45f7:8ee9::/64","updated_at":"2023-11-16T16:01:37.387090Z"}],"tags":[],"updated_at":"2023-11-16T16:01:37.387090Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:43 GMT
+      - Thu, 16 Nov 2023 16:01:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,7 +133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce980378-04d5-49af-aa39-5fa35d0045ae
+      - 8feb101c-584f-4ab3-9ed8-64bf4ba85b7d
     status: 200 OK
     code: 200
     duration: ""
@@ -144,19 +144,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "883"
+      - "915"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:13 GMT
+      - Thu, 16 Nov 2023 16:02:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -166,7 +166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d8d26f8-2dd2-4577-a42c-1be5a471836b
+      - cd29993a-ac56-4e26-a071-36c0b6acb2c7
     status: 200 OK
     code: 200
     duration: ""
@@ -177,19 +177,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "883"
+      - "915"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:43 GMT
+      - Thu, 16 Nov 2023 16:02:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -199,7 +199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10a8d302-b4ee-4771-8f24-fe6c8eb9cb88
+      - e869d7e9-e1af-4708-914e-53ab735f0e7d
     status: 200 OK
     code: 200
     duration: ""
@@ -210,19 +210,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "883"
+      - "915"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:13 GMT
+      - Thu, 16 Nov 2023 16:03:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -232,7 +232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8a032b2-8790-4cf4-8be0-4a33101793f2
+      - 343473fc-4697-4d40-a85b-9e5f5162cab6
     status: 200 OK
     code: 200
     duration: ""
@@ -243,19 +243,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "883"
+      - "915"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:43 GMT
+      - Thu, 16 Nov 2023 16:03:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -265,7 +265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36412343-5779-4dcd-8bfa-47e8a3223fa0
+      - 431e1cdc-7260-43c3-9101-5ee6399517d7
     status: 200 OK
     code: 200
     duration: ""
@@ -276,19 +276,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "883"
+      - "1190"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:14 GMT
+      - Thu, 16 Nov 2023 16:04:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -298,7 +298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d0ba1d6-d56f-4090-9bc9-4c0ff621550f
+      - adeb4cbd-c4f3-480d-89e4-42a2b2048ebf
     status: 200 OK
     code: 200
     duration: ""
@@ -309,19 +309,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587},"endpoints":[{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587}],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1356"
+      - "1405"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:44 GMT
+      - Thu, 16 Nov 2023 16:04:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -331,7 +331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92d7b757-c54c-4fe3-8aa0-67f4310296d8
+      - e01e79e1-28d7-414b-98a9-95c0cf92b5e2
     status: 200 OK
     code: 200
     duration: ""
@@ -342,19 +342,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYkVjM0IxcU92MHc4QUY0d096SXpSZGpvdUZrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qSTBXaGNOTXpNeE1ETXdNVGcxTWpJMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU90bm00TDV2ajBqWDJJblNTQXhncTBOU05TaHdtelF4QWIyeHg4elo1K3hLbERubGFCK2xwOXYKUG1MZnkzRmZJM1hqLyt5SlFjTnh3M0RVOWQ2a2pnbFNRWFQvUVpGNkFiWUxsMkF4OU9MR1RXaUFFQW5TSEU3LwowTnF6RGJ3M3JnYVpMbFFmYmFQdnZBNzRmTFJFNUZOalRBMlh5UGM0RXJra05KWjNOQnl3OEt3WThiWVVMVkswCmZ2WUZhbEZCSEdrM1pNTkZ1YXQ4VjVoYmlrTmZvYjlGT3ExbTZvL1NFUEpqazlIYXprTGJobHd0MUJ5Slp5VUIKc0psdWliOXp0YlNBMUY1Q3VIaC9WbC9nN3RRL1dPMHBrV2tmbWN3WnMrcXBjaVg2TC9iaVp2TDlkT2UwVXVHNwptcmlNaVQ4MmVlYmUyMmZVUnBXdmh1enVXMGk4WmtjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TVdGaVlqUTBaREF0T1dNMU55MDBNall4TFRsa09UWXROREE0WVRRek9USTQKWTJVMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm1PSmh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRRFpFaVNHakZwMVl2NjIwL1MrZzF0MUs2d2JJVS8rUzVLUklkVmJMdWlaSkRqaXVyb3dMQXhQCm0yaUdqdWJOSkJsTWIzYmlaOCsrUG5pemErclBHckN6d1pXVFdXd0ZkWng0U24zUzc5Tm5WRytlTkcxQitIa2kKTnRpc2lERCtrSWR1RUFmcGNFRVE5U3B2SGZ4eXRHYWhua3VLSyt6bmIxOWM2cTd0UUJ5SHA2WmVPcVErOEIwcApHbnlleWdzeW5sTS8xQnRzZlYzS3lja3I2V0lsRDBRemRoSUFOVWNtN1FBdzF1VEJ6a0RrdElqOHBKMndNejNEClVBME5ONDBCN2Jlb2c5N3pZRHpGWmFqQWRKNWJHT3hLaVo5V3hoUXd2KzRwNVdvMENIUXp5OVRRSTV2elpQM1MKbkNlSFM1bWN3azZDMkdKemJ5QnkxcVk1TTJ2cjlSdnQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSU4zbXowaTgrVGx1cUNpTFA3YUZMQldmZWo0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRZd016VTNXaGNOTXpNeE1URXpNVFl3TXpVM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUlXU3l3bUQrL3l6QlYvNGxlb0F4MzNlOFp3S2phZUl0bFpjVENVQmpYb3hzZkxMYThIcnc4RXgKYVNXMUt2R1hPa2gyMFlxR3dTT0FXOVBXcUd5cGZCYmQ3b1JQZzJNME1TL3BDREJSNFNVSG1PSHN6dE4yQlVDZAp1Q3NsQWM3YkIxMzltVFJGb0hKRm5KSzJhdzRxa2NiSFh4RUllcGJrNGpHYmZ6T3V6TnMrV2IvTzgrbmFoSDd5CmVGSFZZZFZqL0V6UE8vZkg0T3JHQ2YydlhGRkExUGpnWVJKTG95UzRrUHhsNmNQcC90STNJOFI3Nk9zbHJrKzAKcTRHR0NjMHlKMENOalVGN01BRk1GSDlxMXdvYW54QlJ6QVQwUjdHS2F3b0o3T2lkNVRhd2dHRlVCamw0SlR2NwpjLzdIaFhicCt6TXVHUmZBMWhkcFprSUhWdDRaNlo4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0WkdWaVlUWXhNR1V0WVRZNU55MDBORGszTFdJMU4yVXRaRGczTURJM05tRmkKWkRBMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtyK2h3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQm44K1c0T1lza1FCbUQ5U2ZTSVlLN1NzL1ZWdkxXajJsTjlpYXlmRElrSGFweU5wK25IeldqCjBaSHh1bitSUVA0bkJHVEdHKzZrNjBGQ2ZGT1hoYk5xb1BVYXVsMGJxK01QcHl1b0lROXNnRUNLd0ZJWXdIcEQKQ1lraTFsRkd3WXJTaWlINHY1VFFOOW5jQUhJQWRXa0RpQTNEdXZDOTZqUTZmVFQrZTMvTFcrZktLMEVLcHdFeAo5WWEzbzRJQVNESHlxZy92ZTlOMys4U1o3SUlRVGRaZzlraDFJYVZrL2lGK0RyR0lXc0NUam5yNEltRUpNK2ZsCnlUSW5ob0V0Q1BFSmErRGcxUGFKKzhUNER5TVVQVjNNRXlFRGd0dEVGam82cll1MGtyOGVFMzZHZ3BBalEwNXAKeHRuQnRRaDlPRzhkTkYwR1ZsNjdPcm5vZkJIRWtJWTcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:44 GMT
+      - Thu, 16 Nov 2023 16:04:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -364,12 +364,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6bac3bc-bcfc-4dbf-b326-705a84c1db17
+      - 47727b98-5242-46f0-944c-480f7a58c296
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"1abb44d0-9c57-4261-9d96-408a43928ce6","endpoint_spec":[{"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","ipam_config":{}}}],"same_zone":false}'
+    body: '{"instance_id":"deba610e-a697-4497-b57e-d870276abd06","endpoint_spec":[{"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","ipam_config":{}}}],"same_zone":false}'
     form: {}
     headers:
       Content-Type:
@@ -380,16 +380,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "336"
+      - "346"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:45 GMT
+      - Thu, 16 Nov 2023 16:04:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -399,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d7cb98b-d759-4e81-a802-c422e906ce9b
+      - 2e3473c9-f559-4aaf-813b-345e92a58afd
     status: 200 OK
     code: 200
     duration: ""
@@ -410,19 +410,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "336"
+      - "346"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:45 GMT
+      - Thu, 16 Nov 2023 16:04:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -432,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd5a5fbf-e6bc-4ea1-bb02-2f275da57f7a
+      - cb9d5e2f-6232-4aa3-9272-d50a6ba72b77
     status: 200 OK
     code: 200
     duration: ""
@@ -443,19 +443,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "336"
+      - "346"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:16 GMT
+      - Thu, 16 Nov 2023 16:05:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -465,7 +465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c80566bd-a61e-45a5-b69f-310f7b14a2b1
+      - 8f8d9f4e-a32d-4396-9197-31a4ef97c0e9
     status: 200 OK
     code: 200
     duration: ""
@@ -476,19 +476,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "336"
+      - "346"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:46 GMT
+      - Thu, 16 Nov 2023 16:05:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -498,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 586c26b2-fa7f-442c-9db9-1d7ef72def5d
+      - 01881981-c42f-428c-88ea-691e97a51c58
     status: 200 OK
     code: 200
     duration: ""
@@ -509,19 +509,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"initializing"}'
     headers:
       Content-Length:
-      - "336"
+      - "346"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:16 GMT
+      - Thu, 16 Nov 2023 16:06:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -531,7 +531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4b58c35-7d93-4901-9c4d-1ec0337f453c
+      - 79c3c749-d060-4c28-aa7c-b1e1aaae51e5
     status: 200 OK
     code: 200
     duration: ""
@@ -542,19 +542,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"initializing"}'
     headers:
       Content-Length:
-      - "336"
+      - "346"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:48 GMT
+      - Thu, 16 Nov 2023 16:06:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -564,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 996e7c05-db3d-4fd5-bb26-fb2a47f2c22f
+      - b00cbf2e-6507-4ea6-8860-d949e4c4d6cc
     status: 200 OK
     code: 200
     duration: ""
@@ -575,19 +575,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "329"
+      - "339"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:18 GMT
+      - Thu, 16 Nov 2023 16:07:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fada8ab-d32f-4a01-8253-978149bce501
+      - 7c4a21d9-2aa0-4d60-afc8-86f243078b29
     status: 200 OK
     code: 200
     duration: ""
@@ -608,19 +608,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "329"
+      - "339"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:18 GMT
+      - Thu, 16 Nov 2023 16:07:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 321593da-59e8-4b27-b42e-54986ac5ac24
+      - 24ff0160-8c33-4764-8a5e-56575d4a6aad
     status: 200 OK
     code: 200
     duration: ""
@@ -641,19 +641,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "329"
+      - "339"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:18 GMT
+      - Thu, 16 Nov 2023 16:07:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30b8c836-f5fe-4be3-91c1-13d205ea9757
+      - f55d19ad-bd20-4603-b678-c4262a263304
     status: 200 OK
     code: 200
     duration: ""
@@ -674,19 +674,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e34af9-9999-4345-a14d-03cb716055fe
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:01:37.387090Z","dhcp_enabled":true,"id":"c8e34af9-9999-4345-a14d-03cb716055fe","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:37.387090Z","id":"84306ff2-d7ae-4d62-9954-2271a5e61003","subnet":"172.16.12.0/22","updated_at":"2023-11-16T16:01:37.387090Z"},{"created_at":"2023-11-16T16:01:37.387090Z","id":"3ac4f652-890f-4758-9a84-14f065566f96","subnet":"fd63:256c:45f7:8ee9::/64","updated_at":"2023-11-16T16:01:37.387090Z"}],"tags":[],"updated_at":"2023-11-16T16:01:37.387090Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:18 GMT
+      - Thu, 16 Nov 2023 16:07:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -696,7 +696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e49988d4-1cd5-40a5-b8d4-b206188d1b18
+      - a2aab9f2-54ba-4a0b-91b8-af60f93c33a2
     status: 200 OK
     code: 200
     duration: ""
@@ -707,19 +707,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e34af9-9999-4345-a14d-03cb716055fe
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:01:37.387090Z","dhcp_enabled":true,"id":"c8e34af9-9999-4345-a14d-03cb716055fe","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:37.387090Z","id":"84306ff2-d7ae-4d62-9954-2271a5e61003","subnet":"172.16.12.0/22","updated_at":"2023-11-16T16:01:37.387090Z"},{"created_at":"2023-11-16T16:01:37.387090Z","id":"3ac4f652-890f-4758-9a84-14f065566f96","subnet":"fd63:256c:45f7:8ee9::/64","updated_at":"2023-11-16T16:01:37.387090Z"}],"tags":[],"updated_at":"2023-11-16T16:01:37.387090Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:18 GMT
+      - Thu, 16 Nov 2023 16:07:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,7 +729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d08eb25-fc37-4f13-afc5-9bed138128e7
+      - 05419e6c-5a2f-43c6-ad21-c3a894609301
     status: 200 OK
     code: 200
     duration: ""
@@ -740,19 +740,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587},"endpoints":[{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587}],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1685"
+      - "1744"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:19 GMT
+      - Thu, 16 Nov 2023 16:07:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -762,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8438957-6036-4dc6-a0f1-6099533a612e
+      - 17f484e2-e329-46ee-88ed-62b88115f657
     status: 200 OK
     code: 200
     duration: ""
@@ -773,19 +773,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYkVjM0IxcU92MHc4QUY0d096SXpSZGpvdUZrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qSTBXaGNOTXpNeE1ETXdNVGcxTWpJMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU90bm00TDV2ajBqWDJJblNTQXhncTBOU05TaHdtelF4QWIyeHg4elo1K3hLbERubGFCK2xwOXYKUG1MZnkzRmZJM1hqLyt5SlFjTnh3M0RVOWQ2a2pnbFNRWFQvUVpGNkFiWUxsMkF4OU9MR1RXaUFFQW5TSEU3LwowTnF6RGJ3M3JnYVpMbFFmYmFQdnZBNzRmTFJFNUZOalRBMlh5UGM0RXJra05KWjNOQnl3OEt3WThiWVVMVkswCmZ2WUZhbEZCSEdrM1pNTkZ1YXQ4VjVoYmlrTmZvYjlGT3ExbTZvL1NFUEpqazlIYXprTGJobHd0MUJ5Slp5VUIKc0psdWliOXp0YlNBMUY1Q3VIaC9WbC9nN3RRL1dPMHBrV2tmbWN3WnMrcXBjaVg2TC9iaVp2TDlkT2UwVXVHNwptcmlNaVQ4MmVlYmUyMmZVUnBXdmh1enVXMGk4WmtjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TVdGaVlqUTBaREF0T1dNMU55MDBNall4TFRsa09UWXROREE0WVRRek9USTQKWTJVMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm1PSmh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRRFpFaVNHakZwMVl2NjIwL1MrZzF0MUs2d2JJVS8rUzVLUklkVmJMdWlaSkRqaXVyb3dMQXhQCm0yaUdqdWJOSkJsTWIzYmlaOCsrUG5pemErclBHckN6d1pXVFdXd0ZkWng0U24zUzc5Tm5WRytlTkcxQitIa2kKTnRpc2lERCtrSWR1RUFmcGNFRVE5U3B2SGZ4eXRHYWhua3VLSyt6bmIxOWM2cTd0UUJ5SHA2WmVPcVErOEIwcApHbnlleWdzeW5sTS8xQnRzZlYzS3lja3I2V0lsRDBRemRoSUFOVWNtN1FBdzF1VEJ6a0RrdElqOHBKMndNejNEClVBME5ONDBCN2Jlb2c5N3pZRHpGWmFqQWRKNWJHT3hLaVo5V3hoUXd2KzRwNVdvMENIUXp5OVRRSTV2elpQM1MKbkNlSFM1bWN3azZDMkdKemJ5QnkxcVk1TTJ2cjlSdnQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSU4zbXowaTgrVGx1cUNpTFA3YUZMQldmZWo0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRZd016VTNXaGNOTXpNeE1URXpNVFl3TXpVM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUlXU3l3bUQrL3l6QlYvNGxlb0F4MzNlOFp3S2phZUl0bFpjVENVQmpYb3hzZkxMYThIcnc4RXgKYVNXMUt2R1hPa2gyMFlxR3dTT0FXOVBXcUd5cGZCYmQ3b1JQZzJNME1TL3BDREJSNFNVSG1PSHN6dE4yQlVDZAp1Q3NsQWM3YkIxMzltVFJGb0hKRm5KSzJhdzRxa2NiSFh4RUllcGJrNGpHYmZ6T3V6TnMrV2IvTzgrbmFoSDd5CmVGSFZZZFZqL0V6UE8vZkg0T3JHQ2YydlhGRkExUGpnWVJKTG95UzRrUHhsNmNQcC90STNJOFI3Nk9zbHJrKzAKcTRHR0NjMHlKMENOalVGN01BRk1GSDlxMXdvYW54QlJ6QVQwUjdHS2F3b0o3T2lkNVRhd2dHRlVCamw0SlR2NwpjLzdIaFhicCt6TXVHUmZBMWhkcFprSUhWdDRaNlo4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0WkdWaVlUWXhNR1V0WVRZNU55MDBORGszTFdJMU4yVXRaRGczTURJM05tRmkKWkRBMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtyK2h3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQm44K1c0T1lza1FCbUQ5U2ZTSVlLN1NzL1ZWdkxXajJsTjlpYXlmRElrSGFweU5wK25IeldqCjBaSHh1bitSUVA0bkJHVEdHKzZrNjBGQ2ZGT1hoYk5xb1BVYXVsMGJxK01QcHl1b0lROXNnRUNLd0ZJWXdIcEQKQ1lraTFsRkd3WXJTaWlINHY1VFFOOW5jQUhJQWRXa0RpQTNEdXZDOTZqUTZmVFQrZTMvTFcrZktLMEVLcHdFeAo5WWEzbzRJQVNESHlxZy92ZTlOMys4U1o3SUlRVGRaZzlraDFJYVZrL2lGK0RyR0lXc0NUam5yNEltRUpNK2ZsCnlUSW5ob0V0Q1BFSmErRGcxUGFKKzhUNER5TVVQVjNNRXlFRGd0dEVGam82cll1MGtyOGVFMzZHZ3BBalEwNXAKeHRuQnRRaDlPRzhkTkYwR1ZsNjdPcm5vZkJIRWtJWTcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:19 GMT
+      - Thu, 16 Nov 2023 16:07:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -795,7 +795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5e8c015-88e8-46c1-b0b7-ae28cc9924a4
+      - 16899e26-2a29-4df1-ad0d-98b9fd7b5f8a
     status: 200 OK
     code: 200
     duration: ""
@@ -806,19 +806,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "329"
+      - "339"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:19 GMT
+      - Thu, 16 Nov 2023 16:07:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -828,7 +828,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23de90ef-6008-4744-a5c8-1c7a5d4a9a59
+      - e46c9424-3ae7-4043-9d6c-4e6a7b0e8d96
     status: 200 OK
     code: 200
     duration: ""
@@ -839,19 +839,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e34af9-9999-4345-a14d-03cb716055fe
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:01:37.387090Z","dhcp_enabled":true,"id":"c8e34af9-9999-4345-a14d-03cb716055fe","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:37.387090Z","id":"84306ff2-d7ae-4d62-9954-2271a5e61003","subnet":"172.16.12.0/22","updated_at":"2023-11-16T16:01:37.387090Z"},{"created_at":"2023-11-16T16:01:37.387090Z","id":"3ac4f652-890f-4758-9a84-14f065566f96","subnet":"fd63:256c:45f7:8ee9::/64","updated_at":"2023-11-16T16:01:37.387090Z"}],"tags":[],"updated_at":"2023-11-16T16:01:37.387090Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:19 GMT
+      - Thu, 16 Nov 2023 16:07:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -861,7 +861,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbcb5166-6b19-4437-9abc-8fab2a7990d8
+      - 76175f56-94f6-4d64-89a4-1dc48391d3d8
     status: 200 OK
     code: 200
     duration: ""
@@ -872,19 +872,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587},"endpoints":[{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587}],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1685"
+      - "1744"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:19 GMT
+      - Thu, 16 Nov 2023 16:07:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -894,7 +894,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb52e466-a315-4a5e-8d1d-27025f91738e
+      - e8cdfb04-ea8c-4180-aad4-b8524cf89451
     status: 200 OK
     code: 200
     duration: ""
@@ -905,19 +905,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYkVjM0IxcU92MHc4QUY0d096SXpSZGpvdUZrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qSTBXaGNOTXpNeE1ETXdNVGcxTWpJMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU90bm00TDV2ajBqWDJJblNTQXhncTBOU05TaHdtelF4QWIyeHg4elo1K3hLbERubGFCK2xwOXYKUG1MZnkzRmZJM1hqLyt5SlFjTnh3M0RVOWQ2a2pnbFNRWFQvUVpGNkFiWUxsMkF4OU9MR1RXaUFFQW5TSEU3LwowTnF6RGJ3M3JnYVpMbFFmYmFQdnZBNzRmTFJFNUZOalRBMlh5UGM0RXJra05KWjNOQnl3OEt3WThiWVVMVkswCmZ2WUZhbEZCSEdrM1pNTkZ1YXQ4VjVoYmlrTmZvYjlGT3ExbTZvL1NFUEpqazlIYXprTGJobHd0MUJ5Slp5VUIKc0psdWliOXp0YlNBMUY1Q3VIaC9WbC9nN3RRL1dPMHBrV2tmbWN3WnMrcXBjaVg2TC9iaVp2TDlkT2UwVXVHNwptcmlNaVQ4MmVlYmUyMmZVUnBXdmh1enVXMGk4WmtjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TVdGaVlqUTBaREF0T1dNMU55MDBNall4TFRsa09UWXROREE0WVRRek9USTQKWTJVMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm1PSmh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRRFpFaVNHakZwMVl2NjIwL1MrZzF0MUs2d2JJVS8rUzVLUklkVmJMdWlaSkRqaXVyb3dMQXhQCm0yaUdqdWJOSkJsTWIzYmlaOCsrUG5pemErclBHckN6d1pXVFdXd0ZkWng0U24zUzc5Tm5WRytlTkcxQitIa2kKTnRpc2lERCtrSWR1RUFmcGNFRVE5U3B2SGZ4eXRHYWhua3VLSyt6bmIxOWM2cTd0UUJ5SHA2WmVPcVErOEIwcApHbnlleWdzeW5sTS8xQnRzZlYzS3lja3I2V0lsRDBRemRoSUFOVWNtN1FBdzF1VEJ6a0RrdElqOHBKMndNejNEClVBME5ONDBCN2Jlb2c5N3pZRHpGWmFqQWRKNWJHT3hLaVo5V3hoUXd2KzRwNVdvMENIUXp5OVRRSTV2elpQM1MKbkNlSFM1bWN3azZDMkdKemJ5QnkxcVk1TTJ2cjlSdnQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSU4zbXowaTgrVGx1cUNpTFA3YUZMQldmZWo0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRZd016VTNXaGNOTXpNeE1URXpNVFl3TXpVM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUlXU3l3bUQrL3l6QlYvNGxlb0F4MzNlOFp3S2phZUl0bFpjVENVQmpYb3hzZkxMYThIcnc4RXgKYVNXMUt2R1hPa2gyMFlxR3dTT0FXOVBXcUd5cGZCYmQ3b1JQZzJNME1TL3BDREJSNFNVSG1PSHN6dE4yQlVDZAp1Q3NsQWM3YkIxMzltVFJGb0hKRm5KSzJhdzRxa2NiSFh4RUllcGJrNGpHYmZ6T3V6TnMrV2IvTzgrbmFoSDd5CmVGSFZZZFZqL0V6UE8vZkg0T3JHQ2YydlhGRkExUGpnWVJKTG95UzRrUHhsNmNQcC90STNJOFI3Nk9zbHJrKzAKcTRHR0NjMHlKMENOalVGN01BRk1GSDlxMXdvYW54QlJ6QVQwUjdHS2F3b0o3T2lkNVRhd2dHRlVCamw0SlR2NwpjLzdIaFhicCt6TXVHUmZBMWhkcFprSUhWdDRaNlo4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0WkdWaVlUWXhNR1V0WVRZNU55MDBORGszTFdJMU4yVXRaRGczTURJM05tRmkKWkRBMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtyK2h3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQm44K1c0T1lza1FCbUQ5U2ZTSVlLN1NzL1ZWdkxXajJsTjlpYXlmRElrSGFweU5wK25IeldqCjBaSHh1bitSUVA0bkJHVEdHKzZrNjBGQ2ZGT1hoYk5xb1BVYXVsMGJxK01QcHl1b0lROXNnRUNLd0ZJWXdIcEQKQ1lraTFsRkd3WXJTaWlINHY1VFFOOW5jQUhJQWRXa0RpQTNEdXZDOTZqUTZmVFQrZTMvTFcrZktLMEVLcHdFeAo5WWEzbzRJQVNESHlxZy92ZTlOMys4U1o3SUlRVGRaZzlraDFJYVZrL2lGK0RyR0lXc0NUam5yNEltRUpNK2ZsCnlUSW5ob0V0Q1BFSmErRGcxUGFKKzhUNER5TVVQVjNNRXlFRGd0dEVGam82cll1MGtyOGVFMzZHZ3BBalEwNXAKeHRuQnRRaDlPRzhkTkYwR1ZsNjdPcm5vZkJIRWtJWTcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:20 GMT
+      - Thu, 16 Nov 2023 16:07:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -927,7 +927,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f5509d6-aecc-4443-8a5e-0b29162a19ba
+      - e08fd037-b8f6-4878-8011-1940edb7cb1a
     status: 200 OK
     code: 200
     duration: ""
@@ -938,19 +938,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "329"
+      - "339"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:20 GMT
+      - Thu, 16 Nov 2023 16:07:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -960,7 +960,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bae55490-85e3-4d9a-a702-41cee5c77c61
+      - e9dc26b1-a909-475f-abc8-ca70a7573743
     status: 200 OK
     code: 200
     duration: ""
@@ -971,19 +971,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "329"
+      - "339"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:20 GMT
+      - Thu, 16 Nov 2023 16:07:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -993,7 +993,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c20545c1-cc88-4b72-9f04-69c4bf2a1d79
+      - 864f7010-9c80-4ff5-b620-e7fcd9d9a52b
     status: 200 OK
     code: 200
     duration: ""
@@ -1004,19 +1004,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"deleting"}'
     headers:
       Content-Length:
-      - "332"
+      - "342"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:21 GMT
+      - Thu, 16 Nov 2023 16:07:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1026,7 +1026,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edaf2256-6a25-45bb-8ed8-44a331868c29
+      - 86d0f2ae-4cb0-40e7-ba0b-3fa40c4ac91b
     status: 200 OK
     code: 200
     duration: ""
@@ -1037,19 +1037,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"endpoints":[{"id":"f61583f2-1516-42bc-ba09-7c93b18f1ab2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"c4321b24-ff18-4265-908e-4de50dcafc55","region":"fr-par","same_zone":false,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"9c3d233a-2fac-454b-b58c-20f124591dce","ip":"172.16.12.2","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.2/22","zone":"fr-par-1"}}],"id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","region":"fr-par","same_zone":false,"status":"deleting"}'
     headers:
       Content-Length:
-      - "332"
+      - "342"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:21 GMT
+      - Thu, 16 Nov 2023 16:07:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1059,7 +1059,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77fd0ada-da37-412b-8dd3-96837a382110
+      - ded724fe-9769-47e7-a361-25f7bea9be9e
     status: 200 OK
     code: 200
     duration: ""
@@ -1070,10 +1070,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c4321b24-ff18-4265-908e-4de50dcafc55
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/67fb0d0a-7543-4c1d-ade0-adf2ff143caf
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"c4321b24-ff18-4265-908e-4de50dcafc55","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"67fb0d0a-7543-4c1d-ade0-adf2ff143caf","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1082,7 +1082,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:52 GMT
+      - Thu, 16 Nov 2023 16:07:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1092,12 +1092,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a43fef0-d3f0-4103-ac61-28f73a70fa19
+      - 446e9d4a-2819-4346-99fe-98d8ae2999c1
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"instance_id":"1abb44d0-9c57-4261-9d96-408a43928ce6","endpoint_spec":[{"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","ipam_config":{}}}],"same_zone":true}'
+    body: '{"instance_id":"deba610e-a697-4497-b57e-d870276abd06","endpoint_spec":[{"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","ipam_config":{}}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -1108,16 +1108,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "335"
+      - "345"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:53 GMT
+      - Thu, 16 Nov 2023 16:07:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1127,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23071623-68b0-48fc-813e-068724ffc2cf
+      - 1df12209-dbd6-46a9-9e1c-c4c3e56af877
     status: 200 OK
     code: 200
     duration: ""
@@ -1138,19 +1138,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "335"
+      - "345"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:53 GMT
+      - Thu, 16 Nov 2023 16:07:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1160,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dec8bea-f744-416a-8f15-74c14f3bb048
+      - 6c6105aa-8486-4749-8ce0-7a808562e3fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1171,19 +1171,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "335"
+      - "345"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:23 GMT
+      - Thu, 16 Nov 2023 16:08:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1193,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37329533-b55f-433e-91b3-b1e0933670ec
+      - fe50d445-8de9-42e5-a5e8-b4655efb4aa0
     status: 200 OK
     code: 200
     duration: ""
@@ -1204,19 +1204,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "335"
+      - "345"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:53 GMT
+      - Thu, 16 Nov 2023 16:08:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1226,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9227799-3bea-4308-a626-2090d3d0e55b
+      - ab4d9aa2-8438-4aab-9bae-746fe2cba576
     status: 200 OK
     code: 200
     duration: ""
@@ -1237,19 +1237,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "335"
+      - "345"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:24 GMT
+      - Thu, 16 Nov 2023 16:09:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1259,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a18ad616-fc8c-4b87-a071-6dd2e0096f4d
+      - 1352d0fc-4366-445f-9511-87f0fa126fba
     status: 200 OK
     code: 200
     duration: ""
@@ -1270,19 +1270,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "335"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:54 GMT
+      - Thu, 16 Nov 2023 16:09:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1292,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37081f71-c41b-4a08-a338-de7bfad24801
+      - 017dd7f7-79dc-48b9-aa59-640a5dc855ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1303,19 +1303,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "328"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:24 GMT
+      - Thu, 16 Nov 2023 16:09:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1325,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccf919d5-4f0a-429f-a2d8-a3ab9fb0ffbd
+      - 385b85b4-0b90-4226-b48f-3a816583c254
     status: 200 OK
     code: 200
     duration: ""
@@ -1336,19 +1336,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "328"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:24 GMT
+      - Thu, 16 Nov 2023 16:09:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1358,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 015c2bba-5954-4d33-b427-04c0e7550870
+      - f2a260de-0761-45d4-b5d2-2b78ff21712a
     status: 200 OK
     code: 200
     duration: ""
@@ -1369,19 +1369,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e34af9-9999-4345-a14d-03cb716055fe
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"created_at":"2023-11-16T16:01:37.387090Z","dhcp_enabled":true,"id":"c8e34af9-9999-4345-a14d-03cb716055fe","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:37.387090Z","id":"84306ff2-d7ae-4d62-9954-2271a5e61003","subnet":"172.16.12.0/22","updated_at":"2023-11-16T16:01:37.387090Z"},{"created_at":"2023-11-16T16:01:37.387090Z","id":"3ac4f652-890f-4758-9a84-14f065566f96","subnet":"fd63:256c:45f7:8ee9::/64","updated_at":"2023-11-16T16:01:37.387090Z"}],"tags":[],"updated_at":"2023-11-16T16:01:37.387090Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "328"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:24 GMT
+      - Thu, 16 Nov 2023 16:09:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1391,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8b02e87-ef98-4f39-af4e-a109946526a9
+      - 06ba541b-383f-4668-9f7b-0c62ec7dba28
     status: 200 OK
     code: 200
     duration: ""
@@ -1402,19 +1402,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e34af9-9999-4345-a14d-03cb716055fe
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:01:37.387090Z","dhcp_enabled":true,"id":"c8e34af9-9999-4345-a14d-03cb716055fe","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:01:37.387090Z","id":"84306ff2-d7ae-4d62-9954-2271a5e61003","subnet":"172.16.12.0/22","updated_at":"2023-11-16T16:01:37.387090Z"},{"created_at":"2023-11-16T16:01:37.387090Z","id":"3ac4f652-890f-4758-9a84-14f065566f96","subnet":"fd63:256c:45f7:8ee9::/64","updated_at":"2023-11-16T16:01:37.387090Z"}],"tags":[],"updated_at":"2023-11-16T16:01:37.387090Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:24 GMT
+      - Thu, 16 Nov 2023 16:09:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1424,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43770051-3500-40da-bd62-90e5c1c920f7
+      - f72f4e18-3bf3-4235-b7f6-1963b8be68ef
     status: 200 OK
     code: 200
     duration: ""
@@ -1435,19 +1435,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:51:42.626490Z","dhcp_enabled":true,"id":"6638dd56-857d-4602-a836-dc564d3eff6d","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:51:42.626490Z","id":"f5ebbf64-601e-4198-ac41-ec60e55600f8","subnet":"172.16.20.0/22","updated_at":"2023-11-02T18:51:42.626490Z"},{"created_at":"2023-11-02T18:51:42.626490Z","id":"5edc57aa-f173-4234-aae4-bbec1c6797d3","subnet":"fd63:256c:45f7:eb34::/64","updated_at":"2023-11-02T18:51:42.626490Z"}],"tags":[],"updated_at":"2023-11-02T18:51:42.626490Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587},"endpoints":[{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587}],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "710"
+      - "1743"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:24 GMT
+      - Thu, 16 Nov 2023 16:09:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1457,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaccdb4d-d31a-4139-a122-08297621e3cf
+      - 51afdaf4-014c-40b9-84a0-e06b67dfa216
     status: 200 OK
     code: 200
     duration: ""
@@ -1468,19 +1468,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSU4zbXowaTgrVGx1cUNpTFA3YUZMQldmZWo0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRZd016VTNXaGNOTXpNeE1URXpNVFl3TXpVM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUlXU3l3bUQrL3l6QlYvNGxlb0F4MzNlOFp3S2phZUl0bFpjVENVQmpYb3hzZkxMYThIcnc4RXgKYVNXMUt2R1hPa2gyMFlxR3dTT0FXOVBXcUd5cGZCYmQ3b1JQZzJNME1TL3BDREJSNFNVSG1PSHN6dE4yQlVDZAp1Q3NsQWM3YkIxMzltVFJGb0hKRm5KSzJhdzRxa2NiSFh4RUllcGJrNGpHYmZ6T3V6TnMrV2IvTzgrbmFoSDd5CmVGSFZZZFZqL0V6UE8vZkg0T3JHQ2YydlhGRkExUGpnWVJKTG95UzRrUHhsNmNQcC90STNJOFI3Nk9zbHJrKzAKcTRHR0NjMHlKMENOalVGN01BRk1GSDlxMXdvYW54QlJ6QVQwUjdHS2F3b0o3T2lkNVRhd2dHRlVCamw0SlR2NwpjLzdIaFhicCt6TXVHUmZBMWhkcFprSUhWdDRaNlo4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0WkdWaVlUWXhNR1V0WVRZNU55MDBORGszTFdJMU4yVXRaRGczTURJM05tRmkKWkRBMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RCtyK2h3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQm44K1c0T1lza1FCbUQ5U2ZTSVlLN1NzL1ZWdkxXajJsTjlpYXlmRElrSGFweU5wK25IeldqCjBaSHh1bitSUVA0bkJHVEdHKzZrNjBGQ2ZGT1hoYk5xb1BVYXVsMGJxK01QcHl1b0lROXNnRUNLd0ZJWXdIcEQKQ1lraTFsRkd3WXJTaWlINHY1VFFOOW5jQUhJQWRXa0RpQTNEdXZDOTZqUTZmVFQrZTMvTFcrZktLMEVLcHdFeAo5WWEzbzRJQVNESHlxZy92ZTlOMys4U1o3SUlRVGRaZzlraDFJYVZrL2lGK0RyR0lXc0NUam5yNEltRUpNK2ZsCnlUSW5ob0V0Q1BFSmErRGcxUGFKKzhUNER5TVVQVjNNRXlFRGd0dEVGam82cll1MGtyOGVFMzZHZ3BBalEwNXAKeHRuQnRRaDlPRzhkTkYwR1ZsNjdPcm5vZkJIRWtJWTcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1684"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:25 GMT
+      - Thu, 16 Nov 2023 16:09:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1490,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05263358-2854-4efb-9472-3ea87347b2e8
+      - 87fc2762-5384-4bb8-9dad-245cfe736760
     status: 200 OK
     code: 200
     duration: ""
@@ -1501,19 +1501,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVYkVjM0IxcU92MHc4QUY0d096SXpSZGpvdUZrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qSTBXaGNOTXpNeE1ETXdNVGcxTWpJMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU90bm00TDV2ajBqWDJJblNTQXhncTBOU05TaHdtelF4QWIyeHg4elo1K3hLbERubGFCK2xwOXYKUG1MZnkzRmZJM1hqLyt5SlFjTnh3M0RVOWQ2a2pnbFNRWFQvUVpGNkFiWUxsMkF4OU9MR1RXaUFFQW5TSEU3LwowTnF6RGJ3M3JnYVpMbFFmYmFQdnZBNzRmTFJFNUZOalRBMlh5UGM0RXJra05KWjNOQnl3OEt3WThiWVVMVkswCmZ2WUZhbEZCSEdrM1pNTkZ1YXQ4VjVoYmlrTmZvYjlGT3ExbTZvL1NFUEpqazlIYXprTGJobHd0MUJ5Slp5VUIKc0psdWliOXp0YlNBMUY1Q3VIaC9WbC9nN3RRL1dPMHBrV2tmbWN3WnMrcXBjaVg2TC9iaVp2TDlkT2UwVXVHNwptcmlNaVQ4MmVlYmUyMmZVUnBXdmh1enVXMGk4WmtjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TVdGaVlqUTBaREF0T1dNMU55MDBNall4TFRsa09UWXROREE0WVRRek9USTQKWTJVMkxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm1PSmh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRRFpFaVNHakZwMVl2NjIwL1MrZzF0MUs2d2JJVS8rUzVLUklkVmJMdWlaSkRqaXVyb3dMQXhQCm0yaUdqdWJOSkJsTWIzYmlaOCsrUG5pemErclBHckN6d1pXVFdXd0ZkWng0U24zUzc5Tm5WRytlTkcxQitIa2kKTnRpc2lERCtrSWR1RUFmcGNFRVE5U3B2SGZ4eXRHYWhua3VLSyt6bmIxOWM2cTd0UUJ5SHA2WmVPcVErOEIwcApHbnlleWdzeW5sTS8xQnRzZlYzS3lja3I2V0lsRDBRemRoSUFOVWNtN1FBdzF1VEJ6a0RrdElqOHBKMndNejNEClVBME5ONDBCN2Jlb2c5N3pZRHpGWmFqQWRKNWJHT3hLaVo5V3hoUXd2KzRwNVdvMENIUXp5OVRRSTV2elpQM1MKbkNlSFM1bWN3azZDMkdKemJ5QnkxcVk1TTJ2cjlSdnQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1843"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:25 GMT
+      - Thu, 16 Nov 2023 16:09:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1523,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7935fbc3-beaa-4916-9109-b6c4b395f0ec
+      - ced52954-9a3f-4467-bed9-e17d9dabdb8b
     status: 200 OK
     code: 200
     duration: ""
@@ -1534,19 +1534,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "328"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:25 GMT
+      - Thu, 16 Nov 2023 16:09:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1556,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77a85123-b396-4691-9995-17618464fd27
+      - db11e2bf-287f-4826-8790-4ae73e1411d2
     status: 200 OK
     code: 200
     duration: ""
@@ -1567,52 +1567,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "328"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 19:00:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d7e388ed-6f15-4060-8ec4-6659fc4a04c8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:26 GMT
+      - Thu, 16 Nov 2023 16:09:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1622,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - caef4537-3367-4942-a8a5-b27c22f10bde
+      - cade1d83-0cf7-4e1a-a643-f74a1cea6c62
     status: 200 OK
     code: 200
     duration: ""
@@ -1633,19 +1600,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b6a58e15-615e-4553-b943-5f3bc6b9e0f2","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"6638dd56-857d-4602-a836-dc564d3eff6d","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"04eb4246-27a9-4be6-a1b1-a78d6c1474d5","ip":"172.16.12.3","name":null,"port":5432,"private_network":{"private_network_id":"c8e34af9-9999-4345-a14d-03cb716055fe","service_ip":"172.16.12.3/22","zone":"fr-par-1"}}],"id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:26 GMT
+      - Thu, 16 Nov 2023 16:09:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1655,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fa9aa72-dcc9-4c1f-845a-c6590a564e43
+      - ee8152a1-b515-4c66-ae22-0671a8518dd2
     status: 200 OK
     code: 200
     duration: ""
@@ -1666,10 +1633,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1678,7 +1645,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:56 GMT
+      - Thu, 16 Nov 2023 16:10:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1688,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2461ca4-71fe-4143-8ec9-679acf29ebd1
+      - 476a98a6-28f2-4dce-9913-eb9ab615f972
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1699,17 +1666,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6638dd56-857d-4602-a836-dc564d3eff6d
-    method: DELETE
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
+    method: GET
   response:
-    body: ""
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587},"endpoints":[{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587}],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
+      Content-Length:
+      - "1405"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:59 GMT
+      - Thu, 16 Nov 2023 16:10:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1719,7 +1688,104 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4f4a9da-c31f-41d6-8696-27a3ad964270
+      - 4ddfe411-ff38-432c-bc8b-8e6244ca7e21
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
+    method: DELETE
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587},"endpoints":[{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587}],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1408"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:10:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 371673c9-4c63-415c-89b0-b6b98052d381
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:01:37.624369Z","endpoint":{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587},"endpoints":[{"id":"2ce88a6a-aa89-4bc0-b0b3-f47fd043fa47","ip":"195.154.197.0","load_balancer":{},"name":null,"port":1587}],"engine":"PostgreSQL-14","id":"deba610e-a697-4497-b57e-d870276abd06","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1408"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:10:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85ef15c8-c548-440c-8338-f30a749d3568
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e34af9-9999-4345-a14d-03cb716055fe
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:10:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a3ff77bc-30db-43c1-bc7c-c40dfe6e9ad7
     status: 204 No Content
     code: 204
     duration: ""
@@ -1730,109 +1796,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1356"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 19:01:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c88247ed-cded-4916-919b-580127cd4fd2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1359"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 19:01:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 57453225-72f5-41b2-9dad-73458d08518b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:51:42.915621Z","endpoint":{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184},"endpoints":[{"id":"88eda783-d17a-4b15-8e4a-5a67545b16d0","ip":"51.159.10.213","load_balancer":{},"name":null,"port":23184}],"engine":"PostgreSQL-14","id":"1abb44d0-9c57-4261-9d96-408a43928ce6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1359"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 19:01:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c0241256-7884-4015-80db-5c7e41335b22
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"1abb44d0-9c57-4261-9d96-408a43928ce6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"deba610e-a697-4497-b57e-d870276abd06","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1841,7 +1808,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:31 GMT
+      - Thu, 16 Nov 2023 16:11:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1851,7 +1818,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9a2d927-dc00-461a-b4a9-e5f4d71c5f20
+      - ecb7e9e3-1e7a-454f-864d-a582f7c464e6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1862,10 +1829,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1abb44d0-9c57-4261-9d96-408a43928ce6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/deba610e-a697-4497-b57e-d870276abd06
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"1abb44d0-9c57-4261-9d96-408a43928ce6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"deba610e-a697-4497-b57e-d870276abd06","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1874,7 +1841,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:31 GMT
+      - Thu, 16 Nov 2023 16:11:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1884,7 +1851,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 696187d2-8ace-42fc-8b0f-786c4b427e7c
+      - 17b6620a-99d1-4634-a915-85c9caf6b2f8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1895,10 +1862,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/8f1e33e1-2826-4d1a-b6ba-383a650f8af3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/37dc713f-daa0-4f2c-a8bb-d1ea942faaed
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"8f1e33e1-2826-4d1a-b6ba-383a650f8af3","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"37dc713f-daa0-4f2c-a8bb-d1ea942faaed","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1907,7 +1874,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:32 GMT
+      - Thu, 16 Nov 2023 16:11:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1917,7 +1884,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6a01ce4-79b7-4cce-94a7-868e98777ec5
+      - b80a6ef0-dbed-4376-99f1-80d5e08d18a0
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-multiple-endpoints.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-multiple-endpoints.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:35 GMT
+      - Thu, 16 Nov 2023 15:52:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,80 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac1e2a28-54be-4f27-988f-ecd56b30e90f
+      - c78b05ee-6f1b-4b14-8d6c-3b7540217467
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-multiple-endpoints","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
-    method: POST
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "774"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f093a8a2-6f02-42b3-8b4e-147fc6da7e17
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "774"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 013f67dd-9e7f-40ee-913e-3853364d7322
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-pn-silly-nobel","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
+    body: '{"name":"tf-pn-focused-bassi","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -412,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-02T18:53:32.999053Z","dhcp_enabled":true,"id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","name":"tf-pn-silly-nobel","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:53:32.999053Z","id":"9258e348-06a6-4cef-b394-bb246b05afc3","subnet":"172.16.12.0/22","updated_at":"2023-11-02T18:53:32.999053Z"},{"created_at":"2023-11-02T18:53:32.999053Z","id":"819c14be-d6ae-4bd2-bd41-e892578291d1","subnet":"fd63:256c:45f7:cd3f::/64","updated_at":"2023-11-02T18:53:32.999053Z"}],"tags":[],"updated_at":"2023-11-02T18:53:32.999053Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T15:52:09.549992Z","dhcp_enabled":true,"id":"b85c357c-015c-4bbd-8ade-c20ae579111d","name":"tf-pn-focused-bassi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T15:52:09.549992Z","id":"169dbcad-7558-4284-aee9-385f689d244d","subnet":"172.16.12.0/22","updated_at":"2023-11-16T15:52:09.549992Z"},{"created_at":"2023-11-16T15:52:09.549992Z","id":"aa38d7ab-1e5b-4d06-8b60-30d028cd21d0","subnet":"fd63:256c:45f7:7217::/64","updated_at":"2023-11-16T15:52:09.549992Z"}],"tags":[],"updated_at":"2023-11-16T15:52:09.549992Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "701"
+      - "720"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0c2d5c7-41bd-46fb-8add-71f438388e17
+      - 3e7f046d-4140-47b5-9573-6b1d6e0c5eb2
     status: 200 OK
     code: 200
     duration: ""
@@ -442,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/89c22642-6cdb-40c2-9b9c-2f582f322f59
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b85c357c-015c-4bbd-8ade-c20ae579111d
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:53:32.999053Z","dhcp_enabled":true,"id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","name":"tf-pn-silly-nobel","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:53:32.999053Z","id":"9258e348-06a6-4cef-b394-bb246b05afc3","subnet":"172.16.12.0/22","updated_at":"2023-11-02T18:53:32.999053Z"},{"created_at":"2023-11-02T18:53:32.999053Z","id":"819c14be-d6ae-4bd2-bd41-e892578291d1","subnet":"fd63:256c:45f7:cd3f::/64","updated_at":"2023-11-02T18:53:32.999053Z"}],"tags":[],"updated_at":"2023-11-02T18:53:32.999053Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T15:52:09.549992Z","dhcp_enabled":true,"id":"b85c357c-015c-4bbd-8ade-c20ae579111d","name":"tf-pn-focused-bassi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T15:52:09.549992Z","id":"169dbcad-7558-4284-aee9-385f689d244d","subnet":"172.16.12.0/22","updated_at":"2023-11-16T15:52:09.549992Z"},{"created_at":"2023-11-16T15:52:09.549992Z","id":"aa38d7ab-1e5b-4d06-8b60-30d028cd21d0","subnet":"fd63:256c:45f7:7217::/64","updated_at":"2023-11-16T15:52:09.549992Z"}],"tags":[],"updated_at":"2023-11-16T15:52:09.549992Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "701"
+      - "720"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:33 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -464,7 +396,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43209572-0ad0-49a7-9588-c97de022e4a9
+      - e83c552c-a824-4334-a658-bc1db206bf69
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-multiple-endpoints","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
+    method: POST
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.917740Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "803"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:52:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7bf79775-5d07-4bba-bb8a-663919e93d99
     status: 200 OK
     code: 200
     duration: ""
@@ -475,19 +442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.917740Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "774"
+      - "803"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:03 GMT
+      - Thu, 16 Nov 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0cc2d16-faa8-4f80-9fc0-b487aa3131d4
+      - 7b45e5a2-9688-45b3-9ad3-ecda1f8ccfea
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.917740Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "774"
+      - "803"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:33 GMT
+      - Thu, 16 Nov 2023 15:52:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b2aad3c-722f-442e-98bd-52afd602e988
+      - ef9f3201-364f-4dac-8548-fe37c0760a46
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.917740Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "774"
+      - "803"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:04 GMT
+      - Thu, 16 Nov 2023 15:53:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec05bea0-59ce-455a-95a2-2aabb0747c27
+      - 5f586c55-33e3-44f3-9e19-ff1974dc6e35
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.917740Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "774"
+      - "803"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:34 GMT
+      - Thu, 16 Nov 2023 15:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a2c6587-2afe-452d-9a97-28574a139764
+      - 780b9ecb-5cd5-482b-bea4-61e7d4b431dc
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.917740Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "774"
+      - "803"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:04 GMT
+      - Thu, 16 Nov 2023 15:54:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d13a0ec8-9841-4cdb-a2ea-ab12d5ca8eb7
+      - d190526b-8a0f-4736-9c8c-11a640cf104a
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450},"endpoints":[{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450}],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.917740Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1078"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:34 GMT
+      - Thu, 16 Nov 2023 15:54:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaed5dc9-aeb1-4378-9d84-3d232d621823
+      - 3c421d1e-ff01-449b-a5ee-c8c107aae5a2
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVS29nZUFRenhWNGdrQ3ZkbThmVzJacUxhVlFnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVME1USmFGdzB6TXpFd016QXhPRFUwTVRKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNzdmNuTWVTTGEzNm11bUxGS1J0L21wOGIzZldJTzNhNFpXdXBPbHFMdDZvaUtTZVZVSEk0UUdJeSsKYTVYWUxwdFM3ekVDYzdEZ1o2bTdvOURpNkhBYi9CVG1Ub1dMSG1JY0V4aG85dENTdFF6UWlxQXBlZ3hudngyQQp5Sldzd0xsZEkzSTJmUCtBajl1NGZvTEQ1dC9RRjY3TFRMeFJUQ3pCN1F4V2pueWxPbXdZMEJHa3BramNSRVRuCjVkMjVLNFlpaWo5S3F4NEtRWVNUYVNuS1lMckg0NGNydEl3TS9PWVNwTS9KeStqa1hmK0tpc00rYSszV1J0MmYKYytxYVBNTC9PR3kya3JtelJFNUg0WUtmWFgybFdDSzZDbGVvR3ljR0tMQjlZZkdnNDZUM21tNk5sZEQ4VEJregptZ2t0ZlhrVkczeFc1bHJacVNzRzRSVlUwMWhYQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPRFV3WkRFMFpXTXRaalV4TVMwME0ySXlMVGt4WTJZdE5USmhNVGxtTURVNU5UVXkKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pyS3RnaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFCS0ZYTWVlQW5BNHBaUUZNZE94Qlg5TkNEK0l5UDRYL296R0hwRHJGS1VQdzgyMFhEcEVPSFkvdGFCCi9vbDhxTGNua0liUjJMemNKVDZ6S2JQcFZBWTdwM21yMzNKaDhycFdwdHVSaEdqMUVWOW8vOVM5YVFpcEFqR3UKVVBaR3YwWTZobXFPdHBTZEt2U2lCelFCYWNXWnk2aEgyMUczYTQvYUtjZWtPR0FzeW5DUE9yZ1VXMzY1L2pIWQpUbm1GYjBkWVltWG45ajEybFVWUVA2TC83clE2d0hUWWlTVHZDQ0lxWnFUNjF0cFk0QzZRSS9ka016NzMvRW9yCndSZy9Ldmc2UjBLMDdVMzR2RlhUUXZQOWxrUTNYeERwbFhCdVFTS3M2WEJaYk5NczFWWVMwWThRWkowQ3l0emkKOEppUkh3U1IxdXh5TmFuTXhTaHlEaEZVYXljQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.917740Z","endpoint":{"id":"ef94f1c3-1e1f-4662-bb86-811d8da4dd45","ip":"195.154.197.0","load_balancer":{},"name":null,"port":17097},"endpoints":[{"id":"ef94f1c3-1e1f-4662-bb86-811d8da4dd45","ip":"195.154.197.0","load_balancer":{},"name":null,"port":17097}],"engine":"PostgreSQL-15","id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1839"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:34 GMT
+      - Thu, 16 Nov 2023 15:55:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,12 +662,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82e07f5f-96fc-4dc1-bbb5-dda37ca84222
+      - c306cd27-d77d-4b52-b6ca-bbcceae7b2ba
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"850d14ec-f511-43b2-91cf-52a19f059552","endpoint_spec":[{"direct_access":{}},{"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmxJYU1BZnlsdGZDQktSUkZieithVTJ5c0V3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRVMU5EUXlXaGNOTXpNeE1URXpNVFUxTkRReVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxNblAvQzladGlHUGJqellsd0dVUWhvdnd2THBWdHc5d2xRSHplQ2NKRE9FVXRxcy9md1BhaCsKRGJYcHJldFNwa2I2OCtLdTN2Z0xZYWNGRWgyMnlrNERqMkpBeGZBUjN4ekpLV3ExRzc3OUNYZTljYk9BR2hYdApON0twV1dISFQ4b2R3bXRnemJTanpRQlRPTHE3Wjg1cDZXR3ZJV0gxRXUvTlA5TGJ0aXgrUzQ2dlJGOXZhVVRaCjYzQm93YTJoQXJQQmZCa3RVQ3k4MU9YeXZ3a2w5ei9hUHZIbzQ5U3ptVHlIUkhaenNCcXdyS3BONEZacGw4bUkKMHZkYWVaeGM5anZkRUtvSXJPQk1oNXRtdnlsYjBySXRaVldEWnpaY09jN0d2VUpkWEc4dTFDcVkyWmljUE1wTApab2ZhRDl5SmY2RFhRU0NFSUZFc1B2cVBKVklvZnlrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0TlRCaE16VXpZekF0T0dRMFpDMDBZVGs1TFdGbE5EY3RZMkkxTldWbVlXUTEKT1dKakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqcklKL2h3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQWxuRThENEo0cWRNOHE0R1Y1NVFidTdSUDViQnJQUGhPSXpqNVRjMnlkYkJ0eGhRNERrRzk2CjhCVExqVEZnR2ZSY1hkK255dmRxNHBvRnNJbmJrWmpRNGJzaERadHRRd2lwSDV5YmdsN0NuTjVoVEs1K3ozS2wKaHUxMCs1cnRFZUU4ZGpXekpKUFJGb0xJVWhkZ2YzdlRwQkxYU3BHZnBqTGRsbTUzYVFqK2ZmWnNjSlhNazk1MApsT1ZXckcrU3pNbVNQUDYyaHFNQ1FhWWtUYmJxck81V1d5b3FHd2ovWGdJSlY2UklaUTJWci9EV29KczBHbUFzCkx4U0hmQ012N09PY2YxbmYxaGpoQ1N5anZzQVd3RzBBZ3VkVTFETEptWVgvT25WNXhOaWpUTE1YZ29kRGhNS0kKOGIvcW8rc3A5anlPcmRjSEJ6WjkzMVViQ00wQ1ltMTgKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1845"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:55:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 035a0d04-f998-42fe-9789-48a2a0321a14
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","endpoint_spec":[{"direct_access":{}},{"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -711,16 +711,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:35 GMT
+      - Thu, 16 Nov 2023 15:55:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +730,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1983cf43-a298-49ce-a344-626edc791319
+      - 12f1af0a-f916-45af-9ed2-9680ffe02552
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:35 GMT
+      - Thu, 16 Nov 2023 15:55:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e04c4eec-7093-4e97-b1b4-933a3d2bdc29
+      - 79934e22-0ff8-4c58-ab7f-a756790f859c
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:05 GMT
+      - Thu, 16 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afbb66f3-f29a-44b4-b94a-9ec44574e48c
+      - 7a9f0d9e-4285-4dd6-8919-0929ddfbca0b
     status: 200 OK
     code: 200
     duration: ""
@@ -807,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:35 GMT
+      - Thu, 16 Nov 2023 15:56:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2716a9d9-5ccd-4a68-a5e3-3f7c3224a2b5
+      - f848fdb7-2c4f-408b-b4cb-a72478458412
     status: 200 OK
     code: 200
     duration: ""
@@ -840,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "440"
+      - "458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:05 GMT
+      - Thu, 16 Nov 2023 15:56:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76703d8a-7803-443f-b526-732580dc74f0
+      - 857846e0-bd5d-439b-b81c-ac1c8be90a69
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "440"
+      - "458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:35 GMT
+      - Thu, 16 Nov 2023 15:57:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53d0a88a-20b2-4cfb-a70f-37136288e838
+      - 46eb5aa6-86cd-4bdd-b0b5-3ce6a5c56718
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "433"
+      - "458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 15:57:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecd5c591-a175-4e18-aecf-a7c051f29da1
+      - 65ac29de-c085-41c8-aecc-b9210e6056e7
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "433"
+      - "458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 15:58:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6c66e80-db61-4f6b-9ec2-bd297bca8355
+      - 6f2c6f16-721f-4f1b-922b-97d1be39dcdb
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "433"
+      - "458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 15:58:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0791e2fc-f19d-4f46-9de0-8f12b1fbe45e
+      - a9c9cffd-9045-4c16-96ff-76bbf1e63ea8
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/89c22642-6cdb-40c2-9b9c-2f582f322f59
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:53:32.999053Z","dhcp_enabled":true,"id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","name":"tf-pn-silly-nobel","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:53:32.999053Z","id":"9258e348-06a6-4cef-b394-bb246b05afc3","subnet":"172.16.12.0/22","updated_at":"2023-11-02T18:53:32.999053Z"},{"created_at":"2023-11-02T18:53:32.999053Z","id":"819c14be-d6ae-4bd2-bd41-e892578291d1","subnet":"fd63:256c:45f7:cd3f::/64","updated_at":"2023-11-02T18:53:32.999053Z"}],"tags":[],"updated_at":"2023-11-02T18:53:32.999053Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "701"
+      - "451"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 15:59:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94e59850-8ee9-49ad-8724-add68cdb3b08
+      - fa1227e8-4746-4490-8220-bef2b0d006e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450},"endpoints":[{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450}],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1676"
+      - "451"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 15:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa83ff04-e87e-4bca-9939-e0fefc7a13e7
+      - 99713b6b-66bf-4689-83ac-e3275f81bdc3
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVS29nZUFRenhWNGdrQ3ZkbThmVzJacUxhVlFnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVME1USmFGdzB6TXpFd016QXhPRFUwTVRKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNzdmNuTWVTTGEzNm11bUxGS1J0L21wOGIzZldJTzNhNFpXdXBPbHFMdDZvaUtTZVZVSEk0UUdJeSsKYTVYWUxwdFM3ekVDYzdEZ1o2bTdvOURpNkhBYi9CVG1Ub1dMSG1JY0V4aG85dENTdFF6UWlxQXBlZ3hudngyQQp5Sldzd0xsZEkzSTJmUCtBajl1NGZvTEQ1dC9RRjY3TFRMeFJUQ3pCN1F4V2pueWxPbXdZMEJHa3BramNSRVRuCjVkMjVLNFlpaWo5S3F4NEtRWVNUYVNuS1lMckg0NGNydEl3TS9PWVNwTS9KeStqa1hmK0tpc00rYSszV1J0MmYKYytxYVBNTC9PR3kya3JtelJFNUg0WUtmWFgybFdDSzZDbGVvR3ljR0tMQjlZZkdnNDZUM21tNk5sZEQ4VEJregptZ2t0ZlhrVkczeFc1bHJacVNzRzRSVlUwMWhYQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPRFV3WkRFMFpXTXRaalV4TVMwME0ySXlMVGt4WTJZdE5USmhNVGxtTURVNU5UVXkKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pyS3RnaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFCS0ZYTWVlQW5BNHBaUUZNZE94Qlg5TkNEK0l5UDRYL296R0hwRHJGS1VQdzgyMFhEcEVPSFkvdGFCCi9vbDhxTGNua0liUjJMemNKVDZ6S2JQcFZBWTdwM21yMzNKaDhycFdwdHVSaEdqMUVWOW8vOVM5YVFpcEFqR3UKVVBaR3YwWTZobXFPdHBTZEt2U2lCelFCYWNXWnk2aEgyMUczYTQvYUtjZWtPR0FzeW5DUE9yZ1VXMzY1L2pIWQpUbm1GYjBkWVltWG45ajEybFVWUVA2TC83clE2d0hUWWlTVHZDQ0lxWnFUNjF0cFk0QzZRSS9ka016NzMvRW9yCndSZy9Ldmc2UjBLMDdVMzR2RlhUUXZQOWxrUTNYeERwbFhCdVFTS3M2WEJaYk5NczFWWVMwWThRWkowQ3l0emkKOEppUkh3U1IxdXh5TmFuTXhTaHlEaEZVYXljQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1839"
+      - "451"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:06 GMT
+      - Thu, 16 Nov 2023 15:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f7fd89c-2918-4fe0-909c-f322821b85e6
+      - 9bab5b8e-40fe-4c3a-95e9-6dc10fd42737
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b85c357c-015c-4bbd-8ade-c20ae579111d
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"created_at":"2023-11-16T15:52:09.549992Z","dhcp_enabled":true,"id":"b85c357c-015c-4bbd-8ade-c20ae579111d","name":"tf-pn-focused-bassi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T15:52:09.549992Z","id":"169dbcad-7558-4284-aee9-385f689d244d","subnet":"172.16.12.0/22","updated_at":"2023-11-16T15:52:09.549992Z"},{"created_at":"2023-11-16T15:52:09.549992Z","id":"aa38d7ab-1e5b-4d06-8b60-30d028cd21d0","subnet":"fd63:256c:45f7:7217::/64","updated_at":"2023-11-16T15:52:09.549992Z"}],"tags":[],"updated_at":"2023-11-16T15:52:09.549992Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "433"
+      - "720"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:07 GMT
+      - Thu, 16 Nov 2023 15:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7780783-57a3-4446-a9ca-265ddf857141
+      - cccb2574-db27-449f-85a2-28c7b32e1b3c
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.917740Z","endpoint":{"id":"ef94f1c3-1e1f-4662-bb86-811d8da4dd45","ip":"195.154.197.0","load_balancer":{},"name":null,"port":17097},"endpoints":[{"id":"ef94f1c3-1e1f-4662-bb86-811d8da4dd45","ip":"195.154.197.0","load_balancer":{},"name":null,"port":17097}],"engine":"PostgreSQL-15","id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "433"
+      - "1746"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:08 GMT
+      - Thu, 16 Nov 2023 15:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e674116-f60e-4123-9e11-3013b8edd29f
+      - 03ae2084-cc01-4449-a866-adf9c585b584
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1170,118 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVTmxJYU1BZnlsdGZDQktSUkZieithVTJ5c0V3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU5TNHhOVFF1TVRrM0xqQXdIaGNOCk1qTXhNVEUyTVRVMU5EUXlXaGNOTXpNeE1URXpNVFUxTkRReVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGsxTGpFMU5DNHhPVGN1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxNblAvQzladGlHUGJqellsd0dVUWhvdnd2THBWdHc5d2xRSHplQ2NKRE9FVXRxcy9md1BhaCsKRGJYcHJldFNwa2I2OCtLdTN2Z0xZYWNGRWgyMnlrNERqMkpBeGZBUjN4ekpLV3ExRzc3OUNYZTljYk9BR2hYdApON0twV1dISFQ4b2R3bXRnemJTanpRQlRPTHE3Wjg1cDZXR3ZJV0gxRXUvTlA5TGJ0aXgrUzQ2dlJGOXZhVVRaCjYzQm93YTJoQXJQQmZCa3RVQ3k4MU9YeXZ3a2w5ei9hUHZIbzQ5U3ptVHlIUkhaenNCcXdyS3BONEZacGw4bUkKMHZkYWVaeGM5anZkRUtvSXJPQk1oNXRtdnlsYjBySXRaVldEWnpaY09jN0d2VUpkWEc4dTFDcVkyWmljUE1wTApab2ZhRDl5SmY2RFhRU0NFSUZFc1B2cVBKVklvZnlrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5NVGsxCkxqRTFOQzR4T1RjdU1JSThjbmN0TlRCaE16VXpZekF0T0dRMFpDMDBZVGs1TFdGbE5EY3RZMkkxTldWbVlXUTEKT1dKakxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqcklKL2h3VERtc1VBTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQWxuRThENEo0cWRNOHE0R1Y1NVFidTdSUDViQnJQUGhPSXpqNVRjMnlkYkJ0eGhRNERrRzk2CjhCVExqVEZnR2ZSY1hkK255dmRxNHBvRnNJbmJrWmpRNGJzaERadHRRd2lwSDV5YmdsN0NuTjVoVEs1K3ozS2wKaHUxMCs1cnRFZUU4ZGpXekpKUFJGb0xJVWhkZ2YzdlRwQkxYU3BHZnBqTGRsbTUzYVFqK2ZmWnNjSlhNazk1MApsT1ZXckcrU3pNbVNQUDYyaHFNQ1FhWWtUYmJxck81V1d5b3FHd2ovWGdJSlY2UklaUTJWci9EV29KczBHbUFzCkx4U0hmQ012N09PY2YxbmYxaGpoQ1N5anZzQVd3RzBBZ3VkVTFETEptWVgvT25WNXhOaWpUTE1YZ29kRGhNS0kKOGIvcW8rc3A5anlPcmRjSEJ6WjkzMVViQ00wQ1ltMTgKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1845"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:59:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5cc8f3d2-8869-415d-a590-3885214ba09c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "451"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:59:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3d2a9bd2-76c6-4213-bb92-0b9805f48656
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "451"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:59:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0e35b107-3d6d-4436-ac3a-f966d9953b1c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "436"
+      - "454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:08 GMT
+      - Thu, 16 Nov 2023 15:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d33b46e-f48b-4a20-b522-d70786e1201f
+      - 43c8ccef-9a0b-426d-a9cc-cf630fbda431
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,19 +1302,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3a8e8cc5-8756-4597-a8e4-35711430bc50","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"89c22642-6cdb-40c2-9b9c-2f582f322f59","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7ccbafdb-ef50-44d2-882c-2a3d1601cb2f","ip":"51.15.131.88","name":null,"port":5432}],"id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"b32abaa7-e87b-46f9-b1e6-4d9a876a30bc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b85c357c-015c-4bbd-8ade-c20ae579111d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"c8d3d37e-6abf-492e-9976-111358eeb22f","ip":"163.172.159.185","name":null,"port":5432}],"id":"5e13d249-51d8-4cdd-801c-b32b056a1975","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "436"
+      - "454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:08 GMT
+      - Thu, 16 Nov 2023 15:59:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 776ec3c2-e4fe-41e3-b338-2df259d482dc
+      - b56d38cb-9a61-4651-84e0-444575381af0
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,10 +1335,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"5e13d249-51d8-4cdd-801c-b32b056a1975","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1248,7 +1347,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:38 GMT
+      - Thu, 16 Nov 2023 15:59:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28d9ab44-1004-41a2-bf6c-1af91c17cdff
+      - 1c584929-0443-4b51-864e-a86f47971609
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1269,19 +1368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450},"endpoints":[{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450}],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.917740Z","endpoint":{"id":"ef94f1c3-1e1f-4662-bb86-811d8da4dd45","ip":"195.154.197.0","load_balancer":{},"name":null,"port":17097},"endpoints":[{"id":"ef94f1c3-1e1f-4662-bb86-811d8da4dd45","ip":"195.154.197.0","load_balancer":{},"name":null,"port":17097}],"engine":"PostgreSQL-15","id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:38 GMT
+      - Thu, 16 Nov 2023 15:59:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50b7eb46-b241-4e4f-a9bc-fa5aeed508a8
+      - c4571220-2f0d-478a-9595-9141dc19bf87
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,73 +1401,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450},"endpoints":[{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450}],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1246"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:59:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 08f40045-1fbe-440a-b9d4-e9713f095e16
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:33.283003Z","endpoint":{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450},"endpoints":[{"id":"1f44e058-95da-4e08-b347-9a4da0096f44","ip":"51.159.25.65","load_balancer":{},"name":null,"port":2450}],"engine":"PostgreSQL-15","id":"850d14ec-f511-43b2-91cf-52a19f059552","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1246"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:59:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 210f9b6a-efcb-42d6-9b88-95aeee58b046
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/89c22642-6cdb-40c2-9b9c-2f582f322f59
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b85c357c-015c-4bbd-8ade-c20ae579111d
     method: DELETE
   response:
     body: ""
@@ -1378,7 +1411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:39 GMT
+      - Thu, 16 Nov 2023 15:59:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43e4c46f-e059-485d-b379-7e4e7be36674
+      - ed6a20b7-889e-4e69-a105-581ebee2d405
     status: 204 No Content
     code: 204
     duration: ""
@@ -1399,19 +1432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
-    method: GET
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
+    method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"850d14ec-f511-43b2-91cf-52a19f059552","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.917740Z","endpoint":{"id":"ef94f1c3-1e1f-4662-bb86-811d8da4dd45","ip":"195.154.197.0","load_balancer":{},"name":null,"port":17097},"endpoints":[{"id":"ef94f1c3-1e1f-4662-bb86-811d8da4dd45","ip":"195.154.197.0","load_balancer":{},"name":null,"port":17097}],"engine":"PostgreSQL-15","id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "129"
+      - "1298"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:09 GMT
+      - Thu, 16 Nov 2023 15:59:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1454,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c2f9499-95f5-4221-be4c-9322bddc6c5d
+      - e684555d-e2aa-42e8-a987-7899110947df
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:52:09.917740Z","endpoint":{"id":"ef94f1c3-1e1f-4662-bb86-811d8da4dd45","ip":"195.154.197.0","load_balancer":{},"name":null,"port":17097},"endpoints":[{"id":"ef94f1c3-1e1f-4662-bb86-811d8da4dd45","ip":"195.154.197.0","load_balancer":{},"name":null,"port":17097}],"engine":"PostgreSQL-15","id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1298"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:59:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7bac7528-b600-4b5f-abe1-22a3e5b71bf6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 258fba5a-866a-40f2-a0ea-0e6f71f4159a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1432,10 +1531,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/850d14ec-f511-43b2-91cf-52a19f059552
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50a353c0-8d4d-4a99-ae47-cb55efad59bc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"850d14ec-f511-43b2-91cf-52a19f059552","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"50a353c0-8d4d-4a99-ae47-cb55efad59bc","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1444,7 +1543,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:09 GMT
+      - Thu, 16 Nov 2023 16:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f9365dd-849b-4260-bf2e-ae6f9ee51ab1
+      - 90081d85-61c1-4b58-98c5-c25321bf7f1c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1465,10 +1564,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5e13d249-51d8-4cdd-801c-b32b056a1975
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"6cea2b9c-7d4c-4f0e-b40f-6d169cd1e042","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"5e13d249-51d8-4cdd-801c-b32b056a1975","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1477,7 +1576,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:09 GMT
+      - Thu, 16 Nov 2023 16:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d0c9e7f-b449-475c-b9fb-288d4084f904
+      - 4c7f2bfa-7b5d-46df-b308-637d0ed3d4d1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-private-network.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-private-network.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:35 GMT
+      - Thu, 16 Nov 2023 15:52:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,80 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf344db8-3699-43db-a4c8-2ed7d56f6914
+      - f7b179cd-ea8e-449a-b410-8f3df64d610a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-pn-adoring-thompson","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-    method: POST
-  response:
-    body: '{"created_at":"2023-11-02T18:53:50.869634Z","dhcp_enabled":true,"id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","name":"tf-pn-adoring-thompson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:53:50.869634Z","id":"05c26b20-f19f-4986-8cff-3a475a41e04e","subnet":"172.16.24.0/22","updated_at":"2023-11-02T18:53:50.869634Z"},{"created_at":"2023-11-02T18:53:50.869634Z","id":"3405fa12-08a2-45c7-97e2-51ec63b1ebea","subnet":"fd63:256c:45f7:be55::/64","updated_at":"2023-11-02T18:53:50.869634Z"}],"tags":[],"updated_at":"2023-11-02T18:53:50.869634Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "706"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d0d754d8-df35-400c-bf5a-260a9f73cc9d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b16795ce-01f0-46f5-b9f5-c22b5c649a0d
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-02T18:53:50.869634Z","dhcp_enabled":true,"id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","name":"tf-pn-adoring-thompson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:53:50.869634Z","id":"05c26b20-f19f-4986-8cff-3a475a41e04e","subnet":"172.16.24.0/22","updated_at":"2023-11-02T18:53:50.869634Z"},{"created_at":"2023-11-02T18:53:50.869634Z","id":"3405fa12-08a2-45c7-97e2-51ec63b1ebea","subnet":"fd63:256c:45f7:be55::/64","updated_at":"2023-11-02T18:53:50.869634Z"}],"tags":[],"updated_at":"2023-11-02T18:53:50.869634Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "706"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:53:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b01fb3ac-f034-4a1c-9ef9-0a43f9d82104
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-pn","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-pn","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -412,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "758"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:51 GMT
+      - Thu, 16 Nov 2023 16:04:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,7 +363,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de4a28bf-35fc-45db-a871-62a77bc93d25
+      - d68e5769-5a3a-4a10-a654-23dfb0f2ec12
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-pn-sweet-gould","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2023-11-16T16:04:15.904238Z","dhcp_enabled":true,"id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","name":"tf-pn-sweet-gould","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:04:15.904238Z","id":"ca724fe4-984d-4cf3-b9d5-9082b718d67f","subnet":"172.16.36.0/22","updated_at":"2023-11-16T16:04:15.904238Z"},{"created_at":"2023-11-16T16:04:15.904238Z","id":"ca4c68b1-6a7b-47f9-bc48-502b2704cd60","subnet":"fd63:256c:45f7:aa80::/64","updated_at":"2023-11-16T16:04:15.904238Z"}],"tags":[],"updated_at":"2023-11-16T16:04:15.904238Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "718"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9ba6fffb-1cde-46ee-9f92-7a4f237bb93f
     status: 200 OK
     code: 200
     duration: ""
@@ -442,19 +409,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9fd70146-5da2-4580-8bc3-a3de52d4fbba
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"created_at":"2023-11-16T16:04:15.904238Z","dhcp_enabled":true,"id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","name":"tf-pn-sweet-gould","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:04:15.904238Z","id":"ca724fe4-984d-4cf3-b9d5-9082b718d67f","subnet":"172.16.36.0/22","updated_at":"2023-11-16T16:04:15.904238Z"},{"created_at":"2023-11-16T16:04:15.904238Z","id":"ca4c68b1-6a7b-47f9-bc48-502b2704cd60","subnet":"fd63:256c:45f7:aa80::/64","updated_at":"2023-11-16T16:04:15.904238Z"}],"tags":[],"updated_at":"2023-11-16T16:04:15.904238Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "758"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:51 GMT
+      - Thu, 16 Nov 2023 16:04:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -464,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e4aee33-d0fe-4cd0-9c76-c890f1877f6e
+      - 38986839-2aea-4b0b-9acf-a2c2a44f70ba
     status: 200 OK
     code: 200
     duration: ""
@@ -475,19 +442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "758"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:22 GMT
+      - Thu, 16 Nov 2023 16:04:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f86b223-cafc-431a-b56d-2da308542b1e
+      - cbb9b0ae-0249-4109-b3ac-90698e4d23ab
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "758"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:52 GMT
+      - Thu, 16 Nov 2023 16:04:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1e32c25-8bf7-487e-84bf-04876e6f285d
+      - c922cf5c-d3be-46c9-94ff-57105905a89b
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "758"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:22 GMT
+      - Thu, 16 Nov 2023 16:05:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8628bcde-92e9-41e2-8d2a-5e2def95264a
+      - b7335b78-bfe4-4c23-95e9-2d62238175f6
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "758"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:52 GMT
+      - Thu, 16 Nov 2023 16:05:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39498382-8132-4ecf-99ca-9707312b8c10
+      - 3311ccd5-3cb2-4c83-82cd-54a9a871f86a
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "758"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:22 GMT
+      - Thu, 16 Nov 2023 16:06:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ddb8959-a14d-4130-be53-6d9020e3c0a8
+      - 323b00c3-a0fd-4eec-a35f-680d7c3161bd
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303},"endpoints":[{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303}],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1231"
+      - "787"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:52 GMT
+      - Thu, 16 Nov 2023 16:06:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1bc5848-cbdd-41a6-914d-f9527b2b5cf0
+      - 8a4dd560-db06-461b-bb6b-26215d960516
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSlE2TU4ydTBUY2ZpSUlRUmJENkp1UzU5NTc4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1URTFNQjRYCkRUSXpNVEV3TWpFNE5UUXpNRm9YRFRNek1UQXpNREU0TlRRek1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRFMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXRzMCtEeEUxVzJkSndkcE80bUR3M0VqdUFvUXN4MnlGLzA5RzFYVWpmVDFsNUJybWFRYXIKS2lyMEMwTmRiUTF3emVQZjU3OU1PZWJIWFdKbVZGM2xjRG9MTnRacnEyUzF0bU9UdjRGZFZOU29RK0hiVXg4NwowN3cyVHJWb3Bwa0VVZ25JRFBKbE5QWjZuTGxLNm55eVVDbHROb3hVOUprN21QTkR2TEg0M0xRcDFCYXVSWFZPCnA4dmhMd3lhb3dFdHlDdzNvWnJDdXdNenZuVWlCZWtzZmI3NlJRRlRpZ3dVVVdXSldzbGdjalhnSmh3YTRuckEKOEZzZy94aWlFaCtGcFREYkNyWXFYQ3RIdXVuK3dwU0pUZGp3dm5uclh2Z0V5ZVNaUm5oOWJHem1FaHBRckJMcQpUTk5aMi9jVndsSnp1b2pSVjVhcDhkMHJLUEJ4R1gyeW9RSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRXhOWUk4Y25jdE9XTmhNR1F4WVRrdE9XTTNOaTAwWW1WakxXSTNPV1l0TVRobVpUa3gKTmpGbU9UTTVMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrVjVod1F6bjgxek1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUMwVkE0YTlzbjkrMUpHYnJzSXUxV1l0ZS80czJMMXFYOGJXeldjZjVNUHNIdTJQRk1zCk5UT3NKZmVvaDJNU01HajhaMUxvM3lxaGVlMkpOMXpnbldWT2JCaFBMWnhRTkNSTjJXNnVqc2dpeEZTT3NuM2QKRVBuTUx4cXJwN0RDZjlwNzIzVXJJR1YyU0F5YWJpVXRuZWYzMndIeWZiRWRUQTFwRERtUS9UbStnUHdZM3AxWAppRzAwMjdCZ1haV21UeTFwT0RGcGFYTVlmNk91YnlhYmZKU0hRK2NUSHRMVUdrNXE1bEVEeGMzRU4xbEtQYzRLCnp4SS9wR01XeGo4MHVqejJjQ290TWg1dmI1aHNqb2Y5SWdNbTAwenNzMnFUSFd2V2kyKzJ2bzhncVZHYVZUTGEKQWcxUGRJUTg2THVrNzlIVTNia1FKZ0tWUFk5UStBQ0sydXNECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1847"
+      - "1062"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:52 GMT
+      - Thu, 16 Nov 2023 16:07:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,12 +662,78 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7698600-b013-4c56-b5d6-bca2f9a0e77c
+      - 6af85394-f614-415e-b1c7-abf2d56c6ce2
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","endpoint_spec":[{"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":{"id":"de36065e-fdef-47a5-b94f-558c2e41048b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":3849},"endpoints":[{"id":"de36065e-fdef-47a5-b94f-558c2e41048b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":3849}],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1277"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:07:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 724dd304-86dd-43db-92c1-43575d3c182c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUWNIZG5GS1lWSjhyRVdxd1JIQlVMS1lCWnA0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNVEUyTVRZd056RXlXaGNOTXpNeE1URXpNVFl3TnpFeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUs5NWZXd2pLNFJhandoNTdRcWUyYXl5NHY4djVHdE5ZNXdBdlBFOFVuQncvZS94dFFCVXJ5NlYKbkUrUEVERUNWTGdLd05vcDZidUIzdDdoZWZhY2lzc05wSFNLbHMvdFVzZkFIUFY3YnFiR0hOL0NER0NWY0JwcApBaVlDUzV3a25jNDRZRUt6RzkxSXdzNGhhNmhlL0x1b3lZUmppN0U0RjA3RHgyQnBMNy9ZK09KOUNHLzYxNEowCk15ODdkUDErdmY0THpmb3AxU2cvcjRNdUlYWFhGQkFsaWhMTEhEcmFQL3QxOU13ZG5Lb2pWWFFZUG85UU03ek4Kc2lIaDMyWW9hR0QvLzIzUzREeEFYM0FWR3dCbHZkVjBTZ0JybWNUVzd5UjIxRkJKQStSdE8xdjc2UmI2N0ZzcgpJcDMvVzdlQmlhZDdEVkVZbjBJQUwwZndXR3d1UTc4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMamMwTGpJek9JSThjbmN0Tm1NMk1XVmtNV0V0WXpNelppMDBNR0UzTFRsbE1qTXROREUyTm1ZeU1tRXgKTXpNMExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bmtTV2h3UXpuMHJ1TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQUh3UXQ0Rk83c05NZGZxOE5uVzV6bVZqcWVVRVZZQXpoaGJnTWx3K3NQcFl0V242ZlhuU21BCi9Zd25JcVF1Y3cySWxKNS81cmhaem1RMGFMMjNxWElER3VmalA1OVVodnphNG9qMExob3Ird0ZwZkRZa2s0RkQKckNrUGdmcHBXZ3YrYUR4ZGQyWUZYbXlqV3J1L29aczl3NnNjNnMvQkNaVlMzekhqZURMOWFIZENKbUFSVmM4SApXNjg1K2xCajFxM3hnUDFSQ29LRm9nbXB6ajJ2bTBESmkrQVJhbGorTGFpZHB0dHZCV3AzeXpySGY5a2JJOVdlCkpVUDI2b3haVmYxRzNsNmowOEhPUVhtd3FVcFNGbVNaWWJsK3ZyYnpLNSsxRUZoVkRDaWE3UVRzZU1CSEVRUXAKcmFYMlpFcGtyYnhYWFFBc1lvYVNUU29TYU5qNC9hdnEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1845"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:07:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 31e358f0-e5c0-45d4-b3ee-4b41a28352b8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","endpoint_spec":[{"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -711,16 +744,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:53 GMT
+      - Thu, 16 Nov 2023 16:07:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e4f6c81-d9ed-49b7-b3ff-8235a13318c0
+      - 2415503d-b21a-4c0d-9284-2ceadbb6f0cf
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:53 GMT
+      - Thu, 16 Nov 2023 16:07:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b83e704-baed-4741-bd0c-9e7f2addbca0
+      - 1091f9ad-fa36-40aa-9f5e-644864e7ebd2
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:23 GMT
+      - Thu, 16 Nov 2023 16:08:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c321f66f-ae5f-4e54-84e3-93e26808b8bb
+      - 01d3855e-70b5-4da4-814d-ba292d698d01
     status: 200 OK
     code: 200
     duration: ""
@@ -807,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:53 GMT
+      - Thu, 16 Nov 2023 16:08:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62b40ebb-f929-42a9-8587-be531e8e5af2
+      - 7c32c905-e3d8-489f-b948-c38ddb6b17cd
     status: 200 OK
     code: 200
     duration: ""
@@ -840,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:24 GMT
+      - Thu, 16 Nov 2023 16:09:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f88224dd-3b29-4138-8693-126517f09d1c
+      - 1c6fd32d-b82c-4902-a45d-25d17c250f8c
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:54 GMT
+      - Thu, 16 Nov 2023 16:09:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f62ba6e-49bb-4de7-830e-03910182d674
+      - 33037243-f47c-42b2-bb87-8fb54a2eace5
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "324"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:24 GMT
+      - Thu, 16 Nov 2023 16:10:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5355c474-c84e-4e3c-968a-4d0f3505c065
+      - 59e09b20-a9f1-4f74-ad2c-2aa1cd182153
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "324"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:24 GMT
+      - Thu, 16 Nov 2023 16:10:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b54b0cfb-95d3-4233-b0df-0a2c8d9c86ed
+      - cc76dbe5-3480-4056-a04b-b14218496752
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "324"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:24 GMT
+      - Thu, 16 Nov 2023 16:11:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ab57b79-551c-467d-abc4-a8f46d4213e6
+      - b8205dec-7fef-4479-ae3e-787ef2090a55
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b16795ce-01f0-46f5-b9f5-c22b5c649a0d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:53:50.869634Z","dhcp_enabled":true,"id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","name":"tf-pn-adoring-thompson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:53:50.869634Z","id":"05c26b20-f19f-4986-8cff-3a475a41e04e","subnet":"172.16.24.0/22","updated_at":"2023-11-02T18:53:50.869634Z"},{"created_at":"2023-11-02T18:53:50.869634Z","id":"3405fa12-08a2-45c7-97e2-51ec63b1ebea","subnet":"fd63:256c:45f7:be55::/64","updated_at":"2023-11-02T18:53:50.869634Z"}],"tags":[],"updated_at":"2023-11-02T18:53:50.869634Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "706"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:24 GMT
+      - Thu, 16 Nov 2023 16:11:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f23c9e22-7d9e-4c14-9ddb-d69604255aba
+      - 8f021d92-02a9-48e8-bde4-1454e15b1202
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303},"endpoints":[{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303}],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1555"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:24 GMT
+      - Thu, 16 Nov 2023 16:11:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c44e694-ffb9-4b3d-ab66-183f0df47844
+      - 74b94a11-ab84-42ac-a9ef-7693031fc110
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSlE2TU4ydTBUY2ZpSUlRUmJENkp1UzU5NTc4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURVdU1URTFNQjRYCkRUSXpNVEV3TWpFNE5UUXpNRm9YRFRNek1UQXpNREU0TlRRek1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRFV1TVRFMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXRzMCtEeEUxVzJkSndkcE80bUR3M0VqdUFvUXN4MnlGLzA5RzFYVWpmVDFsNUJybWFRYXIKS2lyMEMwTmRiUTF3emVQZjU3OU1PZWJIWFdKbVZGM2xjRG9MTnRacnEyUzF0bU9UdjRGZFZOU29RK0hiVXg4NwowN3cyVHJWb3Bwa0VVZ25JRFBKbE5QWjZuTGxLNm55eVVDbHROb3hVOUprN21QTkR2TEg0M0xRcDFCYXVSWFZPCnA4dmhMd3lhb3dFdHlDdzNvWnJDdXdNenZuVWlCZWtzZmI3NlJRRlRpZ3dVVVdXSldzbGdjalhnSmh3YTRuckEKOEZzZy94aWlFaCtGcFREYkNyWXFYQ3RIdXVuK3dwU0pUZGp3dm5uclh2Z0V5ZVNaUm5oOWJHem1FaHBRckJMcQpUTk5aMi9jVndsSnp1b2pSVjVhcDhkMHJLUEJ4R1gyeW9RSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TWpBMUxqRXhOWUk4Y25jdE9XTmhNR1F4WVRrdE9XTTNOaTAwWW1WakxXSTNPV1l0TVRobVpUa3gKTmpGbU9UTTVMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRekQrVjVod1F6bjgxek1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUMwVkE0YTlzbjkrMUpHYnJzSXUxV1l0ZS80czJMMXFYOGJXeldjZjVNUHNIdTJQRk1zCk5UT3NKZmVvaDJNU01HajhaMUxvM3lxaGVlMkpOMXpnbldWT2JCaFBMWnhRTkNSTjJXNnVqc2dpeEZTT3NuM2QKRVBuTUx4cXJwN0RDZjlwNzIzVXJJR1YyU0F5YWJpVXRuZWYzMndIeWZiRWRUQTFwRERtUS9UbStnUHdZM3AxWAppRzAwMjdCZ1haV21UeTFwT0RGcGFYTVlmNk91YnlhYmZKU0hRK2NUSHRMVUdrNXE1bEVEeGMzRU4xbEtQYzRLCnp4SS9wR01XeGo4MHVqejJjQ290TWg1dmI1aHNqb2Y5SWdNbTAwenNzMnFUSFd2V2kyKzJ2bzhncVZHYVZUTGEKQWcxUGRJUTg2THVrNzlIVTNia1FKZ0tWUFk5UStBQ0sydXNECi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1847"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:24 GMT
+      - Thu, 16 Nov 2023 16:11:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 309c48b6-e07b-4966-8f66-2848837afb03
+      - 0e05b2d3-f6be-4eb7-9cd2-6b984e2c9600
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9fd70146-5da2-4580-8bc3-a3de52d4fbba
     method: GET
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"created_at":"2023-11-16T16:04:15.904238Z","dhcp_enabled":true,"id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","name":"tf-pn-sweet-gould","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:04:15.904238Z","id":"ca724fe4-984d-4cf3-b9d5-9082b718d67f","subnet":"172.16.36.0/22","updated_at":"2023-11-16T16:04:15.904238Z"},{"created_at":"2023-11-16T16:04:15.904238Z","id":"ca4c68b1-6a7b-47f9-bc48-502b2704cd60","subnet":"fd63:256c:45f7:aa80::/64","updated_at":"2023-11-16T16:04:15.904238Z"}],"tags":[],"updated_at":"2023-11-16T16:04:15.904238Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "324"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:25 GMT
+      - Thu, 16 Nov 2023 16:11:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 502b9593-09b2-4dc8-9446-dcfa5087fa31
+      - 2c5338c1-8490-4919-9cb6-600a4cad2dd3
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
     method: GET
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":{"id":"de36065e-fdef-47a5-b94f-558c2e41048b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":3849},"endpoints":[{"id":"de36065e-fdef-47a5-b94f-558c2e41048b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":3849}],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "324"
+      - "1611"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:25 GMT
+      - Thu, 16 Nov 2023 16:11:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9df0c6f4-e0cb-4c3a-8768-8742a88a6b1f
+      - f930e010-7c81-40de-97dd-6880dddc5ee8
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1203,118 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUWNIZG5GS1lWSjhyRVdxd1JIQlVMS1lCWnA0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNVEUyTVRZd056RXlXaGNOTXpNeE1URXpNVFl3TnpFeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUs5NWZXd2pLNFJhandoNTdRcWUyYXl5NHY4djVHdE5ZNXdBdlBFOFVuQncvZS94dFFCVXJ5NlYKbkUrUEVERUNWTGdLd05vcDZidUIzdDdoZWZhY2lzc05wSFNLbHMvdFVzZkFIUFY3YnFiR0hOL0NER0NWY0JwcApBaVlDUzV3a25jNDRZRUt6RzkxSXdzNGhhNmhlL0x1b3lZUmppN0U0RjA3RHgyQnBMNy9ZK09KOUNHLzYxNEowCk15ODdkUDErdmY0THpmb3AxU2cvcjRNdUlYWFhGQkFsaWhMTEhEcmFQL3QxOU13ZG5Lb2pWWFFZUG85UU03ek4Kc2lIaDMyWW9hR0QvLzIzUzREeEFYM0FWR3dCbHZkVjBTZ0JybWNUVzd5UjIxRkJKQStSdE8xdjc2UmI2N0ZzcgpJcDMvVzdlQmlhZDdEVkVZbjBJQUwwZndXR3d1UTc4Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMamMwTGpJek9JSThjbmN0Tm1NMk1XVmtNV0V0WXpNelppMDBNR0UzTFRsbE1qTXROREUyTm1ZeU1tRXgKTXpNMExuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bmtTV2h3UXpuMHJ1TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQUh3UXQ0Rk83c05NZGZxOE5uVzV6bVZqcWVVRVZZQXpoaGJnTWx3K3NQcFl0V242ZlhuU21BCi9Zd25JcVF1Y3cySWxKNS81cmhaem1RMGFMMjNxWElER3VmalA1OVVodnphNG9qMExob3Ird0ZwZkRZa2s0RkQKckNrUGdmcHBXZ3YrYUR4ZGQyWUZYbXlqV3J1L29aczl3NnNjNnMvQkNaVlMzekhqZURMOWFIZENKbUFSVmM4SApXNjg1K2xCajFxM3hnUDFSQ29LRm9nbXB6ajJ2bTBESmkrQVJhbGorTGFpZHB0dHZCV3AzeXpySGY5a2JJOVdlCkpVUDI2b3haVmYxRzNsNmowOEhPUVhtd3FVcFNGbVNaWWJsK3ZyYnpLNSsxRUZoVkRDaWE3UVRzZU1CSEVRUXAKcmFYMlpFcGtyYnhYWFFBc1lvYVNUU29TYU5qNC9hdnEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1845"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:11:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5539c5c7-8da6-44e4-a84c-836b49f97517
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "334"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:11:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 266de6a8-83b9-4387-9451-cfa279cc83c0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "334"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:12:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3c1a0da8-bbf7-473b-8350-50b37566e006
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "327"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:26 GMT
+      - Thu, 16 Nov 2023 16:12:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d1d3b04-7199-4cc2-9669-1947760509d8
+      - 790ecc77-ebb2-4ffc-a3d8-891666895330
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,19 +1335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"endpoints":[{"id":"21d21917-18e1-4e91-8871-db9f3b29b332","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b16795ce-01f0-46f5-b9f5-c22b5c649a0d","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"9a89a090-e42a-4f92-b507-f49efb8451fc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9fd70146-5da2-4580-8bc3-a3de52d4fbba","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"31fae503-e966-4998-9324-a587d90e5289","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "327"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:26 GMT
+      - Thu, 16 Nov 2023 16:12:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 935f8560-5152-4e6f-a7a0-f5c351823d7d
+      - 14623bad-c03c-457f-b79d-7defa251118b
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,10 +1368,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"31fae503-e966-4998-9324-a587d90e5289","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1248,7 +1380,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:01 GMT
+      - Thu, 16 Nov 2023 16:12:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3317156a-ab25-4d36-a313-8aa8bfd56010
+      - fefba449-4e67-4f4e-8861-7c7f3740e128
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1269,19 +1401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303},"endpoints":[{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303}],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":{"id":"de36065e-fdef-47a5-b94f-558c2e41048b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":3849},"endpoints":[{"id":"de36065e-fdef-47a5-b94f-558c2e41048b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":3849}],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1231"
+      - "1277"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:01 GMT
+      - Thu, 16 Nov 2023 16:12:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b88d7bd-440f-4a24-8408-a3bb6de21fa8
+      - 682d83bb-7ec2-47b6-b317-42aae73a1768
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,17 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b16795ce-01f0-46f5-b9f5-c22b5c649a0d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
     method: DELETE
   response:
-    body: ""
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":{"id":"de36065e-fdef-47a5-b94f-558c2e41048b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":3849},"endpoints":[{"id":"de36065e-fdef-47a5-b94f-558c2e41048b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":3849}],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
+      Content-Length:
+      - "1280"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:01 GMT
+      - Thu, 16 Nov 2023 16:12:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,7 +1456,38 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ae30cd0-aeec-4e02-98d4-6c55ca27a503
+      - 80cc23ed-c393-4733-bf14-0600e6046a9e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9fd70146-5da2-4580-8bc3-a3de52d4fbba
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:12:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a5ff2351-5c25-4817-a37e-be988ef8c423
     status: 204 No Content
     code: 204
     duration: ""
@@ -1333,19 +1498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
-    method: DELETE
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
+    method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303},"endpoints":[{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303}],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T16:04:16.159183Z","endpoint":{"id":"de36065e-fdef-47a5-b94f-558c2e41048b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":3849},"endpoints":[{"id":"de36065e-fdef-47a5-b94f-558c2e41048b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":3849}],"engine":"PostgreSQL-15","id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1234"
+      - "1280"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:02 GMT
+      - Thu, 16 Nov 2023 16:12:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe894d0e-df43-4818-938a-9a354b86ffc3
+      - 635be69e-2a9f-45cb-b19f-3600dffbedb9
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,43 +1531,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:51.506615Z","endpoint":{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303},"endpoints":[{"id":"04bd8220-0459-4467-bb84-801aab9cebee","ip":"51.159.205.115","load_balancer":{},"name":null,"port":5303}],"engine":"PostgreSQL-15","id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1234"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 19:00:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 86219815-f32b-48fb-a084-39baf157e0b1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1411,7 +1543,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:32 GMT
+      - Thu, 16 Nov 2023 16:13:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe345dda-ace8-4b87-9500-44c1d545d8f3
+      - bb573b67-5827-469b-b729-91e3e23305e1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1432,10 +1564,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9ca0d1a9-9c76-4bec-b79f-18fe9161f939
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6c61ed1a-c33f-40a7-9e23-4166f22a1334
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"9ca0d1a9-9c76-4bec-b79f-18fe9161f939","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"6c61ed1a-c33f-40a7-9e23-4166f22a1334","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1444,7 +1576,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:32 GMT
+      - Thu, 16 Nov 2023 16:13:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9eae72ef-71ce-4fce-bbac-f58c7577dbc2
+      - a23f8c86-b45d-46b0-bf96-278632634091
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1465,10 +1597,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a38be5cc-0845-497d-94e6-27b84cc71ad5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/31fae503-e966-4998-9324-a587d90e5289
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"a38be5cc-0845-497d-94e6-27b84cc71ad5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"31fae503-e966-4998-9324-a587d90e5289","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1477,7 +1609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:32 GMT
+      - Thu, 16 Nov 2023 16:13:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de1e00aa-9ea1-4569-b562-6528dccde418
+      - 7ff3edca-c00d-4b73-adce-818e65c7d347
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-update.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-update.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:35 GMT
+      - Thu, 16 Nov 2023 15:52:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b2a69d2-5064-44eb-9a54-923268ee0baf
+      - e550964b-272d-4d91-a14b-ed42e534ef63
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-update","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-update","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "791"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:36 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a68f6c50-04bd-4fde-ae4c-4cfb5a22e142
+      - 012fb815-f5a1-4f82-96b7-9932e8beaa99
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "791"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:36 GMT
+      - Thu, 16 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c3777a1-8156-4d19-a7b0-00852ba7a49b
+      - 810e8edd-0b8a-4148-8e11-165f387d90d1
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "791"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:06 GMT
+      - Thu, 16 Nov 2023 15:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8a677b6-542f-4b35-ac84-e2b080b9893d
+      - 73a21627-96ae-4c3a-a07a-5015ca3199bb
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "791"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:37 GMT
+      - Thu, 16 Nov 2023 15:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a53e15d-02c0-4be5-9f54-f27469abaf7e
+      - e0d7cc24-e0b9-45d6-b9e0-a337f564935b
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "791"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:07 GMT
+      - Thu, 16 Nov 2023 15:57:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26595a61-2a19-4130-afdd-05b536ec26ff
+      - acd8bf05-5fd9-431a-ac30-47ba16bd7fe7
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "791"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:37 GMT
+      - Thu, 16 Nov 2023 15:58:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0abfc73-69cd-40ea-b88d-8cc11d059bef
+      - a0207b12-f33d-4624-adbb-2472bb69df3a
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "791"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:07 GMT
+      - Thu, 16 Nov 2023 15:58:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5d40455-f784-450d-8811-cf91e2f963de
+      - b151f500-fe3c-4310-97f9-71552184942b
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1233"
+      - "1066"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:37 GMT
+      - Thu, 16 Nov 2023 15:59:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cec5cb3-70b9-4fb0-8cdf-fdcd15d09c5c
+      - 6307c4a8-98c8-4823-9831-a84670e98832
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSXdEL2ZLYUhGVlFDYzhiSWFXbUJiQW82VlN3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVME1UVmFGdzB6TXpFd016QXhPRFUwTVRWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURqcWZQTDBZWHIwcDNhZjhSNnJuOGdCbXRMMlYvTm5GSldxd0h0MDJ2ZUlaWmRZNC90NVE1ejAzcmYKNUpTNDlPZDRMK1ZpN2dCdkpaaG85dHJFK0t4dlBUY0pVQnJqQmdQaGwvMnpxMHE1R3BqLytYdE5GRFByRGpESwpoZVU1SWF4QlhuUHFGNi8reGsvdnUwVEh3dUlBTFp1dk5rRzg2N0lrZjlWYVhmVnFGSndBbzNVWDFwUWZFQmRSCkVTR0RUMEYwemphc0NBc2RmRWFsWXdVaWJHUWFuWkdmZ3l6TVA3NXJmVFUrQUU1TS9ya0JpOEp0ZFM5cU1Tc24KU1M4WDdQYTJHZGx0R3J6OUMxM2VHb2JEbWFMTkwwc3M4WitrYnZlc1E4WE9JVERsNFRyWHI4WTZjTlBBSjNEWApuK2JlMVZxc1cyVmVWSldOcFlEL2k0aEFBbnl6QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPR013WVdZMk5USXRObVEyTWkwMFl6YzBMV0ptWkRBdFkySTJPR1JtWkRjelptWTMKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3JCaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBLzJlbVd4c3JiRVN2eVVtTFRkWmpxcUx5cXhMQVZuNVV4Q1RvejVaRm1LbTI1R0VTTzBnZkc5UndSCktRTFlnS0NuQ0Nyd2NjcFJYK0lkbFVoaTBwcmZaSzRVSisrTEpoQklyWWhVMFRzUzFzdlpuNGp3ck90aDk0dCsKa2FnS2ZlL0pqQ1hqcVhzNnN5Q0lCQlppMlBNSmZWckY5K0czSGZYSCtBUlJVUGg3elNHNXViL0lFY3lnT3pKagpOZGtxOWJESE9YYnRYa2t5dk50cEQ1M1N6T1Q2VnVKSkx0SS9GaGY5bktJTnoybTc4NXZYNHNacm5WOXQ1MjZOCjlCSUF0YjMrR21GbnFKNDlHNytOYUF3WE91bEZFWTIrMlprUEowM1Irb0R1NHVKekxpNytRVVJDQ1d5cVdmQk8KZWZYUkdYUXVrNGlMY1czL2xZZE11aDdRUXlIVwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200},"endpoints":[{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200}],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1839"
+      - "1281"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:37 GMT
+      - Thu, 16 Nov 2023 15:59:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,12 +627,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fc08a53-315b-499b-8857-699c7dfb5433
+      - e9f173cc-1591-4915-b50b-7979bf956fcb
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQ2JvYzNtN090Z0pFQ1dCZ2ZCWjdhMFFrK0hVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNVEUyTVRVMU9USTNXaGNOTXpNeE1URXpNVFUxT1RJM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtkelJHbnJoeFpPenVWenpLUUlxaVlwaUhqYkorZ0U5UlZuSUpPajcxV1JGc1JCYmtkd3VpY0cKa05SeVQ0VEJOYU9jb3l3YTFCbjMzUlpKYTlLejhxTk5ISDRlYTZlbmRIczl1OGZOaDhTd3E1T3BJZDcvZDNWRQpNN052RUtrZTlWQ0E2bk5GQWpRNDBzTFYvVDd5ZncxdE9seUU5d3dlZUw0ZnFGV0lFakdJUjNCWTg1dnF3TUxKCjJZYklyMldqdFhyTDhSN3Rpb3pYREVJQjMrZEFCbXFZNkNva3Jxd3c4ZHdKRmdjSkJuYlBhOFk5aUdmQXd4ZGYKZm5pS0NlQ3l0SlkycjFzZzdtQk9Ja3hOam01WXR5WTlpeHB2dEpRVkZhcG1Jc0xzSTBKQkZ4eFk1TlhrKzIzdgpLc2FObk5BM2NnaEc2b1BacDlMOWt0RGlsSk8zdFMwQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMamMwTGpJek9JSThjbmN0TURkaE9XWmlNRGd0T0RBek1pMDBNbVExTFRsbE16TXRPV1l5WmpRMVpUQm0KWWpBMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bmtpNmh3UXpuMHJ1TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQW1nYmJtc0xrbEhoVklnTnlQMEJaajZTUWtCR1BQcHNmTTE1RVJRU01GdXRNY1BHa3NHZWlaCm8yVXpJWEd1NEE2ZkVjZENhUWFOQ3hjZ2RmRVk0Qk1vNUdTbXRqQXZrcG9SNkVmSlNFV1pRdkJyUCtreU82bXIKU3RaVDQzay9iQnFoQ3ZhYzRyOThmcEhKNFFQU0Vra093dURsdzBpLzBSQWFYbmQwSGFEb2x1Vjh0L2dtSFJwRwpsamc5L0RQaW5EMjhCTUxkQzdQVG95TjBmbER4dW9TYTlMbnYwVlFCeVRiL09rOU9lQ1RWMzVvVERGNkFGOXozCnFFVTNodXh0d3dqWWRMcmwvTUxKUkJzaXhHcDhOVkRFeG1GR3R3dEtLT2JHSWZBZmIrcHFLaHJVVDVjbHhhKzkKSmorazVvTmtCUFBDVlQ3Q1Vpa0JUbXNZZE5aZ3lTTWYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1845"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:59:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6e55d283-412f-400b-81e1-2c59fb94e5a6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -643,16 +676,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "119"
+      - "123"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:38 GMT
+      - Thu, 16 Nov 2023 15:59:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1de1079c-6eeb-4ca2-89d1-7cfd209beb02
+      - 25bd5ad4-af03-489b-9d12-c6ea526f427e
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "119"
+      - "123"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:56:38 GMT
+      - Thu, 16 Nov 2023 15:59:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f06d3f0-6378-4e92-8724-6b4a015f8122
+      - cafe01b7-9aaa-4edb-bb93-9ebdac488a8e
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "119"
+      - "123"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:08 GMT
+      - Thu, 16 Nov 2023 16:00:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 555cf194-5a7d-4999-970c-213a0d62bcff
+      - ccbc3e3b-971b-4fa8-a780-495cb6b3658c
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"be829f55-f328-4503-831a-2fadd8d7ae2a","ip":"163.172.142.154","name":null,"port":5432}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "229"
+      - "238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:57:38 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5988220-0403-4354-9337-8e2d75cc62d9
+      - 8775185c-42e5-4b11-81ab-9507344c7019
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"be829f55-f328-4503-831a-2fadd8d7ae2a","ip":"163.172.142.154","name":null,"port":5432}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "229"
+      - "238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:08 GMT
+      - Thu, 16 Nov 2023 16:01:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0068a6e0-2005-4641-9e36-cec4c1f080aa
+      - 223e10af-2346-4094-b423-df134148b93a
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"be829f55-f328-4503-831a-2fadd8d7ae2a","ip":"163.172.142.154","name":null,"port":5432}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "229"
+      - "238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:58:38 GMT
+      - Thu, 16 Nov 2023 16:01:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fac3b7d1-4b20-496e-9ef8-80bf679f5732
+      - fdd8bf80-0f84-4d54-a310-71fc8c197f36
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"be829f55-f328-4503-831a-2fadd8d7ae2a","ip":"163.172.142.154","name":null,"port":5432}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "222"
+      - "231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:08 GMT
+      - Thu, 16 Nov 2023 16:02:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0ead0f0-4e8c-4656-bd02-23161f65461d
+      - 6979ede6-0a92-4742-901f-07ad11c4458e
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"be829f55-f328-4503-831a-2fadd8d7ae2a","ip":"163.172.142.154","name":null,"port":5432}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "222"
+      - "231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:09 GMT
+      - Thu, 16 Nov 2023 16:02:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74891469-e897-477b-af9d-f1514e5e69ab
+      - a0d4b38d-a522-409a-b24b-e4e829c69f0f
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"be829f55-f328-4503-831a-2fadd8d7ae2a","ip":"163.172.142.154","name":null,"port":5432}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "222"
+      - "231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:09 GMT
+      - Thu, 16 Nov 2023 16:02:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 543890dd-28b2-441d-a28e-840644cd4076
+      - aed65dad-fe3e-4fa7-8e06-d079d86524ad
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200},"endpoints":[{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200}],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"be829f55-f328-4503-831a-2fadd8d7ae2a","ip":"163.172.142.154","name":null,"port":5432}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1455"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:09 GMT
+      - Thu, 16 Nov 2023 16:02:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e163107-5905-439b-bebf-b19a34173d4b
+      - ee52587c-893a-42a3-beb0-2effb1d509c0
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSXdEL2ZLYUhGVlFDYzhiSWFXbUJiQW82VlN3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVME1UVmFGdzB6TXpFd016QXhPRFUwTVRWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURqcWZQTDBZWHIwcDNhZjhSNnJuOGdCbXRMMlYvTm5GSldxd0h0MDJ2ZUlaWmRZNC90NVE1ejAzcmYKNUpTNDlPZDRMK1ZpN2dCdkpaaG85dHJFK0t4dlBUY0pVQnJqQmdQaGwvMnpxMHE1R3BqLytYdE5GRFByRGpESwpoZVU1SWF4QlhuUHFGNi8reGsvdnUwVEh3dUlBTFp1dk5rRzg2N0lrZjlWYVhmVnFGSndBbzNVWDFwUWZFQmRSCkVTR0RUMEYwemphc0NBc2RmRWFsWXdVaWJHUWFuWkdmZ3l6TVA3NXJmVFUrQUU1TS9ya0JpOEp0ZFM5cU1Tc24KU1M4WDdQYTJHZGx0R3J6OUMxM2VHb2JEbWFMTkwwc3M4WitrYnZlc1E4WE9JVERsNFRyWHI4WTZjTlBBSjNEWApuK2JlMVZxc1cyVmVWSldOcFlEL2k0aEFBbnl6QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPR013WVdZMk5USXRObVEyTWkwMFl6YzBMV0ptWkRBdFkySTJPR1JtWkRjelptWTMKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3JCaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBLzJlbVd4c3JiRVN2eVVtTFRkWmpxcUx5cXhMQVZuNVV4Q1RvejVaRm1LbTI1R0VTTzBnZkc5UndSCktRTFlnS0NuQ0Nyd2NjcFJYK0lkbFVoaTBwcmZaSzRVSisrTEpoQklyWWhVMFRzUzFzdlpuNGp3ck90aDk0dCsKa2FnS2ZlL0pqQ1hqcVhzNnN5Q0lCQlppMlBNSmZWckY5K0czSGZYSCtBUlJVUGg3elNHNXViL0lFY3lnT3pKagpOZGtxOWJESE9YYnRYa2t5dk50cEQ1M1N6T1Q2VnVKSkx0SS9GaGY5bktJTnoybTc4NXZYNHNacm5WOXQ1MjZOCjlCSUF0YjMrR21GbnFKNDlHNytOYUF3WE91bEZFWTIrMlprUEowM1Irb0R1NHVKekxpNytRVVJDQ1d5cVdmQk8KZWZYUkdYUXVrNGlMY1czL2xZZE11aDdRUXlIVwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQ2JvYzNtN090Z0pFQ1dCZ2ZCWjdhMFFrK0hVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNVEUyTVRVMU9USTNXaGNOTXpNeE1URXpNVFUxT1RJM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtkelJHbnJoeFpPenVWenpLUUlxaVlwaUhqYkorZ0U5UlZuSUpPajcxV1JGc1JCYmtkd3VpY0cKa05SeVQ0VEJOYU9jb3l3YTFCbjMzUlpKYTlLejhxTk5ISDRlYTZlbmRIczl1OGZOaDhTd3E1T3BJZDcvZDNWRQpNN052RUtrZTlWQ0E2bk5GQWpRNDBzTFYvVDd5ZncxdE9seUU5d3dlZUw0ZnFGV0lFakdJUjNCWTg1dnF3TUxKCjJZYklyMldqdFhyTDhSN3Rpb3pYREVJQjMrZEFCbXFZNkNva3Jxd3c4ZHdKRmdjSkJuYlBhOFk5aUdmQXd4ZGYKZm5pS0NlQ3l0SlkycjFzZzdtQk9Ja3hOam01WXR5WTlpeHB2dEpRVkZhcG1Jc0xzSTBKQkZ4eFk1TlhrKzIzdgpLc2FObk5BM2NnaEc2b1BacDlMOWt0RGlsSk8zdFMwQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMamMwTGpJek9JSThjbmN0TURkaE9XWmlNRGd0T0RBek1pMDBNbVExTFRsbE16TXRPV1l5WmpRMVpUQm0KWWpBMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bmtpNmh3UXpuMHJ1TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQW1nYmJtc0xrbEhoVklnTnlQMEJaajZTUWtCR1BQcHNmTTE1RVJRU01GdXRNY1BHa3NHZWlaCm8yVXpJWEd1NEE2ZkVjZENhUWFOQ3hjZ2RmRVk0Qk1vNUdTbXRqQXZrcG9SNkVmSlNFV1pRdkJyUCtreU82bXIKU3RaVDQzay9iQnFoQ3ZhYzRyOThmcEhKNFFQU0Vra093dURsdzBpLzBSQWFYbmQwSGFEb2x1Vjh0L2dtSFJwRwpsamc5L0RQaW5EMjhCTUxkQzdQVG95TjBmbER4dW9TYTlMbnYwVlFCeVRiL09rOU9lQ1RWMzVvVERGNkFGOXozCnFFVTNodXh0d3dqWWRMcmwvTUxKUkJzaXhHcDhOVkRFeG1GR3R3dEtLT2JHSWZBZmIrcHFLaHJVVDVjbHhhKzkKSmorazVvTmtCUFBDVlQ3Q1Vpa0JUbXNZZE5aZ3lTTWYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1839"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:09 GMT
+      - Thu, 16 Nov 2023 16:02:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52a88946-412d-4869-9be0-ba891e146653
+      - 265e069e-5a76-49e9-a4ec-55378bb6f1ed
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"be829f55-f328-4503-831a-2fadd8d7ae2a","ip":"163.172.142.154","name":null,"port":5432}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "222"
+      - "231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:09 GMT
+      - Thu, 16 Nov 2023 16:02:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b575e97-c976-4a0c-b715-c48074176ac4
+      - 4e1e9bab-f0c3-4a85-b63b-7402f4d682d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200},"endpoints":[{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200}],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"be829f55-f328-4503-831a-2fadd8d7ae2a","ip":"163.172.142.154","name":null,"port":5432}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1455"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:10 GMT
+      - Thu, 16 Nov 2023 16:02:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17dd8174-4ab2-4091-a99a-b1159c43e042
+      - d6ccafe3-0ca5-424b-a034-aa35258f167e
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSXdEL2ZLYUhGVlFDYzhiSWFXbUJiQW82VlN3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVME1UVmFGdzB6TXpFd016QXhPRFUwTVRWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURqcWZQTDBZWHIwcDNhZjhSNnJuOGdCbXRMMlYvTm5GSldxd0h0MDJ2ZUlaWmRZNC90NVE1ejAzcmYKNUpTNDlPZDRMK1ZpN2dCdkpaaG85dHJFK0t4dlBUY0pVQnJqQmdQaGwvMnpxMHE1R3BqLytYdE5GRFByRGpESwpoZVU1SWF4QlhuUHFGNi8reGsvdnUwVEh3dUlBTFp1dk5rRzg2N0lrZjlWYVhmVnFGSndBbzNVWDFwUWZFQmRSCkVTR0RUMEYwemphc0NBc2RmRWFsWXdVaWJHUWFuWkdmZ3l6TVA3NXJmVFUrQUU1TS9ya0JpOEp0ZFM5cU1Tc24KU1M4WDdQYTJHZGx0R3J6OUMxM2VHb2JEbWFMTkwwc3M4WitrYnZlc1E4WE9JVERsNFRyWHI4WTZjTlBBSjNEWApuK2JlMVZxc1cyVmVWSldOcFlEL2k0aEFBbnl6QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPR013WVdZMk5USXRObVEyTWkwMFl6YzBMV0ptWkRBdFkySTJPR1JtWkRjelptWTMKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3JCaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBLzJlbVd4c3JiRVN2eVVtTFRkWmpxcUx5cXhMQVZuNVV4Q1RvejVaRm1LbTI1R0VTTzBnZkc5UndSCktRTFlnS0NuQ0Nyd2NjcFJYK0lkbFVoaTBwcmZaSzRVSisrTEpoQklyWWhVMFRzUzFzdlpuNGp3ck90aDk0dCsKa2FnS2ZlL0pqQ1hqcVhzNnN5Q0lCQlppMlBNSmZWckY5K0czSGZYSCtBUlJVUGg3elNHNXViL0lFY3lnT3pKagpOZGtxOWJESE9YYnRYa2t5dk50cEQ1M1N6T1Q2VnVKSkx0SS9GaGY5bktJTnoybTc4NXZYNHNacm5WOXQ1MjZOCjlCSUF0YjMrR21GbnFKNDlHNytOYUF3WE91bEZFWTIrMlprUEowM1Irb0R1NHVKekxpNytRVVJDQ1d5cVdmQk8KZWZYUkdYUXVrNGlMY1czL2xZZE11aDdRUXlIVwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQ2JvYzNtN090Z0pFQ1dCZ2ZCWjdhMFFrK0hVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNVEUyTVRVMU9USTNXaGNOTXpNeE1URXpNVFUxT1RJM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtkelJHbnJoeFpPenVWenpLUUlxaVlwaUhqYkorZ0U5UlZuSUpPajcxV1JGc1JCYmtkd3VpY0cKa05SeVQ0VEJOYU9jb3l3YTFCbjMzUlpKYTlLejhxTk5ISDRlYTZlbmRIczl1OGZOaDhTd3E1T3BJZDcvZDNWRQpNN052RUtrZTlWQ0E2bk5GQWpRNDBzTFYvVDd5ZncxdE9seUU5d3dlZUw0ZnFGV0lFakdJUjNCWTg1dnF3TUxKCjJZYklyMldqdFhyTDhSN3Rpb3pYREVJQjMrZEFCbXFZNkNva3Jxd3c4ZHdKRmdjSkJuYlBhOFk5aUdmQXd4ZGYKZm5pS0NlQ3l0SlkycjFzZzdtQk9Ja3hOam01WXR5WTlpeHB2dEpRVkZhcG1Jc0xzSTBKQkZ4eFk1TlhrKzIzdgpLc2FObk5BM2NnaEc2b1BacDlMOWt0RGlsSk8zdFMwQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMamMwTGpJek9JSThjbmN0TURkaE9XWmlNRGd0T0RBek1pMDBNbVExTFRsbE16TXRPV1l5WmpRMVpUQm0KWWpBMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bmtpNmh3UXpuMHJ1TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQW1nYmJtc0xrbEhoVklnTnlQMEJaajZTUWtCR1BQcHNmTTE1RVJRU01GdXRNY1BHa3NHZWlaCm8yVXpJWEd1NEE2ZkVjZENhUWFOQ3hjZ2RmRVk0Qk1vNUdTbXRqQXZrcG9SNkVmSlNFV1pRdkJyUCtreU82bXIKU3RaVDQzay9iQnFoQ3ZhYzRyOThmcEhKNFFQU0Vra093dURsdzBpLzBSQWFYbmQwSGFEb2x1Vjh0L2dtSFJwRwpsamc5L0RQaW5EMjhCTUxkQzdQVG95TjBmbER4dW9TYTlMbnYwVlFCeVRiL09rOU9lQ1RWMzVvVERGNkFGOXozCnFFVTNodXh0d3dqWWRMcmwvTUxKUkJzaXhHcDhOVkRFeG1GR3R3dEtLT2JHSWZBZmIrcHFLaHJVVDVjbHhhKzkKSmorazVvTmtCUFBDVlQ3Q1Vpa0JUbXNZZE5aZ3lTTWYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1839"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:10 GMT
+      - Thu, 16 Nov 2023 16:02:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e696613-44a2-4077-bcda-2246976c9163
+      - 28d333c5-d4c3-40dc-8a4d-9e432be290b6
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"be829f55-f328-4503-831a-2fadd8d7ae2a","ip":"163.172.142.154","name":null,"port":5432}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "222"
+      - "231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:10 GMT
+      - Thu, 16 Nov 2023 16:02:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,12 +1157,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aade5a5c-3d26-44be-be45-e66a20cc34e7
+      - fa9fe628-9011-4747-b0a0-23894b93d614
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-pn-vigilant-ellis","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
+    body: '{"name":"tf-pn-festive-cartwright","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -1140,16 +1173,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-02T18:59:11.152006Z","dhcp_enabled":true,"id":"81776f3f-28a0-4cb6-9898-aec76cfea602","name":"tf-pn-vigilant-ellis","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:59:11.152006Z","id":"7882cbae-fbc1-458a-b1dc-23b1a8268f1a","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:59:11.152006Z"},{"created_at":"2023-11-02T18:59:11.152006Z","id":"741d48a2-c9b3-4a07-94a7-6b9ff99e03cd","subnet":"fd63:256c:45f7:9ea8::/64","updated_at":"2023-11-02T18:59:11.152006Z"}],"tags":[],"updated_at":"2023-11-02T18:59:11.152006Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:02:25.982616Z","dhcp_enabled":true,"id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","name":"tf-pn-festive-cartwright","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:02:25.982616Z","id":"ec2e8f3d-e18c-4b00-9461-07deae8f57b8","subnet":"172.16.40.0/22","updated_at":"2023-11-16T16:02:25.982616Z"},{"created_at":"2023-11-16T16:02:25.982616Z","id":"0f154a4b-7dc7-4fb3-8128-b1be12b6b7b7","subnet":"fd63:256c:45f7:f2a9::/64","updated_at":"2023-11-16T16:02:25.982616Z"}],"tags":[],"updated_at":"2023-11-16T16:02:25.982616Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "704"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:12 GMT
+      - Thu, 16 Nov 2023 16:02:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f561db1-9436-4c79-8f0b-8af284086246
+      - 0cccf727-a40a-423c-800b-102ca3450285
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1203,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/81776f3f-28a0-4cb6-9898-aec76cfea602
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bfebdb2b-0553-4fa0-a15f-2b233aa0915e
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:59:11.152006Z","dhcp_enabled":true,"id":"81776f3f-28a0-4cb6-9898-aec76cfea602","name":"tf-pn-vigilant-ellis","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:59:11.152006Z","id":"7882cbae-fbc1-458a-b1dc-23b1a8268f1a","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:59:11.152006Z"},{"created_at":"2023-11-02T18:59:11.152006Z","id":"741d48a2-c9b3-4a07-94a7-6b9ff99e03cd","subnet":"fd63:256c:45f7:9ea8::/64","updated_at":"2023-11-02T18:59:11.152006Z"}],"tags":[],"updated_at":"2023-11-02T18:59:11.152006Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:02:25.982616Z","dhcp_enabled":true,"id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","name":"tf-pn-festive-cartwright","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:02:25.982616Z","id":"ec2e8f3d-e18c-4b00-9461-07deae8f57b8","subnet":"172.16.40.0/22","updated_at":"2023-11-16T16:02:25.982616Z"},{"created_at":"2023-11-16T16:02:25.982616Z","id":"0f154a4b-7dc7-4fb3-8128-b1be12b6b7b7","subnet":"fd63:256c:45f7:f2a9::/64","updated_at":"2023-11-16T16:02:25.982616Z"}],"tags":[],"updated_at":"2023-11-16T16:02:25.982616Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "704"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:12 GMT
+      - Thu, 16 Nov 2023 16:02:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2788f67-cd7c-48f8-b5b1-1f6f47526d77
+      - 659345d7-6002-4281-93af-f3589754e77d
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,19 +1236,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"be829f55-f328-4503-831a-2fadd8d7ae2a","ip":"163.172.142.154","name":null,"port":5432}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "222"
+      - "231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:12 GMT
+      - Thu, 16 Nov 2023 16:02:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b50ab3eb-990b-40cd-a3d2-753b38acad90
+      - da803895-4ae2-4ae4-8cbe-439b4c35b5a3
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,7 +1269,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/7ce62594-a076-4680-8a1a-9facf153ca7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/be829f55-f328-4503-831a-2fadd8d7ae2a
     method: DELETE
   response:
     body: ""
@@ -1246,7 +1279,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:12 GMT
+      - Thu, 16 Nov 2023 16:02:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d757aece-73f7-44f0-87fe-234f6c9eac9a
+      - d0d0d6fd-41f8-4173-9ba2-c0b1099674f5
     status: 204 No Content
     code: 204
     duration: ""
@@ -1267,19 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"7ce62594-a076-4680-8a1a-9facf153ca7e","ip":"51.158.113.202","name":null,"port":5432}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"configuring"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"be829f55-f328-4503-831a-2fadd8d7ae2a","ip":"163.172.142.154","name":null,"port":5432}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"configuring"}'
     headers:
       Content-Length:
-      - "228"
+      - "237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:12 GMT
+      - Thu, 16 Nov 2023 16:02:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fea6edd-681f-4d15-a8df-f66fab414792
+      - 52fa03ef-7417-49e4-8552-5e056dbce5db
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,19 +1333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "112"
+      - "116"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:42 GMT
+      - Thu, 16 Nov 2023 16:02:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,12 +1355,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f47a7fe8-40da-49f1-aaa1-261cf029ba87
+      - 5ff748d1-5d73-4fd4-b38f-c1a162d12a06
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20"}}]}'
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","service_ip":"10.12.1.0/20"}}]}'
     form: {}
     headers:
       Content-Type:
@@ -1335,19 +1368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185/endpoints
     method: POST
   response:
-    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"0d2494ff-bf27-4875-95fc-3bc068b06409","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:43 GMT
+      - Thu, 16 Nov 2023 16:03:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0be8444b-5d7f-419f-aa7d-c13a9b272f86
+      - 7fe288e0-ae50-4442-870d-5052ff0ebc37
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,19 +1401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"0d2494ff-bf27-4875-95fc-3bc068b06409","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "331"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:59:43 GMT
+      - Thu, 16 Nov 2023 16:03:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1edb5434-2cd3-49fd-b7ae-d016b60f86b5
+      - 55487319-1d24-461e-9cb3-34437a1514fe
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,19 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"0d2494ff-bf27-4875-95fc-3bc068b06409","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "324"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:13 GMT
+      - Thu, 16 Nov 2023 16:03:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8ddc763-0747-4d83-bc23-6d96e7107164
+      - efb660a9-b90a-417e-9035-d97bca7896d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"0d2494ff-bf27-4875-95fc-3bc068b06409","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "324"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:13 GMT
+      - Thu, 16 Nov 2023 16:03:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45112172-4b36-427b-887d-6d28a73174d6
+      - 1ec51ed6-0f6f-4cc8-9fb1-65d149e74430
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,19 +1500,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"0d2494ff-bf27-4875-95fc-3bc068b06409","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "324"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:13 GMT
+      - Thu, 16 Nov 2023 16:03:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db085c77-aead-451d-8c59-2091e886c2a2
+      - f811781e-24e1-4ed0-8c5a-144216b3ca75
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/81776f3f-28a0-4cb6-9898-aec76cfea602
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bfebdb2b-0553-4fa0-a15f-2b233aa0915e
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T18:59:11.152006Z","dhcp_enabled":true,"id":"81776f3f-28a0-4cb6-9898-aec76cfea602","name":"tf-pn-vigilant-ellis","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-02T18:59:11.152006Z","id":"7882cbae-fbc1-458a-b1dc-23b1a8268f1a","subnet":"172.16.32.0/22","updated_at":"2023-11-02T18:59:11.152006Z"},{"created_at":"2023-11-02T18:59:11.152006Z","id":"741d48a2-c9b3-4a07-94a7-6b9ff99e03cd","subnet":"fd63:256c:45f7:9ea8::/64","updated_at":"2023-11-02T18:59:11.152006Z"}],"tags":[],"updated_at":"2023-11-02T18:59:11.152006Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-16T16:02:25.982616Z","dhcp_enabled":true,"id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","name":"tf-pn-festive-cartwright","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-16T16:02:25.982616Z","id":"ec2e8f3d-e18c-4b00-9461-07deae8f57b8","subnet":"172.16.40.0/22","updated_at":"2023-11-16T16:02:25.982616Z"},{"created_at":"2023-11-16T16:02:25.982616Z","id":"0f154a4b-7dc7-4fb3-8128-b1be12b6b7b7","subnet":"fd63:256c:45f7:f2a9::/64","updated_at":"2023-11-16T16:02:25.982616Z"}],"tags":[],"updated_at":"2023-11-16T16:02:25.982616Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "704"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:14 GMT
+      - Thu, 16 Nov 2023 16:03:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9ee3d2f-01b0-4488-a63b-671dbac29f04
+      - b5a08108-202f-44e4-91f1-1c467f00eea7
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,19 +1566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200},"endpoints":[{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200}],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"0d2494ff-bf27-4875-95fc-3bc068b06409","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1557"
+      - "1615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:14 GMT
+      - Thu, 16 Nov 2023 16:03:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8538c67a-4640-4087-a35e-2b4fb332732f
+      - ea7dc490-2770-4a66-9fa4-9778548e032b
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,19 +1599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSXdEL2ZLYUhGVlFDYzhiSWFXbUJiQW82VlN3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR5TlM0Mk5UQWVGdzB5Ck16RXhNREl4T0RVME1UVmFGdzB6TXpFd016QXhPRFUwTVRWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1qVXVOalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURqcWZQTDBZWHIwcDNhZjhSNnJuOGdCbXRMMlYvTm5GSldxd0h0MDJ2ZUlaWmRZNC90NVE1ejAzcmYKNUpTNDlPZDRMK1ZpN2dCdkpaaG85dHJFK0t4dlBUY0pVQnJqQmdQaGwvMnpxMHE1R3BqLytYdE5GRFByRGpESwpoZVU1SWF4QlhuUHFGNi8reGsvdnUwVEh3dUlBTFp1dk5rRzg2N0lrZjlWYVhmVnFGSndBbzNVWDFwUWZFQmRSCkVTR0RUMEYwemphc0NBc2RmRWFsWXdVaWJHUWFuWkdmZ3l6TVA3NXJmVFUrQUU1TS9ya0JpOEp0ZFM5cU1Tc24KU1M4WDdQYTJHZGx0R3J6OUMxM2VHb2JEbWFMTkwwc3M4WitrYnZlc1E4WE9JVERsNFRyWHI4WTZjTlBBSjNEWApuK2JlMVZxc1cyVmVWSldOcFlEL2k0aEFBbnl6QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHlOUzQyTllJOGNuY3RPR013WVdZMk5USXRObVEyTWkwMFl6YzBMV0ptWkRBdFkySTJPR1JtWkRjelptWTMKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3JCaHdRem54bEJNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBLzJlbVd4c3JiRVN2eVVtTFRkWmpxcUx5cXhMQVZuNVV4Q1RvejVaRm1LbTI1R0VTTzBnZkc5UndSCktRTFlnS0NuQ0Nyd2NjcFJYK0lkbFVoaTBwcmZaSzRVSisrTEpoQklyWWhVMFRzUzFzdlpuNGp3ck90aDk0dCsKa2FnS2ZlL0pqQ1hqcVhzNnN5Q0lCQlppMlBNSmZWckY5K0czSGZYSCtBUlJVUGg3elNHNXViL0lFY3lnT3pKagpOZGtxOWJESE9YYnRYa2t5dk50cEQ1M1N6T1Q2VnVKSkx0SS9GaGY5bktJTnoybTc4NXZYNHNacm5WOXQ1MjZOCjlCSUF0YjMrR21GbnFKNDlHNytOYUF3WE91bEZFWTIrMlprUEowM1Irb0R1NHVKekxpNytRVVJDQ1d5cVdmQk8KZWZYUkdYUXVrNGlMY1czL2xZZE11aDdRUXlIVwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQ2JvYzNtN090Z0pFQ1dCZ2ZCWjdhMFFrK0hVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNVEUyTVRVMU9USTNXaGNOTXpNeE1URXpNVFUxT1RJM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtkelJHbnJoeFpPenVWenpLUUlxaVlwaUhqYkorZ0U5UlZuSUpPajcxV1JGc1JCYmtkd3VpY0cKa05SeVQ0VEJOYU9jb3l3YTFCbjMzUlpKYTlLejhxTk5ISDRlYTZlbmRIczl1OGZOaDhTd3E1T3BJZDcvZDNWRQpNN052RUtrZTlWQ0E2bk5GQWpRNDBzTFYvVDd5ZncxdE9seUU5d3dlZUw0ZnFGV0lFakdJUjNCWTg1dnF3TUxKCjJZYklyMldqdFhyTDhSN3Rpb3pYREVJQjMrZEFCbXFZNkNva3Jxd3c4ZHdKRmdjSkJuYlBhOFk5aUdmQXd4ZGYKZm5pS0NlQ3l0SlkycjFzZzdtQk9Ja3hOam01WXR5WTlpeHB2dEpRVkZhcG1Jc0xzSTBKQkZ4eFk1TlhrKzIzdgpLc2FObk5BM2NnaEc2b1BacDlMOWt0RGlsSk8zdFMwQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMamMwTGpJek9JSThjbmN0TURkaE9XWmlNRGd0T0RBek1pMDBNbVExTFRsbE16TXRPV1l5WmpRMVpUQm0KWWpBMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bmtpNmh3UXpuMHJ1TUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQW1nYmJtc0xrbEhoVklnTnlQMEJaajZTUWtCR1BQcHNmTTE1RVJRU01GdXRNY1BHa3NHZWlaCm8yVXpJWEd1NEE2ZkVjZENhUWFOQ3hjZ2RmRVk0Qk1vNUdTbXRqQXZrcG9SNkVmSlNFV1pRdkJyUCtreU82bXIKU3RaVDQzay9iQnFoQ3ZhYzRyOThmcEhKNFFQU0Vra093dURsdzBpLzBSQWFYbmQwSGFEb2x1Vjh0L2dtSFJwRwpsamc5L0RQaW5EMjhCTUxkQzdQVG95TjBmbER4dW9TYTlMbnYwVlFCeVRiL09rOU9lQ1RWMzVvVERGNkFGOXozCnFFVTNodXh0d3dqWWRMcmwvTUxKUkJzaXhHcDhOVkRFeG1GR3R3dEtLT2JHSWZBZmIrcHFLaHJVVDVjbHhhKzkKSmorazVvTmtCUFBDVlQ3Q1Vpa0JUbXNZZE5aZ3lTTWYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1839"
+      - "1845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:14 GMT
+      - Thu, 16 Nov 2023 16:03:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3c9ba45-908b-474b-b848-b68e5c740492
+      - 0b2a7990-a7f8-463e-8dd3-c3159784c4e4
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,19 +1632,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"0d2494ff-bf27-4875-95fc-3bc068b06409","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "324"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:14 GMT
+      - Thu, 16 Nov 2023 16:03:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6201d6ec-228f-4abf-afc0-91ceaec19d16
+      - 514466da-f20e-4a1d-b78b-5e572ac5d4f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1632,19 +1665,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"0d2494ff-bf27-4875-95fc-3bc068b06409","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "324"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:15 GMT
+      - Thu, 16 Nov 2023 16:03:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f93749b5-184c-4369-b0d9-2c17e6dd5628
+      - e4e54a87-c243-4989-89e7-938580c9a8d6
     status: 200 OK
     code: 200
     duration: ""
@@ -1665,19 +1698,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"0d2494ff-bf27-4875-95fc-3bc068b06409","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "327"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:15 GMT
+      - Thu, 16 Nov 2023 16:03:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 640c4866-325d-4c8c-b3f8-dba08ffbf343
+      - 1b92c1f6-63d0-4269-9144-4bdfa9702a12
     status: 200 OK
     code: 200
     duration: ""
@@ -1698,19 +1731,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"endpoints":[{"id":"ab597724-0016-49e5-a00a-5bc697b32921","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"81776f3f-28a0-4cb6-9898-aec76cfea602","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"0d2494ff-bf27-4875-95fc-3bc068b06409","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"bfebdb2b-0553-4fa0-a15f-2b233aa0915e","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "327"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:15 GMT
+      - Thu, 16 Nov 2023 16:03:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b0673f7-4064-4ff0-97f4-4a9d0f637996
+      - 9c6fb7c5-384c-4c9e-98e1-6d941ee282e1
     status: 200 OK
     code: 200
     duration: ""
@@ -1731,10 +1764,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1743,7 +1776,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:49 GMT
+      - Thu, 16 Nov 2023 16:04:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1786,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb397076-65c6-4af5-9065-906e5134f102
+      - c27a2524-1581-47a0-91cd-8ce6986edef2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1764,19 +1797,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200},"endpoints":[{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200}],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1233"
+      - "1281"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:49 GMT
+      - Thu, 16 Nov 2023 16:04:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5d3d155-fe23-4ab4-bd24-5cc7de9d2a53
+      - 3fe8ef7b-c20e-434d-9a35-7ffbc9a98be5
     status: 200 OK
     code: 200
     duration: ""
@@ -1797,17 +1830,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/81776f3f-28a0-4cb6-9898-aec76cfea602
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: DELETE
   response:
-    body: ""
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200},"endpoints":[{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200}],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
+      Content-Length:
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:00:50 GMT
+      - Thu, 16 Nov 2023 16:04:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1817,7 +1852,71 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67778ed4-1ebb-4ab1-9ea6-14a58bd3d451
+      - d02b0dad-bcd5-456b-b57f-012d8c600c47
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-16T15:56:14.664884Z","endpoint":{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200},"endpoints":[{"id":"547a2e7d-659f-473d-b7df-4c7fe1807e9b","ip":"51.159.74.238","load_balancer":{},"name":null,"port":1200}],"engine":"PostgreSQL-15","id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1284"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9a42fc18-3b78-4f5a-b85d-ffdfa3c2c15f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bfebdb2b-0553-4fa0-a15f-2b233aa0915e
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:04:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 70f329e5-b2f0-4ec6-ad5a-4ca7d23cb86e
     status: 204 No Content
     code: 204
     duration: ""
@@ -1828,76 +1927,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1236"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 19:00:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d7afeb0b-b13e-445f-a64a-c98f3595fa06
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-02T18:53:36.581811Z","endpoint":{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888},"endpoints":[{"id":"7f81e54d-ce05-4e66-a0de-f9ee4473fdef","ip":"51.159.25.65","load_balancer":{},"name":null,"port":13888}],"engine":"PostgreSQL-15","id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1236"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 19:00:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ea475439-a441-4df1-a575-98c85e86ae0d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1906,7 +1939,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:21 GMT
+      - Thu, 16 Nov 2023 16:04:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1916,7 +1949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83518b9c-a5ee-470e-a7e9-6c19b698d158
+      - 375c6ced-e33b-41dc-9a75-75badaf77433
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1927,10 +1960,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8c0af652-6d62-4c74-bfd0-cb68dfd73ff7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/07a9fb08-8032-42d5-9e33-9f2f45e0fb05
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"8c0af652-6d62-4c74-bfd0-cb68dfd73ff7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"07a9fb08-8032-42d5-9e33-9f2f45e0fb05","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1939,7 +1972,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:21 GMT
+      - Thu, 16 Nov 2023 16:04:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1949,7 +1982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fa46af6-097a-4fb3-9b48-471003a27e36
+      - 746cd6d4-2145-42b7-8ce7-df18a7e811a7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1960,10 +1993,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e0c77cce-e133-4c30-bb18-6556ad9d467b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/a3e50466-c3ae-4740-bd1c-4b9eb867a185
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"e0c77cce-e133-4c30-bb18-6556ad9d467b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"a3e50466-c3ae-4740-bd1c-4b9eb867a185","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1972,7 +2005,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 19:01:21 GMT
+      - Thu, 16 Nov 2023 16:04:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1982,7 +2015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a967a96b-0967-464d-95af-79ac489fd166
+      - df78b4a2-2f44-4c86-9e7f-282ed495a7a6
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-user-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-user-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:46:35 GMT
+      - Thu, 16 Nov 2023 15:52:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 862a3090-59ab-450c-8a56-b09afe903c58
+      - 21ea5847-27de-471c-97ea-bef77e16e2d3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbUser_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbUser_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:21 GMT
+      - Thu, 16 Nov 2023 15:56:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bada1925-10cb-4c5a-8ef2-c33b7fce516b
+      - f4e2d174-d2c0-42ee-80da-75ce69b91e22
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:21 GMT
+      - Thu, 16 Nov 2023 15:56:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9cf7825e-6417-485d-9639-ad9cacdaf105
+      - cfc33ea7-75c3-4efd-bc18-edeb76ddfe60
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:51:52 GMT
+      - Thu, 16 Nov 2023 15:56:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1caca6fd-507d-46ea-a456-c8cb4024f404
+      - 80dbb3b2-8b10-4b48-b3fb-5904dbc14795
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:22 GMT
+      - Thu, 16 Nov 2023 15:57:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - daf720f8-2408-4d00-82f5-721b0d07fbda
+      - 9a0ee665-8494-46f6-a5fe-99f5c8331bbe
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:52:52 GMT
+      - Thu, 16 Nov 2023 15:57:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28ef35d0-44f0-4a30-90b8-b15d09879058
+      - d1387f26-4bf5-47da-a5ad-9a646b7ca510
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:22 GMT
+      - Thu, 16 Nov 2023 15:58:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 646a6fcf-0920-4cd2-b912-38ecd8a88a22
+      - df67ffab-62cf-4cb7-b76a-4dc9af38af43
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:53:52 GMT
+      - Thu, 16 Nov 2023 15:58:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0117998e-b8b4-45d1-be37-00b08270d91a
+      - 7d0804b8-7072-4448-a2e1-88204a71bfbf
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:22 GMT
+      - Thu, 16 Nov 2023 15:59:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14b9364d-0d1a-4b56-917b-38581e80bf15
+      - 8d7891fd-c775-4a27-a4c5-cebb602af1de
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "819"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 15:59:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a1ad971-e684-4f80-a0ff-ffa74cb213fa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1094"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9681e2df-cb24-471a-9659-6064c86f6619
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1313"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:00:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6dbfa266-ba7c-42cb-87de-428998e8fac4
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:23 GMT
+      - Thu, 16 Nov 2023 16:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f99040bb-8034-4ac1-9d26-7df60ec96016
+      - ae3f37fc-0ec3-4157-b27a-cd0b25606343
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:23 GMT
+      - Thu, 16 Nov 2023 16:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e3f8371-1f6a-484f-a6bb-a908ebb0c317
+      - 6c2c7f1b-d450-46ef-a0e8-7d43669012c6
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVR1ducURFcUk0c2FnSGxWcFY4cUF1UFdWSmZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qQXdXaGNOTXpNeE1ETXdNVGcxTWpBd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1JOFhCSndVdnFBR2taT3MxNGwxcHN1MmRIdnlCUzJxNWNmQXlsOHpEeE1BMjVrM0tBTk1rUUcKUHowaTIreWwrOHBzNEtmUXdyT2VRVnh6Vm9nR2tMSDhUK0drRERvcEQwaFNPVUh5bDVtK2hiSW5KV2hPSjlHQwpnNHBjdVQ0NFNIMnVLb1hFR3pCMHRLbTZ6NllDT21MZGhVRGNsZkFBQ0Z1WUEwVDF3ZjRQNUtoTXBQR3BQL2tlCjJ4bHFwVUljN1prUzVrbWtPc2Jab2VYb05rM0F3QjUzaXFPTmRtRnhMbjVYeHgzMGd0K2UxamtPdHVqTUFwQ2wKTFFaQ01UY01hcmFsdlVxOElsNmhJcTBQb2tZSURteTYyL0RyZ3ZnREM3b0ZoK3VuNWtYWG5jNFo4TTVCSWNpdwptTWMvUzNlQ1hvNHVuWWIyWFc0WkEvZ2s5RG5YUDBNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TURoak1UVmhOR0l0TVdRMFpDMDBaak5rTFdGa1lUWXRNakV5TkdFek16UmgKTnpZeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDROWWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ2daaWNwU3lIQWlQSkdLcmxxNk90ZTRvUmY5T3lITXMrSGtyaUpuaHRwRU9rbXllVHoweWlkCjYrUWRxOUlSckNCbUxhQTZwWVJhRWNVNENVS1Rtb0JPYzBFdUptOTlBdlBvSFFXN3JnQnU1VjNZY0hUSHVlMWgKY1llTUkxYzMzZWp5OGFTdjZaZGFUaGdjeEFOdzQvajNJdUs0VTFNYVlNVmxlditkUHVHdDA0aWhkUEtyUkN4ZApSR1ZETWg2ZzFqdnpzQ05uQU5wMEM2QVNRN21SR1JtRllYZkVPMTJTWTNhdjVoZVhVbnNDY2VGWmdZR3NyWlltCitYVVh6a1JMVzFLc3lNY3k2RTJBaVJVaHJ4a2hXQVgyWVpId3BoSVE3QXJCQkNzaVUrMlpGN2JnYSthR0RIb0UKMmxZd1RFMVpZWjBsT3VPN21Mam1DTmlEaWdYTkJKZ2kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTZiYVoyelFFaWVTMFJvRkU2SkJaT25zUHdrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EQXhNRm9YRFRNek1URXhNekUyTURBeE1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNaUHV5MGZ0b3BqRm1seFQ0VTZrbVcrRVhtSUFnNVl1OTRPV0l3UmxzeWYwREpNOVo4bnQKVFlLL25EaWZta2Z2cmsxcnpna1lKaFovR0cxOGxzbU9jeTZGWjBoMllVdFZOd2dLUnExbVVZRGFzbFF5VHdxbwpLSjlSZzZEeDhabnB0OTAvMGZES28vMVlhUzk0OG0wdG1PSXlVOHNrNGFNM2I3QkR3aDJWWUl2WUlsZDk3MEFzCjlWVlpHRTRyR2tWRDhMRjBYMnRjamw5bWRDdWo1T05BSDZIRzZhMXZLT1hLdUpHbm5QU0JiZDJxMThNMkNoZGgKN0FkMTRJYXo3OEN1MGhybHR0Z0VzNkcyS2ZMZnNCQ0UxSmxxMVNXM0pXcW5HVEY5Vmx6MVpibXlmNkdEU0JLUwp6aGpYZWM5T2N5emMvQmFVS2xUVWZ3Y3NoZ3dSSERCZjh3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE5EbGtObU0zTWpJdFpqVXpaUzAwWTJaakxUazRNMlF0TkdGbU9URTEKT1dRMlpUTTBMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5tS2Rod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJLRHhYODJHOWNqUmxvOVIxRHQrVjRGQ25LMkY0dnBXSUwxdU9mdDh1L2UxcG9CK0pxCjJKVHFhemV6TTEyZVAwR0YxUWFLTnZjUUY1YVlYTmxHdHk0OFRVRXZ1SEY1OGZuaGkwWVNPUC9kaDNQS1p3NGwKYkZrNFVWZHltb05PTHNTUklTVGRXbzV5T29DQVpqcGl0QUY4UGNZMWQvb1l4T2NwaU54YjFxSXA3L0Z0d3I1cApQQklnS0IxNERBb0pVWGtUTHIwWVZPZUNFQWhGUTUxSE5ZQTJmdjFXTVdaTGlmN3R2SThabjVqeXdFbEFlajBMCk43SWlzYVRzMnRIeDRlOEpsSkRlemJ2RTNLN2xKenVwdzNZcDZKU3pmL3hnM05Kb1orcEhHUzZmM3JXZm1GUUoKbWNNbDl2eFFrdUdWOUxlaDRvNzhIK3cyWk8xcW1vcXJNMXo4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:23 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80ed5aa0-f1e5-422a-9665-834a752a5d11
+      - 0c23ca40-43af-4c66-a741-70fc873e38f7
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:23 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0cf8d69-ca2a-41f8-a691-a9df59e01021
+      - 0816d6da-9157-4918-b6a4-77fc0dff532f
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/users
     method: POST
   response:
     body: '{"is_admin":true,"name":"foo"}'
     headers:
       Content-Length:
-      - "30"
+      - "31"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:23 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46481c28-8ae2-4443-bec2-b307ecae4144
+      - 60151530-6e46-4ba6-8b4b-906f7ccb0bdb
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:24 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e4bc8b2-4f4e-45b9-a638-55568871ec84
+      - 7a8cc31f-4934-4c38-917b-bc6263b67f7f
     status: 200 OK
     code: 200
     duration: ""
@@ -807,52 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "58"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:54:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 63811a6e-42ab-42ee-b75a-0d9ff987760b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "58"
+      - "60"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:24 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cd959ad-bce6-44d2-8e77-756e73a9fd0e
+      - 04d24cda-0375-4308-a1b7-432a0fe4f1a9
     status: 200 OK
     code: 200
     duration: ""
@@ -873,118 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1263"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:54:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 812284a6-60b1-46bc-b4aa-9f67e03b943c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVR1ducURFcUk0c2FnSGxWcFY4cUF1UFdWSmZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qQXdXaGNOTXpNeE1ETXdNVGcxTWpBd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1JOFhCSndVdnFBR2taT3MxNGwxcHN1MmRIdnlCUzJxNWNmQXlsOHpEeE1BMjVrM0tBTk1rUUcKUHowaTIreWwrOHBzNEtmUXdyT2VRVnh6Vm9nR2tMSDhUK0drRERvcEQwaFNPVUh5bDVtK2hiSW5KV2hPSjlHQwpnNHBjdVQ0NFNIMnVLb1hFR3pCMHRLbTZ6NllDT21MZGhVRGNsZkFBQ0Z1WUEwVDF3ZjRQNUtoTXBQR3BQL2tlCjJ4bHFwVUljN1prUzVrbWtPc2Jab2VYb05rM0F3QjUzaXFPTmRtRnhMbjVYeHgzMGd0K2UxamtPdHVqTUFwQ2wKTFFaQ01UY01hcmFsdlVxOElsNmhJcTBQb2tZSURteTYyL0RyZ3ZnREM3b0ZoK3VuNWtYWG5jNFo4TTVCSWNpdwptTWMvUzNlQ1hvNHVuWWIyWFc0WkEvZ2s5RG5YUDBNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TURoak1UVmhOR0l0TVdRMFpDMDBaak5rTFdGa1lUWXRNakV5TkdFek16UmgKTnpZeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDROWWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ2daaWNwU3lIQWlQSkdLcmxxNk90ZTRvUmY5T3lITXMrSGtyaUpuaHRwRU9rbXllVHoweWlkCjYrUWRxOUlSckNCbUxhQTZwWVJhRWNVNENVS1Rtb0JPYzBFdUptOTlBdlBvSFFXN3JnQnU1VjNZY0hUSHVlMWgKY1llTUkxYzMzZWp5OGFTdjZaZGFUaGdjeEFOdzQvajNJdUs0VTFNYVlNVmxlditkUHVHdDA0aWhkUEtyUkN4ZApSR1ZETWg2ZzFqdnpzQ05uQU5wMEM2QVNRN21SR1JtRllYZkVPMTJTWTNhdjVoZVhVbnNDY2VGWmdZR3NyWlltCitYVVh6a1JMVzFLc3lNY3k2RTJBaVJVaHJ4a2hXQVgyWVpId3BoSVE3QXJCQkNzaVUrMlpGN2JnYSthR0RIb0UKMmxZd1RFMVpZWjBsT3VPN21Mam1DTmlEaWdYTkJKZ2kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1843"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:54:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ee6ca65d-84da-4038-b9cb-84610d4c5dc9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1263"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:54:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 25fd4aff-c8d2-4e58-b1b8-42291110dc4f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "58"
+      - "60"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:25 GMT
+      - Thu, 16 Nov 2023 16:00:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c286e22d-9906-4bca-854a-d198c7822b5d
+      - 87d4f0e3-5054-4fe1-8a80-e94a61801cd9
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:25 GMT
+      - Thu, 16 Nov 2023 16:00:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0e04036-f356-41c8-807e-ea89a6d50563
+      - 71380427-0d27-40ac-93d2-bc22afa776eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVR1ducURFcUk0c2FnSGxWcFY4cUF1UFdWSmZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qQXdXaGNOTXpNeE1ETXdNVGcxTWpBd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1JOFhCSndVdnFBR2taT3MxNGwxcHN1MmRIdnlCUzJxNWNmQXlsOHpEeE1BMjVrM0tBTk1rUUcKUHowaTIreWwrOHBzNEtmUXdyT2VRVnh6Vm9nR2tMSDhUK0drRERvcEQwaFNPVUh5bDVtK2hiSW5KV2hPSjlHQwpnNHBjdVQ0NFNIMnVLb1hFR3pCMHRLbTZ6NllDT21MZGhVRGNsZkFBQ0Z1WUEwVDF3ZjRQNUtoTXBQR3BQL2tlCjJ4bHFwVUljN1prUzVrbWtPc2Jab2VYb05rM0F3QjUzaXFPTmRtRnhMbjVYeHgzMGd0K2UxamtPdHVqTUFwQ2wKTFFaQ01UY01hcmFsdlVxOElsNmhJcTBQb2tZSURteTYyL0RyZ3ZnREM3b0ZoK3VuNWtYWG5jNFo4TTVCSWNpdwptTWMvUzNlQ1hvNHVuWWIyWFc0WkEvZ2s5RG5YUDBNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TURoak1UVmhOR0l0TVdRMFpDMDBaak5rTFdGa1lUWXRNakV5TkdFek16UmgKTnpZeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDROWWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ2daaWNwU3lIQWlQSkdLcmxxNk90ZTRvUmY5T3lITXMrSGtyaUpuaHRwRU9rbXllVHoweWlkCjYrUWRxOUlSckNCbUxhQTZwWVJhRWNVNENVS1Rtb0JPYzBFdUptOTlBdlBvSFFXN3JnQnU1VjNZY0hUSHVlMWgKY1llTUkxYzMzZWp5OGFTdjZaZGFUaGdjeEFOdzQvajNJdUs0VTFNYVlNVmxlditkUHVHdDA0aWhkUEtyUkN4ZApSR1ZETWg2ZzFqdnpzQ05uQU5wMEM2QVNRN21SR1JtRllYZkVPMTJTWTNhdjVoZVhVbnNDY2VGWmdZR3NyWlltCitYVVh6a1JMVzFLc3lNY3k2RTJBaVJVaHJ4a2hXQVgyWVpId3BoSVE3QXJCQkNzaVUrMlpGN2JnYSthR0RIb0UKMmxZd1RFMVpZWjBsT3VPN21Mam1DTmlEaWdYTkJKZ2kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTZiYVoyelFFaWVTMFJvRkU2SkJaT25zUHdrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EQXhNRm9YRFRNek1URXhNekUyTURBeE1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNaUHV5MGZ0b3BqRm1seFQ0VTZrbVcrRVhtSUFnNVl1OTRPV0l3UmxzeWYwREpNOVo4bnQKVFlLL25EaWZta2Z2cmsxcnpna1lKaFovR0cxOGxzbU9jeTZGWjBoMllVdFZOd2dLUnExbVVZRGFzbFF5VHdxbwpLSjlSZzZEeDhabnB0OTAvMGZES28vMVlhUzk0OG0wdG1PSXlVOHNrNGFNM2I3QkR3aDJWWUl2WUlsZDk3MEFzCjlWVlpHRTRyR2tWRDhMRjBYMnRjamw5bWRDdWo1T05BSDZIRzZhMXZLT1hLdUpHbm5QU0JiZDJxMThNMkNoZGgKN0FkMTRJYXo3OEN1MGhybHR0Z0VzNkcyS2ZMZnNCQ0UxSmxxMVNXM0pXcW5HVEY5Vmx6MVpibXlmNkdEU0JLUwp6aGpYZWM5T2N5emMvQmFVS2xUVWZ3Y3NoZ3dSSERCZjh3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE5EbGtObU0zTWpJdFpqVXpaUzAwWTJaakxUazRNMlF0TkdGbU9URTEKT1dRMlpUTTBMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5tS2Rod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJLRHhYODJHOWNqUmxvOVIxRHQrVjRGQ25LMkY0dnBXSUwxdU9mdDh1L2UxcG9CK0pxCjJKVHFhemV6TTEyZVAwR0YxUWFLTnZjUUY1YVlYTmxHdHk0OFRVRXZ1SEY1OGZuaGkwWVNPUC9kaDNQS1p3NGwKYkZrNFVWZHltb05PTHNTUklTVGRXbzV5T29DQVpqcGl0QUY4UGNZMWQvb1l4T2NwaU54YjFxSXA3L0Z0d3I1cApQQklnS0IxNERBb0pVWGtUTHIwWVZPZUNFQWhGUTUxSE5ZQTJmdjFXTVdaTGlmN3R2SThabjVqeXdFbEFlajBMCk43SWlzYVRzMnRIeDRlOEpsSkRlemJ2RTNLN2xKenVwdzNZcDZKU3pmL3hnM05Kb1orcEhHUzZmM3JXZm1GUUoKbWNNbDl2eFFrdUdWOUxlaDRvNzhIK3cyWk8xcW1vcXJNMXo4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "1849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:25 GMT
+      - Thu, 16 Nov 2023 16:00:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74b5836d-7142-45af-ada4-bf1da663b115
+      - a99bf67c-10a6-4721-9cc7-c45b3ead62ab
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:25 GMT
+      - Thu, 16 Nov 2023 16:00:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9cccbf4-9c28-4bec-a0c3-d07a1245bdbd
+      - 3cb9c3a6-c1f6-4ed6-b311-210a34bea3db
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "58"
+      - "60"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:26 GMT
+      - Thu, 16 Nov 2023 16:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22147d25-9ae3-4537-b8bf-05831158b81c
+      - 20086c31-4962-401e-bfcf-07a624b78775
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:26 GMT
+      - Thu, 16 Nov 2023 16:01:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7089b9f4-793c-4e8d-8910-a4faa56c273b
+      - 760b1549-e3c6-4979-8ad8-b94fd8c078e2
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,7 +1137,139 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTZiYVoyelFFaWVTMFJvRkU2SkJaT25zUHdrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EQXhNRm9YRFRNek1URXhNekUyTURBeE1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNaUHV5MGZ0b3BqRm1seFQ0VTZrbVcrRVhtSUFnNVl1OTRPV0l3UmxzeWYwREpNOVo4bnQKVFlLL25EaWZta2Z2cmsxcnpna1lKaFovR0cxOGxzbU9jeTZGWjBoMllVdFZOd2dLUnExbVVZRGFzbFF5VHdxbwpLSjlSZzZEeDhabnB0OTAvMGZES28vMVlhUzk0OG0wdG1PSXlVOHNrNGFNM2I3QkR3aDJWWUl2WUlsZDk3MEFzCjlWVlpHRTRyR2tWRDhMRjBYMnRjamw5bWRDdWo1T05BSDZIRzZhMXZLT1hLdUpHbm5QU0JiZDJxMThNMkNoZGgKN0FkMTRJYXo3OEN1MGhybHR0Z0VzNkcyS2ZMZnNCQ0UxSmxxMVNXM0pXcW5HVEY5Vmx6MVpibXlmNkdEU0JLUwp6aGpYZWM5T2N5emMvQmFVS2xUVWZ3Y3NoZ3dSSERCZjh3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE5EbGtObU0zTWpJdFpqVXpaUzAwWTJaakxUazRNMlF0TkdGbU9URTEKT1dRMlpUTTBMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5tS2Rod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJLRHhYODJHOWNqUmxvOVIxRHQrVjRGQ25LMkY0dnBXSUwxdU9mdDh1L2UxcG9CK0pxCjJKVHFhemV6TTEyZVAwR0YxUWFLTnZjUUY1YVlYTmxHdHk0OFRVRXZ1SEY1OGZuaGkwWVNPUC9kaDNQS1p3NGwKYkZrNFVWZHltb05PTHNTUklTVGRXbzV5T29DQVpqcGl0QUY4UGNZMWQvb1l4T2NwaU54YjFxSXA3L0Z0d3I1cApQQklnS0IxNERBb0pVWGtUTHIwWVZPZUNFQWhGUTUxSE5ZQTJmdjFXTVdaTGlmN3R2SThabjVqeXdFbEFlajBMCk43SWlzYVRzMnRIeDRlOEpsSkRlemJ2RTNLN2xKenVwdzNZcDZKU3pmL3hnM05Kb1orcEhHUzZmM3JXZm1GUUoKbWNNbDl2eFFrdUdWOUxlaDRvNzhIK3cyWk8xcW1vcXJNMXo4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1849"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:01:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1878ce44-03bb-456f-a395-79d328759707
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1313"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:01:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0055b0a0-c3bf-4998-921f-21a3b88ed77c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "60"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:01:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9b4a8cf0-56f0-4500-b54d-d46627d1feb0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1313"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:01:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a3dbe797-0c80-401c-a735-9547e32886e6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/users/foo
     method: DELETE
   response:
     body: ""
@@ -1180,7 +1279,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:26 GMT
+      - Thu, 16 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 229ba6c6-e3a8-4b0b-a010-f142c0a3c1a7
+      - 7aac255f-7470-4e54-8015-cf3d384f7c72
     status: 204 No Content
     code: 204
     duration: ""
@@ -1201,19 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:27 GMT
+      - Thu, 16 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50863d72-94dc-49d8-98e1-6b5cb8d708ed
+      - 3a68f481-7a47-4ef0-9ac9-433effbe0247
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"bar"}'
     headers:
       Content-Length:
-      - "31"
+      - "32"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:27 GMT
+      - Thu, 16 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2eb86600-8b0c-4666-95b4-13411526c92a
+      - 55bbdec9-b2ce-416a-ac20-800200fb7b8c
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:27 GMT
+      - Thu, 16 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fef063f1-70b5-4c02-9870-578f9b0fa59a
+      - 718e9648-66c4-429d-ad75-6b6db6d8410f
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,52 +1401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=bar&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:54:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2c2bdc02-e19b-40c0-8908-9125d04f7f8d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=bar&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/users?name=bar&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:27 GMT
+      - Thu, 16 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a51b7d47-ed0b-49cd-8fd3-241beece5ca9
+      - 6689338a-9aef-43c5-b185-f1462699df1a
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,118 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1263"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:54:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eb53cdce-f0c8-480d-aa16-621773fb41c9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVR1ducURFcUk0c2FnSGxWcFY4cUF1UFdWSmZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qTXhNVEF5TVRnMU1qQXdXaGNOTXpNeE1ETXdNVGcxTWpBd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1JOFhCSndVdnFBR2taT3MxNGwxcHN1MmRIdnlCUzJxNWNmQXlsOHpEeE1BMjVrM0tBTk1rUUcKUHowaTIreWwrOHBzNEtmUXdyT2VRVnh6Vm9nR2tMSDhUK0drRERvcEQwaFNPVUh5bDVtK2hiSW5KV2hPSjlHQwpnNHBjdVQ0NFNIMnVLb1hFR3pCMHRLbTZ6NllDT21MZGhVRGNsZkFBQ0Z1WUEwVDF3ZjRQNUtoTXBQR3BQL2tlCjJ4bHFwVUljN1prUzVrbWtPc2Jab2VYb05rM0F3QjUzaXFPTmRtRnhMbjVYeHgzMGd0K2UxamtPdHVqTUFwQ2wKTFFaQ01UY01hcmFsdlVxOElsNmhJcTBQb2tZSURteTYyL0RyZ3ZnREM3b0ZoK3VuNWtYWG5jNFo4TTVCSWNpdwptTWMvUzNlQ1hvNHVuWWIyWFc0WkEvZ2s5RG5YUDBNQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakV3TGpJeE00SThjbmN0TURoak1UVmhOR0l0TVdRMFpDMDBaak5rTFdGa1lUWXRNakV5TkdFek16UmgKTnpZeUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6RDROWWh3UXpud3JWTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ2daaWNwU3lIQWlQSkdLcmxxNk90ZTRvUmY5T3lITXMrSGtyaUpuaHRwRU9rbXllVHoweWlkCjYrUWRxOUlSckNCbUxhQTZwWVJhRWNVNENVS1Rtb0JPYzBFdUptOTlBdlBvSFFXN3JnQnU1VjNZY0hUSHVlMWgKY1llTUkxYzMzZWp5OGFTdjZaZGFUaGdjeEFOdzQvajNJdUs0VTFNYVlNVmxlditkUHVHdDA0aWhkUEtyUkN4ZApSR1ZETWg2ZzFqdnpzQ05uQU5wMEM2QVNRN21SR1JtRllYZkVPMTJTWTNhdjVoZVhVbnNDY2VGWmdZR3NyWlltCitYVVh6a1JMVzFLc3lNY3k2RTJBaVJVaHJ4a2hXQVgyWVpId3BoSVE3QXJCQkNzaVUrMlpGN2JnYSthR0RIb0UKMmxZd1RFMVpZWjBsT3VPN21Mam1DTmlEaWdYTkJKZ2kKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1843"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:54:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aa2db832-ab6b-4591-ba74-28b1d3942aa3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1263"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 18:54:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 410069b5-6080-48d6-ab23-0129d809d7fa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users?name=bar&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/users?name=bar&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
     headers:
       Content-Length:
-      - "59"
+      - "61"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:28 GMT
+      - Thu, 16 Nov 2023 16:01:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ea86754-0000-4fc0-87ba-9e9adb2ccf36
+      - 77327bba-616e-4914-b134-162cd3ae307b
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:28 GMT
+      - Thu, 16 Nov 2023 16:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cce5a100-4c3d-4cd5-acf8-d609999522bb
+      - 0fb6edae-b3fe-44fe-8813-2e9158e51730
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,7 +1500,139 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762/users/bar
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSTZiYVoyelFFaWVTMFJvRkU2SkJaT25zUHdrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEV4TmpFMk1EQXhNRm9YRFRNek1URXhNekUyTURBeE1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXNaUHV5MGZ0b3BqRm1seFQ0VTZrbVcrRVhtSUFnNVl1OTRPV0l3UmxzeWYwREpNOVo4bnQKVFlLL25EaWZta2Z2cmsxcnpna1lKaFovR0cxOGxzbU9jeTZGWjBoMllVdFZOd2dLUnExbVVZRGFzbFF5VHdxbwpLSjlSZzZEeDhabnB0OTAvMGZES28vMVlhUzk0OG0wdG1PSXlVOHNrNGFNM2I3QkR3aDJWWUl2WUlsZDk3MEFzCjlWVlpHRTRyR2tWRDhMRjBYMnRjamw5bWRDdWo1T05BSDZIRzZhMXZLT1hLdUpHbm5QU0JiZDJxMThNMkNoZGgKN0FkMTRJYXo3OEN1MGhybHR0Z0VzNkcyS2ZMZnNCQ0UxSmxxMVNXM0pXcW5HVEY5Vmx6MVpibXlmNkdEU0JLUwp6aGpYZWM5T2N5emMvQmFVS2xUVWZ3Y3NoZ3dSSERCZjh3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGt1TVRFekxqRTNNNEk4Y25jdE5EbGtObU0zTWpJdFpqVXpaUzAwWTJaakxUazRNMlF0TkdGbU9URTEKT1dRMlpUTTBMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5tS2Rod1F6bjNHdE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJLRHhYODJHOWNqUmxvOVIxRHQrVjRGQ25LMkY0dnBXSUwxdU9mdDh1L2UxcG9CK0pxCjJKVHFhemV6TTEyZVAwR0YxUWFLTnZjUUY1YVlYTmxHdHk0OFRVRXZ1SEY1OGZuaGkwWVNPUC9kaDNQS1p3NGwKYkZrNFVWZHltb05PTHNTUklTVGRXbzV5T29DQVpqcGl0QUY4UGNZMWQvb1l4T2NwaU54YjFxSXA3L0Z0d3I1cApQQklnS0IxNERBb0pVWGtUTHIwWVZPZUNFQWhGUTUxSE5ZQTJmdjFXTVdaTGlmN3R2SThabjVqeXdFbEFlajBMCk43SWlzYVRzMnRIeDRlOEpsSkRlemJ2RTNLN2xKenVwdzNZcDZKU3pmL3hnM05Kb1orcEhHUzZmM3JXZm1GUUoKbWNNbDl2eFFrdUdWOUxlaDRvNzhIK3cyWk8xcW1vcXJNMXo4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1849"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:01:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2ca18c1d-422c-4fbd-8ebf-26126f6c6e02
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1313"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:01:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a41bd18a-7633-47c1-9517-42e1fc107740
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/users?name=bar&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
+    headers:
+      Content-Length:
+      - "61"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:01:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - adf429fc-dc86-4cb3-9c40-4c2c3a578036
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1313"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Nov 2023 16:01:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 39d4cc4f-fe63-4e07-88cb-cab1d0a2167a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34/users/bar
     method: DELETE
   response:
     body: ""
@@ -1543,7 +1642,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:29 GMT
+      - Thu, 16 Nov 2023 16:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1553,7 +1652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 845a8847-c00b-405f-8bbc-a0b9b508edd3
+      - 55fe5a96-6dc7-43ec-a443-050075067b3b
     status: 204 No Content
     code: 204
     duration: ""
@@ -1564,19 +1663,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:29 GMT
+      - Thu, 16 Nov 2023 16:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1586,7 +1685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a8b6f1b-85fd-45a3-8fdb-ffd6a954e053
+      - 7abe02d8-096f-4c59-90c0-dfde3b7b35eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,19 +1696,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1316"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:29 GMT
+      - Thu, 16 Nov 2023 16:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1619,7 +1718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e336d0ef-f20e-4435-adb8-831d202d6ca2
+      - e808413a-0b2f-4834-bd70-b4d68df4da1c
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,19 +1729,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-03T18:51:20.930539Z","retention":7},"created_at":"2023-11-02T18:51:20.930539Z","endpoint":{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702},"endpoints":[{"id":"633cffed-e2f5-42f6-bcbd-bbb7fc021436","ip":"51.159.10.213","load_balancer":{},"name":null,"port":24702}],"engine":"PostgreSQL-15","id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-17T15:56:20.898913Z","retention":7},"created_at":"2023-11-16T15:56:20.898913Z","endpoint":{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274},"endpoints":[{"id":"91ca07de-28fa-4b9d-84ec-20f6283b1a69","ip":"51.159.113.173","load_balancer":{},"name":null,"port":22274}],"engine":"PostgreSQL-15","id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1316"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:54:29 GMT
+      - Thu, 16 Nov 2023 16:01:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1652,7 +1751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a123b506-e191-4a98-865c-13e7daafa76b
+      - f2060c46-e7e0-4d66-8b36-3ae6d0390927
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,10 +1762,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1675,7 +1774,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:00 GMT
+      - Thu, 16 Nov 2023 16:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1685,7 +1784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9775f1c-6757-4102-b36c-a89e9fec8bc6
+      - 076e968c-f1d4-4551-96dc-210af927e1d8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1696,10 +1795,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/08c15a4b-1d4d-4f3d-ada6-2124a334a762
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/49d6c722-f53e-4cfc-983d-4af9159d6e34
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"08c15a4b-1d4d-4f3d-ada6-2124a334a762","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"49d6c722-f53e-4cfc-983d-4af9159d6e34","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1708,7 +1807,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 18:55:00 GMT
+      - Thu, 16 Nov 2023 16:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1718,7 +1817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ac8e397-7483-4b6a-8bb9-9523d7623a35
+      - 58d4a87a-3689-4cf8-83dc-c94941a0eabe
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
This PR replaces usage of deprecated package `ioutil` by `io` and `resource` by `retry`.

The only deprecated elements left in the rdb area are the `endpoint_ip` and `endpoint_port` fields (because instance.Endpoint is deprecated in the rdb API), should they be removed now also ?

EDIT: just noticed that there already was an issue open for this particular topic (#1377) so this belongs in another PR.