### PR TITLE
fix(k8s): check status before returning error

### DIFF
--- a/scaleway/helpers_k8s.go
+++ b/scaleway/helpers_k8s.go
@@ -124,7 +124,10 @@ func waitK8SClusterDeleted(ctx context.Context, k8sAPI *k8s.API, region scw.Regi
 		return err
 	}
 
-	return fmt.Errorf("cluster %s has state %s, wants %s", clusterID, cluster.Status, k8s.ClusterStatusDeleted)
+	if cluster.Status != k8s.ClusterStatusDeleted {
+		return fmt.Errorf("cluster %s has state %s, wants %s", clusterID, cluster.Status, k8s.ClusterStatusDeleted)
+	}
+	return nil
 }
 
 func waitK8SPoolReady(ctx context.Context, k8sAPI *k8s.API, region scw.Region, poolID string, timeout time.Duration) (*k8s.Pool, error) {


### PR DESCRIPTION
The k8s nightly tests currently fail with the error message `cluster xxx-xx-xxx has state deleted, wants deleted` because the only way to exit the waitK8SClusterDeleted function without an error is with a 404. But sometimes the cluster has state `deleted` but does not return a 404 right away, prompting this error message.
This can be fixed by checking the status before returning the error.