### PR TITLE
docs(s3): remove `skip_requesting_account_id` option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -238,7 +238,6 @@ terraform {
     secret_key                  = "my-secret-key"
     skip_credentials_validation = true
     skip_region_validation      = true
-    skip_requesting_account_id  = true
   }
 }
 ```


### PR DESCRIPTION
`skip_requesting_account_id` is deprecated and unusable.

```
Initializing the backend...
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 13, in terraform:
│   13:     skip_requesting_account_id  = true
│ 
│ An argument named "skip_requesting_account_id" is not expected here.
|
```