### PR TITLE
fix(dom): update DNS record with dynamic data

### DIFF
--- a/scaleway/testdata/data-source-domain-record-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-domain-record-basic.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"1.2.3.4","name":"www","priority":10,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"1.2.3.4","name":"www","priority":10,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}]}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}]}'
     headers:
       Content-Length:
-      - "146"
+      - "140"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 298e3167-b5a3-41e1-b22d-81444f3c30f1
+      - 9754942f-083d-43e6-bf85-9d56cf62e7a7
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?name=www&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c6483e0-d35a-4735-8c32-ce64707b17b9
+      - f6685c4c-96e9-41a0-8525-bf453de4e7e8
     status: 200 OK
     code: 200
     duration: ""
@@ -74,21 +74,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?name=www&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d1582b9-dfbe-4d4f-87b8-eea756620c61
+      - 38147f56-1c64-42a8-b6a4-d70a69bfba45
     status: 200 OK
     code: 200
     duration: ""
@@ -107,21 +107,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=74de908b-b0b5-4241-a4b7-909427dfdb01&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=141bad98-358f-45c8-8e5e-06198781f375&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec6f0e22-2a4b-4c70-ab0e-209ec32d289c
+      - f8ae5600-c236-43eb-9370-2e750c1c1d24
     status: 200 OK
     code: 200
     duration: ""
@@ -140,21 +140,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af44c0df-9c65-462b-87b2-41a3b851a368
+      - fe205f06-738e-482c-b67b-7ce269d7f0bc
     status: 200 OK
     code: 200
     duration: ""
@@ -173,21 +173,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=74de908b-b0b5-4241-a4b7-909427dfdb01&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=141bad98-358f-45c8-8e5e-06198781f375&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9e7874e-964a-4dbc-96dc-82906065cfa3
+      - 69c0dc7c-9338-4aa1-9992-5deaacd68a53
     status: 200 OK
     code: 200
     duration: ""
@@ -206,21 +206,54 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "358"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b05ab6ff-4a70-43bc-92a3-71af559009ca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?name=www&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f194eabe-00e1-48fd-a656-c6cce97085a1
+      - c50f2d1f-d31f-4584-9e06-175df15a7e8d
     status: 200 OK
     code: 200
     duration: ""
@@ -239,21 +272,54 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=141bad98-358f-45c8-8e5e-06198781f375&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "156"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85594ae7-46b1-490b-934a-8fa446c3a7e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -263,7 +329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ecc70ae-d3a2-4e65-8bcb-d5e9388198bb
+      - c0067f0a-e208-45ad-8dbf-0a5bd5d7f99a
     status: 200 OK
     code: 200
     duration: ""
@@ -272,87 +338,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=74de908b-b0b5-4241-a4b7-909427dfdb01&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "163"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 42a5d48e-3796-4875-90e2-decd9a7dc54d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "348"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a8b4a777-1797-4e61-afb6-6bb0cb36b62d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"8bd83e1f-6c70-4222-bc77-53ef483c4098","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"380b8703-415d-4a43-a228-40abafbb3a73","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"533cc69d-cc8c-4d6d-b35d-9f8ce1e97120","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"84a90cce-8154-4328-917e-c36652a40251","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":3}'
     headers:
       Content-Length:
-      - "447"
+      - "426"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -362,7 +362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00677cc3-5644-43d5-8b2d-2c350b90ad8b
+      - 2cf588cc-3ca0-41a0-9b48-dea5a0230a22
     status: 200 OK
     code: 200
     duration: ""
@@ -371,21 +371,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"8bd83e1f-6c70-4222-bc77-53ef483c4098","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"380b8703-415d-4a43-a228-40abafbb3a73","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"533cc69d-cc8c-4d6d-b35d-9f8ce1e97120","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"84a90cce-8154-4328-917e-c36652a40251","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":3}'
     headers:
       Content-Length:
-      - "447"
+      - "426"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -395,7 +395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13bc6e73-7165-4f55-be45-cf7609783078
+      - 28da0d9c-0d9b-45e4-b0a5-5833b3aaac97
     status: 200 OK
     code: 200
     duration: ""
@@ -404,21 +404,87 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=141bad98-358f-45c8-8e5e-06198781f375&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "156"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c75a188f-8c5f-4a4d-af24-99c8403fadc6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "358"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a8a76200-4d32-45b8-bf1a-7a6521a0c2e4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?name=www&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -428,7 +494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 302d982f-ae11-4146-87a7-8c842b28651d
+      - 322d9eeb-cfad-40d0-af8d-3dfde6c091de
     status: 200 OK
     code: 200
     duration: ""
@@ -437,21 +503,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=74de908b-b0b5-4241-a4b7-909427dfdb01&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=141bad98-358f-45c8-8e5e-06198781f375&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -461,7 +527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32ee192b-3c92-4949-9330-621f11ce0353
+      - ba83c718-b65a-44ea-98df-e29d35a57766
     status: 200 OK
     code: 200
     duration: ""
@@ -470,54 +536,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=74de908b-b0b5-4241-a4b7-909427dfdb01&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "163"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a5408439-bec5-4e7d-b79a-a8e50dd917db
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -527,7 +560,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e6d17ea-a77b-4c81-b436-f33c91945ab2
+      - 669518dd-f970-4096-a81f-27fbe19da057
     status: 200 OK
     code: 200
     duration: ""
@@ -536,21 +569,54 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=141bad98-358f-45c8-8e5e-06198781f375&name=www&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "156"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ebaba0d7-3986-433b-a849-2e55710f6f90
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -560,7 +626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4261ecd-cae8-48b5-8bd1-ca7347d33602
+      - 9b3c7254-2712-4077-bb5a-689880a9655b
     status: 200 OK
     code: 200
     duration: ""
@@ -569,21 +635,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=74de908b-b0b5-4241-a4b7-909427dfdb01&name=www&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=141bad98-358f-45c8-8e5e-06198781f375&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -593,7 +659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fc12467-a662-40e5-a9bb-2e568df00cc1
+      - 81602589-1201-4065-974e-8999844ff9c4
     status: 200 OK
     code: 200
     duration: ""
@@ -602,54 +668,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "348"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0a3a39a4-08ba-458c-ba1f-35d439192fc5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?name=www&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -659,7 +692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fdfb114-236e-41f8-a8b4-9ced04145457
+      - 8563e05e-fa15-4ced-b268-73ec9c6608d4
     status: 200 OK
     code: 200
     duration: ""
@@ -668,87 +701,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=74de908b-b0b5-4241-a4b7-909427dfdb01&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "163"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9ce2d70d-c164-4df1-80d7-d5d285dda543
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=74de908b-b0b5-4241-a4b7-909427dfdb01&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "163"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 49122987-0caa-4f76-902a-099678d11361
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -758,7 +725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10db4937-25bb-4a2d-8f1a-7b0f75592aab
+      - e7f3ef2f-f784-45ac-a3bb-fe431c26d1c3
     status: 200 OK
     code: 200
     duration: ""
@@ -767,21 +734,54 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=141bad98-358f-45c8-8e5e-06198781f375&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "156"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7f329e30-4af5-4e32-87f7-280b19f5962f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -791,7 +791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc722047-d7e8-481a-91d2-daddd8577a41
+      - 0fb05aa5-88a9-4868-acbd-57b3f78ab75a
     status: 200 OK
     code: 200
     duration: ""
@@ -800,21 +800,54 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=141bad98-358f-45c8-8e5e-06198781f375&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "156"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 53a9ae8a-23bc-43b3-b396-197f795b5bc4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?name=www&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -824,7 +857,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4866d472-c4f2-42b6-bcb9-c7303184dbd4
+      - 633e62dc-9e7c-4cc5-981d-b803e018e80d
     status: 200 OK
     code: 200
     duration: ""
@@ -833,54 +866,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=74de908b-b0b5-4241-a4b7-909427dfdb01&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "163"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7e778415-38f9-4771-a220-3d902a6ba4f5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -890,7 +890,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fb50b6e-fea1-4612-b353-f7d23e731e46
+      - 02c30ca8-72f7-4a25-abbd-baef84cdac95
     status: 200 OK
     code: 200
     duration: ""
@@ -899,21 +899,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=74de908b-b0b5-4241-a4b7-909427dfdb01&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=141bad98-358f-45c8-8e5e-06198781f375&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -923,7 +923,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 555045e0-a900-4d7e-a4d6-ae0d8bdd589a
+      - 95c11100-45a9-496f-9d91-2931cc071859
     status: 200 OK
     code: 200
     duration: ""
@@ -932,87 +932,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "348"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 602f2ae7-bf3b-45d2-98c7-1fd557f18eaa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=74de908b-b0b5-4241-a4b7-909427dfdb01&name=www&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"74de908b-b0b5-4241-a4b7-909427dfdb01","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "163"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 73f8922e-7d70-418b-8ad2-1e4f0310dba5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1022,18 +956,84 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e937a25-e06a-4689-994c-e4bd2eaeeaed
+      - b23e01c2-fdbf-42b3-88f3-ff901304043c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"74de908b-b0b5-4241-a4b7-909427dfdb01"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?id=141bad98-358f-45c8-8e5e-06198781f375&name=www&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"141bad98-358f-45c8-8e5e-06198781f375","name":"www","priority":10,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "156"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 26e383cb-ede2-432c-b459-3273b8c3cfa9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "358"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b919d386-89c7-47c8-aa38-a5fd57d27210
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"delete":{"id":"141bad98-358f-45c8-8e5e-06198781f375"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records
     method: PATCH
@@ -1047,7 +1047,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1057,7 +1057,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f26402e8-7ba8-48c7-a0a4-6a107e4c6df5
+      - fbadbcf9-2506-49e5-8371-92e7b7357202
     status: 200 OK
     code: 200
     duration: ""
@@ -1066,21 +1066,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"8bd83e1f-6c70-4222-bc77-53ef483c4098","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"380b8703-415d-4a43-a228-40abafbb3a73","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"533cc69d-cc8c-4d6d-b35d-9f8ce1e97120","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"84a90cce-8154-4328-917e-c36652a40251","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1090,7 +1090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f2e2012-e89c-4a94-ac95-5d6f69f40dfc
+      - 5af1c002-dda7-44d4-bb5f-d21943cdf39a
     status: 200 OK
     code: 200
     duration: ""
@@ -1099,21 +1099,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:40Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:07Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1123,32 +1123,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d95375f0-e0c7-4289-952a-738b3ccae730
+      - 0445980d-172d-4ba8-be36-af2503e72e13
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"1.2.3.4","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A","comment":null,"geo_ip_config":{"matches":[{"countries":["FR"],"continents":["EU"],"data":"1.2.3.4"},{"countries":[],"continents":["NA"],"data":"1.2.3.5"}],"default":"1.2.3.4"},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"1.2.3.4","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A","comment":null,"geo_ip_config":{"matches":[{"countries":["FR"],"continents":["EU"],"data":"1.2.3.4"},{"countries":[],"continents":["NA"],"data":"1.2.3.5"}],"default":"1.2.3.4"},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}]}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"a13fe8f4-38ad-48a8-a33d-42458e06b8fd","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}]}'
     headers:
       Content-Length:
-      - "320"
+      - "307"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1158,7 +1158,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 328b042b-6f56-4783-9fed-81e7f4e49f34
+      - 72dbb1fa-0a6d-4a3c-a798-5b8ff27448f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1167,21 +1167,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?name=tf_geo_ip&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"a13fe8f4-38ad-48a8-a33d-42458e06b8fd","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "337"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1191,7 +1191,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22d411c6-2d31-4449-8e11-02c10e015949
+      - 4001078a-553b-471d-b505-cdc1586f8f1b
     status: 200 OK
     code: 200
     duration: ""
@@ -1200,21 +1200,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?name=tf_geo_ip&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"a13fe8f4-38ad-48a8-a33d-42458e06b8fd","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "337"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1224,7 +1224,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a679aaa-1aa0-429c-92ae-403e3f9b7943
+      - 90d556fa-de63-4a8e-827e-f88468726cf6
     status: 200 OK
     code: 200
     duration: ""
@@ -1233,21 +1233,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=a13fe8f4-38ad-48a8-a33d-42458e06b8fd&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"a13fe8f4-38ad-48a8-a33d-42458e06b8fd","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "337"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1257,7 +1257,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 139c8e71-e386-4642-b028-3e6e271ab79c
+      - aea5a4b2-b800-4828-832f-a95bb6200a1a
     status: 200 OK
     code: 200
     duration: ""
@@ -1266,87 +1266,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-geo-ip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-geo-ip","updated_at":"2023-07-28T09:33:41Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "355"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dbe25f09-ae79-40ac-bdae-8bb1a4354a57
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "337"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6740dee5-bff5-47ed-a6a8-0052d7b4cac1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-geo-ip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-07-28T09:33:41Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-geo-ip","updated_at":"2023-12-14T12:43:07Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "354"
+      - "365"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1356,7 +1290,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79f3a9f6-9e50-4f57-9663-f50db541927e
+      - 804084be-9576-45b1-8006-1164ce328405
     status: 200 OK
     code: 200
     duration: ""
@@ -1365,21 +1299,87 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=a13fe8f4-38ad-48a8-a33d-42458e06b8fd&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"a13fe8f4-38ad-48a8-a33d-42458e06b8fd","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "323"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a1b5adc5-e4af-4a55-a04d-fff68f106a04
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-geo-ip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-geo-ip","updated_at":"2023-12-14T12:43:07Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "365"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bee96e99-960d-4532-a857-71d5957c20cc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source","updated_at":"2023-07-28T09:33:42Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:07Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "347"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1389,7 +1389,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ab5dcbd-3e6f-4108-b0d7-6a5891f029d2
+      - 0b06254f-17f8-468c-aaa7-1af699d92951
     status: 200 OK
     code: 200
     duration: ""
@@ -1398,7 +1398,40 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source","updated_at":"2023-12-14T12:43:14Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "357"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2c307b20-de6a-4963-ad63-50017633179a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -1412,7 +1445,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1422,7 +1455,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 731f7ef1-2a01-43da-a2cd-39ef45546f84
+      - 7fffffb7-c59d-4074-8f4c-06b74340b667
     status: 200 OK
     code: 200
     duration: ""
@@ -1431,21 +1464,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"cab5d368-23d9-4e2e-b26d-581dddf804cb","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"e2338abd-fa2b-48cf-834f-2e84c5aff306","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"e221dffc-c3b9-44c4-aa25-9418bff5d734","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"992aef55-af12-4c48-9a80-c326cf18bc3a","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"a13fe8f4-38ad-48a8-a33d-42458e06b8fd","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
     headers:
       Content-Length:
-      - "621"
+      - "593"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1455,7 +1488,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffa13e2c-85c6-472e-944d-fdf6f643fbb5
+      - e067f639-c476-4689-be17-1170ba522a28
     status: 200 OK
     code: 200
     duration: ""
@@ -1464,21 +1497,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=a13fe8f4-38ad-48a8-a33d-42458e06b8fd&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"a13fe8f4-38ad-48a8-a33d-42458e06b8fd","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "337"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:47 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1488,7 +1521,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ca78c60-8650-4f2f-a041-839706c53258
+      - e87dd2a5-1fe2-40cb-9db2-f92c4b9acb80
     status: 200 OK
     code: 200
     duration: ""
@@ -1497,87 +1530,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-geo-ip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-07-28T09:33:42Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "354"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2f697f7e-6944-496d-b0f5-9846dbfbd92d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3&name=tf_geo_ip&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "337"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ecf4b3ad-eddc-4416-8729-7fe490436657
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-geo-ip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-07-28T09:33:42Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-12-14T12:43:14Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "354"
+      - "364"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:47 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1587,7 +1554,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea69df3a-5ad6-4e8b-b9b4-16e880bc4dc8
+      - cf158eac-97a3-4476-bd0b-bf12ee286983
     status: 200 OK
     code: 200
     duration: ""
@@ -1596,21 +1563,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=a13fe8f4-38ad-48a8-a33d-42458e06b8fd&name=tf_geo_ip&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"a13fe8f4-38ad-48a8-a33d-42458e06b8fd","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "337"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:47 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1620,7 +1587,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28caadaf-eef6-4cd7-8cff-58504cc0a9e3
+      - 000cfd9e-6d58-4999-8ad7-1ce3b669f004
     status: 200 OK
     code: 200
     duration: ""
@@ -1629,87 +1596,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-geo-ip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-07-28T09:33:42Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "354"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d331b3f2-baf1-4c12-9472-3a5db0fa48bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "337"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 206dbf74-c86f-4609-9c1b-897a98cd32f5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-geo-ip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-07-28T09:33:42Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-12-14T12:43:14Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "354"
+      - "364"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:48 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1719,7 +1620,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a39ce6cb-5483-425b-bf15-533008f56307
+      - f2e6cbfd-8b2d-404d-86de-3707dc3b40db
     status: 200 OK
     code: 200
     duration: ""
@@ -1728,21 +1629,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3&name=tf_geo_ip&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=a13fe8f4-38ad-48a8-a33d-42458e06b8fd&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"a13fe8f4-38ad-48a8-a33d-42458e06b8fd","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "337"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:48 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1752,7 +1653,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2888b91-6eeb-4470-b27d-01df365307db
+      - adc39262-3f8e-41ea-8607-e9d838fb9908
     status: 200 OK
     code: 200
     duration: ""
@@ -1761,21 +1662,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-geo-ip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-07-28T09:33:42Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-12-14T12:43:14Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "354"
+      - "364"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:48 GMT
+      - Thu, 14 Dec 2023 12:43:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1785,18 +1686,150 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c649534-bd6f-4934-8843-52fd19227286
+      - e1644161-810a-42af-86c8-a29a3705660a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"d4a53cdc-63c4-45e2-8c1a-353fcf1f8bd3"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=a13fe8f4-38ad-48a8-a33d-42458e06b8fd&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"a13fe8f4-38ad-48a8-a33d-42458e06b8fd","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "323"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e3c49cf1-9588-4928-8a94-c704817d1866
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-geo-ip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-12-14T12:43:14Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "364"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 267b4e3f-485b-477a-ad53-68beca88e724
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?id=a13fe8f4-38ad-48a8-a33d-42458e06b8fd&name=tf_geo_ip&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","geo_ip_config":{"default":"1.2.3.4","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"a13fe8f4-38ad-48a8-a33d-42458e06b8fd","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "323"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 071af218-ec85-405c-9259-f9090c86a790
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-geo-ip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-12-14T12:43:14Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "364"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c42a19e8-d3db-4f76-a865-4dd955d5dc62
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"delete":{"id":"a13fe8f4-38ad-48a8-a33d-42458e06b8fd"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records
     method: PATCH
@@ -1810,7 +1843,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1820,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4955a526-1281-43ac-881b-bb1c54dc988b
+      - adcd1601-04f8-4c52-a0cc-719906977ce8
     status: 200 OK
     code: 200
     duration: ""
@@ -1829,21 +1862,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"cab5d368-23d9-4e2e-b26d-581dddf804cb","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"e2338abd-fa2b-48cf-834f-2e84c5aff306","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"e221dffc-c3b9-44c4-aa25-9418bff5d734","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"992aef55-af12-4c48-9a80-c326cf18bc3a","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1853,7 +1886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fbec674-4232-455d-a14f-550095a48935
+      - 992e588e-430e-43e1-b6a2-b00468a30d13
     status: 200 OK
     code: 200
     duration: ""
@@ -1862,21 +1895,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-geo-ip.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-geo-ip","updated_at":"2023-07-28T09:33:49Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-geo-ip","updated_at":"2023-12-14T12:43:20Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "355"
+      - "365"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1886,32 +1919,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7eb9c327-40ff-4eb9-9088-436f46cbd914
+      - 96f0cdaf-7624-4bce-a521-cfe6f4cbae9d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"1.2.3.4","name":"tf_http_service","priority":0,"ttl":3600,"type":"A","comment":null,"http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","url":"http://mywebsite.com/health","user_agent":"scw_service_up","strategy":"hashed"},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"1.2.3.4","name":"tf_http_service","priority":0,"ttl":3600,"type":"A","comment":null,"http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","url":"http://mywebsite.com/health","user_agent":"scw_service_up","strategy":"hashed"},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"84f393b4-8e38-463f-a609-787eec5f2c00","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}]}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"3000e156-a932-4525-a592-dd07885d1958","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}]}'
     headers:
       Content-Length:
-      - "321"
+      - "309"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10e101dc-7790-4fb2-93dd-899777c22065
+      - f1aa3c1c-77be-4525-843a-19824def0437
     status: 200 OK
     code: 200
     duration: ""
@@ -1930,21 +1963,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?name=tf_http_service&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"84f393b4-8e38-463f-a609-787eec5f2c00","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"3000e156-a932-4525-a592-dd07885d1958","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "338"
+      - "325"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f102924-cafc-4463-a876-c04ea029eba3
+      - 7d26faf6-4d64-4951-8f30-2dea9db314a0
     status: 200 OK
     code: 200
     duration: ""
@@ -1963,21 +1996,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?name=tf_http_service&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"84f393b4-8e38-463f-a609-787eec5f2c00","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"3000e156-a932-4525-a592-dd07885d1958","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "338"
+      - "325"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95059cdf-119e-439c-b8b9-498a247b8bc0
+      - 447797d6-7098-40dc-9e04-3cccf632dec3
     status: 200 OK
     code: 200
     duration: ""
@@ -1996,21 +2029,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=84f393b4-8e38-463f-a609-787eec5f2c00&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=3000e156-a932-4525-a592-dd07885d1958&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"84f393b4-8e38-463f-a609-787eec5f2c00","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"3000e156-a932-4525-a592-dd07885d1958","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "338"
+      - "325"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:50 GMT
+      - Thu, 14 Dec 2023 12:43:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2607ce8-547d-4ccb-9516-104e2f26410c
+      - 51f36d51-a1c1-4b9b-80dc-903385c6ce4f
     status: 200 OK
     code: 200
     duration: ""
@@ -2029,87 +2062,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-http-service","updated_at":"2023-07-28T09:33:49Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "361"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 07434445-4dbd-4091-a1b6-c8bee3d842cc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=84f393b4-8e38-463f-a609-787eec5f2c00&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"84f393b4-8e38-463f-a609-787eec5f2c00","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "338"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a32457e0-4190-4089-b2d5-e0950e893f13
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-http-service","updated_at":"2023-07-28T09:33:49Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-http-service","updated_at":"2023-12-14T12:43:20Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "361"
+      - "371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:50 GMT
+      - Thu, 14 Dec 2023 12:43:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a9cce91-29f2-4bcd-9eb4-56ca5d13f34e
+      - ae90ce05-f0da-429e-82de-ab92ccc4df33
     status: 200 OK
     code: 200
     duration: ""
@@ -2128,21 +2095,87 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=3000e156-a932-4525-a592-dd07885d1958&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"3000e156-a932-4525-a592-dd07885d1958","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "325"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1fbfb4d3-6f37-48c0-8122-f46158f7a692
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-http-service","updated_at":"2023-12-14T12:43:20Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "371"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f3127855-b475-4e9e-80d5-fe96d09a727b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-geo-ip.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-07-28T09:33:52Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-geo-ip","updated_at":"2023-12-14T12:43:25Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "354"
+      - "364"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:54 GMT
+      - Thu, 14 Dec 2023 12:43:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 896370dc-7103-43c7-8b02-52b8f8851099
+      - 132f0e1e-faed-4d1d-983d-d9732c84629b
     status: 200 OK
     code: 200
     duration: ""
@@ -2161,7 +2194,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-geo-ip.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -2175,7 +2208,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:54 GMT
+      - Thu, 14 Dec 2023 12:43:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f95d2626-a228-4d12-83e0-ab657ee22387
+      - ffd85768-3706-4a20-a2fa-9e67b4ec1834
     status: 200 OK
     code: 200
     duration: ""
@@ -2194,21 +2227,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"8d90d692-f874-474d-8b66-6c09ab1f9e39","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"786a767c-3a01-43d1-ad23-78bb5fcf8536","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"84f393b4-8e38-463f-a609-787eec5f2c00","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"80384d72-b129-4c82-894f-b2a6260ae428","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"c3b7f822-85c2-4829-b757-e007d3a79f33","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"3000e156-a932-4525-a592-dd07885d1958","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
     headers:
       Content-Length:
-      - "622"
+      - "595"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:55 GMT
+      - Thu, 14 Dec 2023 12:43:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7996e2b-a366-4ce5-aaf5-141169120be9
+      - e9ce904e-1e63-4661-9f32-b81782b46675
     status: 200 OK
     code: 200
     duration: ""
@@ -2227,21 +2260,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=84f393b4-8e38-463f-a609-787eec5f2c00&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=3000e156-a932-4525-a592-dd07885d1958&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"84f393b4-8e38-463f-a609-787eec5f2c00","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"3000e156-a932-4525-a592-dd07885d1958","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "338"
+      - "325"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:55 GMT
+      - Thu, 14 Dec 2023 12:43:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f731aebe-434f-41b2-b198-b0d1d21da1d3
+      - 5e99ea06-2b1e-4f4b-91a4-173560d9bac9
     status: 200 OK
     code: 200
     duration: ""
@@ -2260,87 +2293,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-http-service","updated_at":"2023-07-28T09:33:53Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "360"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9148ede8-d448-44cd-ba01-82c40a948335
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=84f393b4-8e38-463f-a609-787eec5f2c00&name=tf_http_service&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"84f393b4-8e38-463f-a609-787eec5f2c00","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "338"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 36974704-c597-472e-af8f-db064bb215f1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-http-service","updated_at":"2023-07-28T09:33:53Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-http-service","updated_at":"2023-12-14T12:43:25Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "360"
+      - "370"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:55 GMT
+      - Thu, 14 Dec 2023 12:43:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30a00510-37c7-4fd4-8d62-bc8519d15363
+      - daffa6ec-76dd-47ce-ad24-6f69636339ef
     status: 200 OK
     code: 200
     duration: ""
@@ -2359,21 +2326,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=84f393b4-8e38-463f-a609-787eec5f2c00&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=3000e156-a932-4525-a592-dd07885d1958&name=tf_http_service&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"84f393b4-8e38-463f-a609-787eec5f2c00","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"3000e156-a932-4525-a592-dd07885d1958","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "338"
+      - "325"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:55 GMT
+      - Thu, 14 Dec 2023 12:43:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a1e80a9-31eb-4a24-8c3f-da2fa78ed3e8
+      - 5b02a041-5425-4c95-a84f-2cd3c47fac8d
     status: 200 OK
     code: 200
     duration: ""
@@ -2392,87 +2359,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-http-service","updated_at":"2023-07-28T09:33:53Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "360"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c3b081f5-9858-46f0-8b05-c1383353a307
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=84f393b4-8e38-463f-a609-787eec5f2c00&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"84f393b4-8e38-463f-a609-787eec5f2c00","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "338"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 380841c2-bb76-463e-91b3-e6750b7557da
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-http-service","updated_at":"2023-07-28T09:33:53Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-http-service","updated_at":"2023-12-14T12:43:25Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "360"
+      - "370"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:56 GMT
+      - Thu, 14 Dec 2023 12:43:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4c9b914-050b-456e-8bcd-84c63cf1c083
+      - f35d3ed0-eec1-41cd-a2c1-2489fd13fba9
     status: 200 OK
     code: 200
     duration: ""
@@ -2491,21 +2392,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=84f393b4-8e38-463f-a609-787eec5f2c00&name=tf_http_service&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=3000e156-a932-4525-a592-dd07885d1958&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"84f393b4-8e38-463f-a609-787eec5f2c00","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"3000e156-a932-4525-a592-dd07885d1958","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "338"
+      - "325"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:56 GMT
+      - Thu, 14 Dec 2023 12:43:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 500dccbc-8b3a-43b1-b785-b807f4091122
+      - bf32ee53-5516-4580-bbc4-54c7d96a14ea
     status: 200 OK
     code: 200
     duration: ""
@@ -2524,21 +2425,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-http-service","updated_at":"2023-07-28T09:33:53Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-http-service","updated_at":"2023-12-14T12:43:25Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "360"
+      - "370"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:56 GMT
+      - Thu, 14 Dec 2023 12:43:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,18 +2449,150 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82ed5810-bc8d-4e3e-9d18-4b905734816f
+      - d545da18-ec37-4a83-a737-d3f59315be98
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"84f393b4-8e38-463f-a609-787eec5f2c00"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=3000e156-a932-4525-a592-dd07885d1958&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"3000e156-a932-4525-a592-dd07885d1958","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "325"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 383253da-fd28-4c09-8159-0ca2154d147e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-http-service","updated_at":"2023-12-14T12:43:25Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "370"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77806a8c-0692-4867-a092-df4d8266a16c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?id=3000e156-a932-4525-a592-dd07885d1958&name=tf_http_service&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"3000e156-a932-4525-a592-dd07885d1958","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "325"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e9ce4d47-ffc5-4d93-9b37-0bd6ea6b2eeb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-http-service","updated_at":"2023-12-14T12:43:25Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "370"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1fc48506-8656-4861-b504-3b84e5b4bd1f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"delete":{"id":"3000e156-a932-4525-a592-dd07885d1958"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records
     method: PATCH
@@ -2573,7 +2606,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:56 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2583,7 +2616,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57715fe3-4823-4003-89f6-daea914709a5
+      - 1721de5d-a76f-417d-93ea-3d71e887edce
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,21 +2625,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"8d90d692-f874-474d-8b66-6c09ab1f9e39","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"786a767c-3a01-43d1-ad23-78bb5fcf8536","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"80384d72-b129-4c82-894f-b2a6260ae428","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"c3b7f822-85c2-4829-b757-e007d3a79f33","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:56 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2616,7 +2649,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6452ea2f-947f-4b7a-8bf8-5ca7983e3739
+      - 55f20c56-8270-467a-8346-90557cda28fb
     status: 200 OK
     code: 200
     duration: ""
@@ -2625,21 +2658,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-http-service","updated_at":"2023-07-28T09:33:56Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-http-service","updated_at":"2023-12-14T12:43:28Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "361"
+      - "371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:57 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2649,32 +2682,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 643ca7e4-3dca-4a8b-9641-76ed812be317
+      - db0fca4f-ccc3-4899-a7c5-32b7f38583ab
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"1.2.3.4","name":"tf_view","priority":0,"ttl":3600,"type":"A","comment":null,"view_config":{"views":[{"subnet":"100.0.0.0/16","data":"1.2.3.4"},{"subnet":"100.1.0.0/16","data":"4.3.2.1"}]},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"1.2.3.4","name":"tf_view","priority":0,"ttl":3600,"type":"A","comment":null,"view_config":{"views":[{"subnet":"100.0.0.0/16","data":"1.2.3.4"},{"subnet":"100.1.0.0/16","data":"4.3.2.1"}]},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"5e4a0910-69df-488a-a6b1-1864e2a58d64","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}]}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"b431862b-c46c-49b9-8a88-9b2b0ab9f2fe","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}]}'
     headers:
       Content-Length:
-      - "265"
+      - "255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:57 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2684,7 +2717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d08f0419-fd9a-40a1-9b11-a688513f25a5
+      - 3f89c00e-8cc6-44db-b3dc-926c8dde618c
     status: 200 OK
     code: 200
     duration: ""
@@ -2693,21 +2726,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?name=tf_view&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"5e4a0910-69df-488a-a6b1-1864e2a58d64","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"b431862b-c46c-49b9-8a88-9b2b0ab9f2fe","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "282"
+      - "271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:57 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2717,7 +2750,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 661439fc-30cd-49dc-b8c1-71529b777052
+      - 5a105927-26e8-4c95-939f-47423113bff3
     status: 200 OK
     code: 200
     duration: ""
@@ -2726,21 +2759,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?name=tf_view&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"5e4a0910-69df-488a-a6b1-1864e2a58d64","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"b431862b-c46c-49b9-8a88-9b2b0ab9f2fe","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "282"
+      - "271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:57 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2750,7 +2783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e319d448-9e49-43f9-87b8-2d5a9f2ac1cc
+      - 3dcd3c9b-3d07-4dcf-bb6e-b7890949cfb5
     status: 200 OK
     code: 200
     duration: ""
@@ -2759,21 +2792,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=5e4a0910-69df-488a-a6b1-1864e2a58d64&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=b431862b-c46c-49b9-8a88-9b2b0ab9f2fe&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"5e4a0910-69df-488a-a6b1-1864e2a58d64","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"b431862b-c46c-49b9-8a88-9b2b0ab9f2fe","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "282"
+      - "271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:57 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2783,7 +2816,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbb223b4-65ad-4f7a-a52f-c01c9670d801
+      - 0ddcf0eb-25b7-44ee-842d-afbbf9bb2fae
     status: 200 OK
     code: 200
     duration: ""
@@ -2792,87 +2825,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-view","updated_at":"2023-07-28T09:33:57Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "353"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 07aa6f82-252a-4201-9b8d-fd93a37d4cfb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=5e4a0910-69df-488a-a6b1-1864e2a58d64&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"5e4a0910-69df-488a-a6b1-1864e2a58d64","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "282"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0026c059-40f4-4394-93dc-98a5a5ab2090
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-view","updated_at":"2023-07-28T09:33:57Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-view","updated_at":"2023-12-14T12:43:28Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "353"
+      - "363"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:57 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2882,7 +2849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 108fd6e4-011b-4999-b536-d497f19a3635
+      - 3c7745f2-8cf5-4589-af1f-54b688ab33f6
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,21 +2858,87 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=b431862b-c46c-49b9-8a88-9b2b0ab9f2fe&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"b431862b-c46c-49b9-8a88-9b2b0ab9f2fe","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "271"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e65767b2-707a-4d97-afa8-46686f659b91
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-view","updated_at":"2023-12-14T12:43:28Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "363"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2a5e4c16-e7f9-42a5-a293-ec4da98f5161
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-http-service","updated_at":"2023-07-28T09:33:56Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-http-service","updated_at":"2023-12-14T12:43:28Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "361"
+      - "371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:02 GMT
+      - Thu, 14 Dec 2023 12:43:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2915,7 +2948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca84c5fb-5e91-4217-903b-310da2fbcfc4
+      - 61f68e63-a650-4cff-af6b-7d5f7a2da13d
     status: 200 OK
     code: 200
     duration: ""
@@ -2924,21 +2957,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-http-service.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-http-service","updated_at":"2023-07-28T09:34:03Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-http-service","updated_at":"2023-12-14T12:43:36Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "360"
+      - "370"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:07 GMT
+      - Thu, 14 Dec 2023 12:43:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2948,7 +2981,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efe2c13f-8515-4a6d-b18f-00c8a53fe453
+      - b43a5b87-da2b-4910-b4e8-f1265fa4237a
     status: 200 OK
     code: 200
     duration: ""
@@ -2957,7 +2990,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-http-service.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -2971,7 +3004,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:07 GMT
+      - Thu, 14 Dec 2023 12:43:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2981,7 +3014,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b317527-816b-4f60-aacd-0726e83d4efe
+      - 7d21f29e-9c9b-4de9-8a4f-7ea4ffdce859
     status: 200 OK
     code: 200
     duration: ""
@@ -2990,21 +3023,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"ff0eee7a-55b9-462e-9a1b-fb556f0faec5","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"4365ce83-b828-4c85-8128-1076e0003547","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1.2.3.4","id":"5e4a0910-69df-488a-a6b1-1864e2a58d64","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"3250b532-5838-42f3-9699-d417a658dd63","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"02927c73-8f17-45fc-a053-25394530efe6","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1.2.3.4","id":"b431862b-c46c-49b9-8a88-9b2b0ab9f2fe","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":3}'
     headers:
       Content-Length:
-      - "566"
+      - "541"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:07 GMT
+      - Thu, 14 Dec 2023 12:43:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3014,7 +3047,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e778902-a9b9-4bbf-8a80-6fc2a0b8ed02
+      - dea85eb7-851a-4858-bfbc-77e9d3a1d377
     status: 200 OK
     code: 200
     duration: ""
@@ -3023,21 +3056,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=5e4a0910-69df-488a-a6b1-1864e2a58d64&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=b431862b-c46c-49b9-8a88-9b2b0ab9f2fe&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"5e4a0910-69df-488a-a6b1-1864e2a58d64","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"b431862b-c46c-49b9-8a88-9b2b0ab9f2fe","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "282"
+      - "271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:07 GMT
+      - Thu, 14 Dec 2023 12:43:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3047,7 +3080,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e0b0e5e-f5d9-47d1-9d42-2d60df75716c
+      - 02d42f45-c6e0-40e7-98da-615ed168a37e
     status: 200 OK
     code: 200
     duration: ""
@@ -3056,87 +3089,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-view","updated_at":"2023-07-28T09:34:04Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "352"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:34:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 52dc84b1-7bec-496f-913b-e35d2267931c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=5e4a0910-69df-488a-a6b1-1864e2a58d64&name=tf_view&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"5e4a0910-69df-488a-a6b1-1864e2a58d64","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "282"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:34:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ea20caed-a4de-4e4b-9226-f47f88c546d2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-view","updated_at":"2023-07-28T09:34:04Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-view","updated_at":"2023-12-14T12:43:36Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "352"
+      - "362"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:08 GMT
+      - Thu, 14 Dec 2023 12:43:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3146,7 +3113,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87a014eb-f09d-4942-a787-0b4db52a9da8
+      - ad4ac96d-dc6e-4e5d-a5e1-82a43efb090f
     status: 200 OK
     code: 200
     duration: ""
@@ -3155,21 +3122,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=5e4a0910-69df-488a-a6b1-1864e2a58d64&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=b431862b-c46c-49b9-8a88-9b2b0ab9f2fe&name=tf_view&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"5e4a0910-69df-488a-a6b1-1864e2a58d64","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"b431862b-c46c-49b9-8a88-9b2b0ab9f2fe","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "282"
+      - "271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:08 GMT
+      - Thu, 14 Dec 2023 12:43:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3179,7 +3146,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57be05d0-51e5-47a7-bb36-dd073e4c1ca5
+      - 0d14884a-e4b9-4553-aae4-9b6d68f4fbeb
     status: 200 OK
     code: 200
     duration: ""
@@ -3188,87 +3155,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-view","updated_at":"2023-07-28T09:34:04Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "352"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:34:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4d408a5a-e79b-4684-9f41-c57b4d74502e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=5e4a0910-69df-488a-a6b1-1864e2a58d64&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"5e4a0910-69df-488a-a6b1-1864e2a58d64","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "282"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:34:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8eae499d-784f-430f-a20d-ca5fbf2e066f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-view","updated_at":"2023-07-28T09:34:04Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-view","updated_at":"2023-12-14T12:43:36Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "352"
+      - "362"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:08 GMT
+      - Thu, 14 Dec 2023 12:43:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3278,7 +3179,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - daadf20c-9d6e-4e17-8953-9f6abb2d4249
+      - 954564cd-1f4c-484a-abad-2631f699bc96
     status: 200 OK
     code: 200
     duration: ""
@@ -3287,21 +3188,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=5e4a0910-69df-488a-a6b1-1864e2a58d64&name=tf_view&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=b431862b-c46c-49b9-8a88-9b2b0ab9f2fe&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"5e4a0910-69df-488a-a6b1-1864e2a58d64","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"b431862b-c46c-49b9-8a88-9b2b0ab9f2fe","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "282"
+      - "271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:08 GMT
+      - Thu, 14 Dec 2023 12:43:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3311,7 +3212,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b07ae95-83ec-4c1b-8680-c023ea1a7f80
+      - ed2b477f-5b7c-4165-82ac-85fe096f8159
     status: 200 OK
     code: 200
     duration: ""
@@ -3320,21 +3221,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-view","updated_at":"2023-07-28T09:34:04Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-view","updated_at":"2023-12-14T12:43:36Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "352"
+      - "362"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:08 GMT
+      - Thu, 14 Dec 2023 12:43:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3344,18 +3245,150 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31f39ae4-db8f-46fd-8ab2-52462e036eb1
+      - 5d5e238a-1880-427d-b3ba-e35b6412153a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"5e4a0910-69df-488a-a6b1-1864e2a58d64"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=b431862b-c46c-49b9-8a88-9b2b0ab9f2fe&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"b431862b-c46c-49b9-8a88-9b2b0ab9f2fe","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "271"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8f37ddd-086a-4ab2-9cbf-b7509d191daf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-view","updated_at":"2023-12-14T12:43:36Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "362"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8e3c2518-0ab8-40fd-8b37-e1977085d1c7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?id=b431862b-c46c-49b9-8a88-9b2b0ab9f2fe&name=tf_view&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"b431862b-c46c-49b9-8a88-9b2b0ab9f2fe","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "271"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ddbbe2dd-3de4-4b5c-b730-ed405eda416e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-view","updated_at":"2023-12-14T12:43:36Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "362"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f12a1124-2e5a-436e-af50-f53fb81c823d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"delete":{"id":"b431862b-c46c-49b9-8a88-9b2b0ab9f2fe"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records
     method: PATCH
@@ -3369,7 +3402,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:09 GMT
+      - Thu, 14 Dec 2023 12:43:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3379,7 +3412,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ecae1c5-457c-4c13-b1e0-4551e37a2f13
+      - 85a9a641-aa50-4ef2-b18a-91ca875003c4
     status: 200 OK
     code: 200
     duration: ""
@@ -3388,21 +3421,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"ff0eee7a-55b9-462e-9a1b-fb556f0faec5","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"4365ce83-b828-4c85-8128-1076e0003547","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"3250b532-5838-42f3-9699-d417a658dd63","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"02927c73-8f17-45fc-a053-25394530efe6","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:09 GMT
+      - Thu, 14 Dec 2023 12:43:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3412,7 +3445,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74ad0767-2c18-43ed-8a4b-3ab8285d0fa6
+      - 62176337-56f4-4907-9a40-19b9cbd0620a
     status: 200 OK
     code: 200
     duration: ""
@@ -3421,21 +3454,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-view","updated_at":"2023-07-28T09:34:09Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-view","updated_at":"2023-12-14T12:43:40Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "353"
+      - "363"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:09 GMT
+      - Thu, 14 Dec 2023 12:43:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3445,32 +3478,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c98f11b6-f5cc-4adb-9a1f-bea9ed896607
+      - 78dc354e-9283-4c6c-ae23-66a6c23ddecd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"1.2.3.4","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","comment":null,"weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"1.2.3.4","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","comment":null,"weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"4d72a68b-ee15-4dc0-994e-9f6f77db1db5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}]}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"0e201447-3b86-4bc7-a922-87748f0ceeda","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}]}'
     headers:
       Content-Length:
-      - "250"
+      - "240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:09 GMT
+      - Thu, 14 Dec 2023 12:43:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3480,7 +3513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ad3a8b5-6871-4a7d-a8bb-e349007d48ef
+      - a422e704-a110-462f-b9eb-87e3554ccca1
     status: 200 OK
     code: 200
     duration: ""
@@ -3489,21 +3522,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?name=tf_weighted&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"4d72a68b-ee15-4dc0-994e-9f6f77db1db5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"0e201447-3b86-4bc7-a922-87748f0ceeda","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "267"
+      - "256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:09 GMT
+      - Thu, 14 Dec 2023 12:43:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3513,7 +3546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 982311f9-65ca-4822-91cd-c8b442567e30
+      - 42dfefc0-aa91-4775-b844-e943df2ef111
     status: 200 OK
     code: 200
     duration: ""
@@ -3522,21 +3555,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?name=tf_weighted&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"4d72a68b-ee15-4dc0-994e-9f6f77db1db5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"0e201447-3b86-4bc7-a922-87748f0ceeda","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "267"
+      - "256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:09 GMT
+      - Thu, 14 Dec 2023 12:43:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3546,7 +3579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 979e09e1-64f9-4c0f-905a-dfb6bc47cbcb
+      - 6827cd73-68cd-4bf2-adc8-7d281c671505
     status: 200 OK
     code: 200
     duration: ""
@@ -3555,21 +3588,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?id=4d72a68b-ee15-4dc0-994e-9f6f77db1db5&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?id=0e201447-3b86-4bc7-a922-87748f0ceeda&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"4d72a68b-ee15-4dc0-994e-9f6f77db1db5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"0e201447-3b86-4bc7-a922-87748f0ceeda","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "267"
+      - "256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:10 GMT
+      - Thu, 14 Dec 2023 12:43:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3579,7 +3612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78b22a4d-7d4a-4660-bb00-f1b893952f23
+      - e67963c9-a523-4869-95d9-7f60e90cca8b
     status: 200 OK
     code: 200
     duration: ""
@@ -3588,87 +3621,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-weighted","updated_at":"2023-07-28T09:34:09Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "357"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:34:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 98b1c2cf-e3a8-45be-b830-3e8d6c5308f0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?id=4d72a68b-ee15-4dc0-994e-9f6f77db1db5&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"4d72a68b-ee15-4dc0-994e-9f6f77db1db5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "267"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:34:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e3e0329c-8dbb-416f-9641-9b35d1c832b7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-weighted","updated_at":"2023-07-28T09:34:09Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-weighted","updated_at":"2023-12-14T12:43:41Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "357"
+      - "367"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:10 GMT
+      - Thu, 14 Dec 2023 12:43:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3678,7 +3645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df96c4a0-8e09-4dfb-84f9-13f88e1bb606
+      - ad51f909-f145-497a-bbb8-95d04b2c3e50
     status: 200 OK
     code: 200
     duration: ""
@@ -3687,21 +3654,87 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?id=0e201447-3b86-4bc7-a922-87748f0ceeda&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"0e201447-3b86-4bc7-a922-87748f0ceeda","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cfe203e7-4853-4783-a42b-d1c0fff15d3f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-weighted","updated_at":"2023-12-14T12:43:41Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "367"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2ccd8348-bb14-4b8a-b9e3-1bc44c0dc58d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-view","updated_at":"2023-07-28T09:34:13Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-view","updated_at":"2023-12-14T12:43:40Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "352"
+      - "363"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:14 GMT
+      - Thu, 14 Dec 2023 12:43:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3711,7 +3744,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be01bf8f-795c-40fb-a4e8-3d2603fe4a28
+      - 9841aee1-970f-4acb-9cc1-9c49ba90cc8d
     status: 200 OK
     code: 200
     duration: ""
@@ -3720,7 +3753,40 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-view.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-view","updated_at":"2023-12-14T12:43:47Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "362"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1bc70981-e204-49ff-b38d-cb2e28ae235e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-view.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -3734,7 +3800,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:14 GMT
+      - Thu, 14 Dec 2023 12:43:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3744,7 +3810,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20fa5ccf-ffac-4f68-b86e-2414d8808b6c
+      - 078a7f3c-cb6a-4b09-aa0d-f0410e198be2
     status: 200 OK
     code: 200
     duration: ""
@@ -3753,21 +3819,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"e6f1727f-3862-4376-8a22-c8e7c251f353","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"dbc45f8c-c368-4428-b82d-6184c61f1779","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1.2.3.4","id":"4d72a68b-ee15-4dc0-994e-9f6f77db1db5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"65ac0379-8f2b-4ffa-803d-3a880fedc543","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"4150ee0e-1498-4eab-ba7c-5ee509bb9084","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1.2.3.4","id":"0e201447-3b86-4bc7-a922-87748f0ceeda","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":3}'
     headers:
       Content-Length:
-      - "551"
+      - "526"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:15 GMT
+      - Thu, 14 Dec 2023 12:43:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3777,7 +3843,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46276dd1-5c26-4a12-baae-9d7dc81c4f21
+      - 7edbaf24-59bf-4e91-b64c-bb326d9711f3
     status: 200 OK
     code: 200
     duration: ""
@@ -3786,21 +3852,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?id=4d72a68b-ee15-4dc0-994e-9f6f77db1db5&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?id=0e201447-3b86-4bc7-a922-87748f0ceeda&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"4d72a68b-ee15-4dc0-994e-9f6f77db1db5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"0e201447-3b86-4bc7-a922-87748f0ceeda","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "267"
+      - "256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:15 GMT
+      - Thu, 14 Dec 2023 12:43:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3810,7 +3876,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9efded7-23cd-469a-a1f1-d587fe8ebc9b
+      - b57370b5-f3a5-49c1-a05c-211759500f55
     status: 200 OK
     code: 200
     duration: ""
@@ -3819,87 +3885,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-weighted","updated_at":"2023-07-28T09:34:14Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "356"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:34:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 55fe0dfb-456e-4f10-952e-9e0b34d2294a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?id=4d72a68b-ee15-4dc0-994e-9f6f77db1db5&name=tf_weighted&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"4d72a68b-ee15-4dc0-994e-9f6f77db1db5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "267"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:34:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6598c6e0-9ed6-4579-8a40-457f7ec3cc15
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-weighted","updated_at":"2023-07-28T09:34:14Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-weighted","updated_at":"2023-12-14T12:43:47Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "356"
+      - "366"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:15 GMT
+      - Thu, 14 Dec 2023 12:43:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3909,7 +3909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df49f55a-93b7-4b51-b45f-4e6a0a594203
+      - 12b14a3a-3993-43c8-84e1-1ce21efa93ea
     status: 200 OK
     code: 200
     duration: ""
@@ -3918,21 +3918,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?id=4d72a68b-ee15-4dc0-994e-9f6f77db1db5&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?id=0e201447-3b86-4bc7-a922-87748f0ceeda&name=tf_weighted&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"4d72a68b-ee15-4dc0-994e-9f6f77db1db5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"0e201447-3b86-4bc7-a922-87748f0ceeda","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "267"
+      - "256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:15 GMT
+      - Thu, 14 Dec 2023 12:43:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3942,7 +3942,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f2e588e-fde8-4c07-b658-bad4350c6b7b
+      - 72cfb25c-f661-49b4-a7dd-d62261520877
     status: 200 OK
     code: 200
     duration: ""
@@ -3951,87 +3951,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-weighted","updated_at":"2023-07-28T09:34:14Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "356"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:34:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 393ef8b3-d541-48a2-8c01-0845ac3804a0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?id=4d72a68b-ee15-4dc0-994e-9f6f77db1db5&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"4d72a68b-ee15-4dc0-994e-9f6f77db1db5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "267"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:34:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d57369dd-0204-4885-a603-14c8172f3a85
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-weighted","updated_at":"2023-07-28T09:34:14Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-weighted","updated_at":"2023-12-14T12:43:47Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "356"
+      - "366"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:15 GMT
+      - Thu, 14 Dec 2023 12:43:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4041,18 +3975,150 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81e2e54f-31f4-4622-afb7-b2baa38e4b31
+      - 32397d90-38c5-4700-864e-486aea6cab53
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"4d72a68b-ee15-4dc0-994e-9f6f77db1db5"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?id=0e201447-3b86-4bc7-a922-87748f0ceeda&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"0e201447-3b86-4bc7-a922-87748f0ceeda","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b6d760d8-e97b-4832-a119-e28c887bf3b8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-weighted","updated_at":"2023-12-14T12:43:47Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "366"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 338f3f50-0a1a-40e2-8003-0d67d9ca593d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?id=0e201447-3b86-4bc7-a922-87748f0ceeda&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"1.2.3.4","id":"0e201447-3b86-4bc7-a922-87748f0ceeda","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b17dc113-4ae8-4efe-a930-7dea74df802c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-weighted","updated_at":"2023-12-14T12:43:47Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "366"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a98bb5db-faab-4e9f-b351-2bf570147ba8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"delete":{"id":"0e201447-3b86-4bc7-a922-87748f0ceeda"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records
     method: PATCH
@@ -4066,7 +4132,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:16 GMT
+      - Thu, 14 Dec 2023 12:43:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4076,7 +4142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e768d4f2-10cc-4d73-bf5c-2dfffc988b94
+      - 13391683-cc8d-4033-b696-0d94295a095b
     status: 200 OK
     code: 200
     duration: ""
@@ -4085,21 +4151,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"e6f1727f-3862-4376-8a22-c8e7c251f353","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"dbc45f8c-c368-4428-b82d-6184c61f1779","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"65ac0379-8f2b-4ffa-803d-3a880fedc543","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"4150ee0e-1498-4eab-ba7c-5ee509bb9084","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:16 GMT
+      - Thu, 14 Dec 2023 12:43:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4109,7 +4175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95864bf0-6724-46ed-87ed-a2b2820cf990
+      - 2a218590-0274-44f0-a0a3-ee19110e9329
     status: 200 OK
     code: 200
     duration: ""
@@ -4118,21 +4184,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-weighted.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-weighted","updated_at":"2023-07-28T09:34:16Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-weighted","updated_at":"2023-12-14T12:43:52Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "357"
+      - "367"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:16 GMT
+      - Thu, 14 Dec 2023 12:43:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4142,7 +4208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33d3bed7-1e70-43a7-b679-c1542109cdff
+      - ec844816-cd7e-4654-8362-40ba1d85aa29
     status: 200 OK
     code: 200
     duration: ""
@@ -4151,21 +4217,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-weighted.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-data-source-weighted","updated_at":"2023-07-28T09:34:16Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-weighted","updated_at":"2023-12-14T12:43:57Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "357"
+      - "366"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:21 GMT
+      - Thu, 14 Dec 2023 12:43:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4175,7 +4241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23861619-47fd-4f59-972f-2576a4dea9e8
+      - 1820784b-76db-40d4-bab1-78de0be62678
     status: 200 OK
     code: 200
     duration: ""
@@ -4184,40 +4250,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-data-source-weighted.scaleway-terraform.com&domain=&order_by=domain_asc
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-data-source-weighted","updated_at":"2023-07-28T09:34:23Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "356"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:34:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7564c27b-3c65-427b-9ab9-a885dbf9804f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -4231,7 +4264,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:26 GMT
+      - Thu, 14 Dec 2023 12:43:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4241,7 +4274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76f0168b-747f-4601-9f22-7cc74e47aced
+      - 42514345-ee77-4bf9-b16e-e7eab7387871
     status: 200 OK
     code: 200
     duration: ""
@@ -4250,7 +4283,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-data-source-weighted.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
@@ -4264,7 +4297,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:34:26 GMT
+      - Thu, 14 Dec 2023 12:43:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4274,7 +4307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3394aae2-dd76-4490-b3f6-7571e14479ef
+      - 3928a6af-c143-4fb0-9d63-fbebfacd3b41
     status: 403 Forbidden
     code: 403
     duration: ""

--- a/scaleway/testdata/domain-record-arobase.cassette.yaml
+++ b/scaleway/testdata/domain-record-arobase.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"this-is-a-test","name":"","priority":0,"ttl":3600,"type":"TXT","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"this-is-a-test","name":"","priority":0,"ttl":3600,"type":"TXT","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"345ffcc2-662c-4710-ba8d-046f6898ef89","name":"","priority":0,"ttl":3600,"type":"TXT"}]}'
+    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"9f4a5f37-5afb-4e3b-adf2-3467789765a8","name":"","priority":0,"ttl":3600,"type":"TXT"}]}'
     headers:
       Content-Length:
-      - "155"
+      - "149"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e86d6f2d-9d8d-4b18-8646-0c0d3329b053
+      - cba3cd59-1825-4baa-9e84-675e325ad586
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?name=&order_by=name_asc&type=TXT
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"345ffcc2-662c-4710-ba8d-046f6898ef89","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"9f4a5f37-5afb-4e3b-adf2-3467789765a8","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
     headers:
       Content-Length:
-      - "172"
+      - "165"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32e30940-f63d-42e7-8cc6-1d37a74d2161
+      - c7025adf-e353-47c4-a324-25677eb7c72d
     status: 200 OK
     code: 200
     duration: ""
@@ -74,21 +74,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?name=&order_by=name_asc&page=1&type=TXT
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"345ffcc2-662c-4710-ba8d-046f6898ef89","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"9f4a5f37-5afb-4e3b-adf2-3467789765a8","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
     headers:
       Content-Length:
-      - "172"
+      - "165"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 177cd884-1557-41ff-9cde-97302bc03271
+      - b4dfb2b6-5735-4aa7-b328-514f87152833
     status: 200 OK
     code: 200
     duration: ""
@@ -107,21 +107,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?id=345ffcc2-662c-4710-ba8d-046f6898ef89&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?id=9f4a5f37-5afb-4e3b-adf2-3467789765a8&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"345ffcc2-662c-4710-ba8d-046f6898ef89","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"9f4a5f37-5afb-4e3b-adf2-3467789765a8","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
     headers:
       Content-Length:
-      - "172"
+      - "165"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f154438-9b69-4a61-ac12-12d1c783d38a
+      - b3eba8e5-cfbc-4584-9ebf-d313b89c1d26
     status: 200 OK
     code: 200
     duration: ""
@@ -140,21 +140,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-arobase.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-arobase","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-arobase","updated_at":"2023-12-14T12:43:02Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "344"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09a95e9d-b5e6-49a9-bbdc-cec00311b7b0
+      - 05acefa0-9dee-4457-981b-76823ed2a1c0
     status: 200 OK
     code: 200
     duration: ""
@@ -173,21 +173,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"345ffcc2-662c-4710-ba8d-046f6898ef89","name":"","priority":0,"ttl":3600,"type":"TXT"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"74915d32-4742-4093-b511-7fb2a299a086","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"a763d4c3-133a-4f4a-922a-749008072de9","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"10780949-050a-4080-8c33-8bba64beba34","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"5d215b46-9417-47b1-83c6-fa55f5ea25a1","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"\"this-is-a-test\"","id":"9f4a5f37-5afb-4e3b-adf2-3467789765a8","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":3}'
     headers:
       Content-Length:
-      - "456"
+      - "435"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 304f5057-8ee2-40f4-8bee-d601750d7655
+      - ac0fb079-bd6c-402c-9d7d-d5feaf1b3dd8
     status: 200 OK
     code: 200
     duration: ""
@@ -206,21 +206,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?id=345ffcc2-662c-4710-ba8d-046f6898ef89&name=&order_by=name_asc&page=1&type=TXT
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?id=9f4a5f37-5afb-4e3b-adf2-3467789765a8&name=&order_by=name_asc&page=1&type=TXT
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"345ffcc2-662c-4710-ba8d-046f6898ef89","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"9f4a5f37-5afb-4e3b-adf2-3467789765a8","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
     headers:
       Content-Length:
-      - "172"
+      - "165"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5db4df92-93c7-481e-9238-35888ce5d2ec
+      - d2f88083-b71d-4b76-9fe5-2402bfaa45fd
     status: 200 OK
     code: 200
     duration: ""
@@ -239,87 +239,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-arobase.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-arobase","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "344"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2f482bd5-4843-4afe-948d-f75ec3a88afc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?id=345ffcc2-662c-4710-ba8d-046f6898ef89&name=&order_by=name_asc&page=1&type=TXT
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"345ffcc2-662c-4710-ba8d-046f6898ef89","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "172"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 492d727a-5858-414c-9d0f-229bdf26e517
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-arobase.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-arobase","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-arobase","updated_at":"2023-12-14T12:43:02Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "344"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -329,7 +263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f6df4dc-5a7c-4ec2-9214-67e6e81cd8a5
+      - 8be4f234-93d7-4771-b7f8-b12232d92c0e
     status: 200 OK
     code: 200
     duration: ""
@@ -338,21 +272,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?id=345ffcc2-662c-4710-ba8d-046f6898ef89&name=&order_by=name_asc&page=1&type=TXT
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?id=9f4a5f37-5afb-4e3b-adf2-3467789765a8&name=&order_by=name_asc&page=1&type=TXT
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"345ffcc2-662c-4710-ba8d-046f6898ef89","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"9f4a5f37-5afb-4e3b-adf2-3467789765a8","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
     headers:
       Content-Length:
-      - "172"
+      - "165"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -362,7 +296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a5baf3e-b229-4353-9a3d-bc2370019fde
+      - bf990b45-147d-4e7d-b030-b928c1210608
     status: 200 OK
     code: 200
     duration: ""
@@ -371,21 +305,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-arobase.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-arobase","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-arobase","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "344"
+      - "353"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -395,18 +329,84 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89f0bdd5-1b94-4548-a738-ee437554048d
+      - 3499501b-d382-42c1-ab47-f746e632455f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"345ffcc2-662c-4710-ba8d-046f6898ef89"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?id=9f4a5f37-5afb-4e3b-adf2-3467789765a8&name=&order_by=name_asc&page=1&type=TXT
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"\"this-is-a-test\"","id":"9f4a5f37-5afb-4e3b-adf2-3467789765a8","name":"","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 33d0a12d-46c8-4738-a842-99c09634a7d1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-arobase.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-arobase","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "353"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 20fbeac3-5666-46d1-8bbe-4d77c9f9b522
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"delete":{"id":"9f4a5f37-5afb-4e3b-adf2-3467789765a8"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records
     method: PATCH
@@ -420,7 +420,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -430,7 +430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7293d49-9d3b-41fa-a67b-366389a26afd
+      - 9fece27d-31d2-4387-af4e-5938c5b1cb95
     status: 200 OK
     code: 200
     duration: ""
@@ -439,21 +439,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"74915d32-4742-4093-b511-7fb2a299a086","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"a763d4c3-133a-4f4a-922a-749008072de9","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"10780949-050a-4080-8c33-8bba64beba34","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"5d215b46-9417-47b1-83c6-fa55f5ea25a1","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -463,7 +463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb454dcd-92ef-4b45-a9df-b244b0f4efe1
+      - 2a9f607a-e4cb-4ab1-9e04-954daadafdb3
     status: 200 OK
     code: 200
     duration: ""
@@ -472,21 +472,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-arobase.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-arobase","updated_at":"2023-07-28T09:33:40Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-arobase","updated_at":"2023-12-14T12:43:05Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "344"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -496,7 +496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07239119-ff2b-4085-bcb9-503f4c9d87b8
+      - b8675b45-1e05-403e-b1ea-1fee657114a7
     status: 200 OK
     code: 200
     duration: ""
@@ -505,21 +505,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-arobase.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-arobase","updated_at":"2023-07-28T09:33:42Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-arobase","updated_at":"2023-12-14T12:43:05Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "343"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:45 GMT
+      - Thu, 14 Dec 2023 12:43:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -529,7 +529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f4622cb-96b6-4127-804a-9bc3f74930ea
+      - ec0b0624-d148-4b18-9a67-e34613a89243
     status: 200 OK
     code: 200
     duration: ""
@@ -538,7 +538,40 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-arobase.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-arobase","updated_at":"2023-12-14T12:43:15Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "353"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b3ae7c29-ec5e-4f2b-8e48-f2badc071cc0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -552,7 +585,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -562,7 +595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0694a296-6aaa-42b6-94b8-1cd31ce43b6b
+      - 46c98152-4617-4113-b921-90fcde6d77f7
     status: 200 OK
     code: 200
     duration: ""
@@ -571,7 +604,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-arobase.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
@@ -585,7 +618,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -595,7 +628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10043cfb-9f82-4e02-94c4-de3c03c5ff28
+      - 17a0e621-5090-44e6-b33d-9dc965fef1f7
     status: 403 Forbidden
     code: 403
     duration: ""

--- a/scaleway/testdata/domain-record-basic.cassette.yaml
+++ b/scaleway/testdata/domain-record-basic.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.1","name":"","priority":0,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.1","name":"","priority":0,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"e61c12bd-8612-4578-bcdf-64c6fd9c51d8","name":"","priority":0,"ttl":3600,"type":"A"}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"426811cc-37b1-4cb9-a2b3-a4dcf76a5a4e","name":"","priority":0,"ttl":3600,"type":"A"}]}'
     headers:
       Content-Length:
-      - "144"
+      - "138"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:01 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b56c047f-286f-49bc-a47b-8b04c05726ef
+      - 2431f1c0-41f1-4b28-88d3-30d41f0442e8
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"e61c12bd-8612-4578-bcdf-64c6fd9c51d8","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"426811cc-37b1-4cb9-a2b3-a4dcf76a5a4e","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "161"
+      - "154"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:01 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e567cda-ef61-4beb-954c-a14fdadb3201
+      - 755cbc99-4416-49f8-b40f-e1faee747149
     status: 200 OK
     code: 200
     duration: ""
@@ -74,21 +74,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"e61c12bd-8612-4578-bcdf-64c6fd9c51d8","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"426811cc-37b1-4cb9-a2b3-a4dcf76a5a4e","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "161"
+      - "154"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:01 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af69a6d3-6b1b-45f9-af46-c6688017ec2c
+      - 09e32c82-a233-491f-98b5-0d552206408e
     status: 200 OK
     code: 200
     duration: ""
@@ -107,21 +107,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=e61c12bd-8612-4578-bcdf-64c6fd9c51d8&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=426811cc-37b1-4cb9-a2b3-a4dcf76a5a4e&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"e61c12bd-8612-4578-bcdf-64c6fd9c51d8","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"426811cc-37b1-4cb9-a2b3-a4dcf76a5a4e","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "161"
+      - "154"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:01 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79dbd63d-ac55-4598-af6f-fd4f8521e98a
+      - f1b60e33-81b3-4d50-9d93-7cc0e4bc09a1
     status: 200 OK
     code: 200
     duration: ""
@@ -140,21 +140,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:01Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:16Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:01 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed1a8938-4cc5-4c05-98f0-8a71306dd2e7
+      - bd08da4f-cc99-46be-b8f9-d8c3632630c3
     status: 200 OK
     code: 200
     duration: ""
@@ -173,21 +173,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"e61c12bd-8612-4578-bcdf-64c6fd9c51d8","name":"","priority":0,"ttl":3600,"type":"A"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"285ffd04-1004-41e5-80ba-542c18eb2078","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"b66ae765-e047-49e7-9073-7ef94ce5e314","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"4e52abba-785d-4a67-9e92-39005f8edcf5","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"63637c54-d7a2-41ea-a26d-029668a81f07","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.1","id":"426811cc-37b1-4cb9-a2b3-a4dcf76a5a4e","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
     headers:
       Content-Length:
-      - "445"
+      - "424"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:02 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9848579e-78a0-4bb9-b90f-bd5fd87b588c
+      - 4d654d06-b545-41fb-a414-d83f4b36cee4
     status: 200 OK
     code: 200
     duration: ""
@@ -206,21 +206,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=e61c12bd-8612-4578-bcdf-64c6fd9c51d8&name=&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=426811cc-37b1-4cb9-a2b3-a4dcf76a5a4e&name=&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"e61c12bd-8612-4578-bcdf-64c6fd9c51d8","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"426811cc-37b1-4cb9-a2b3-a4dcf76a5a4e","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "161"
+      - "154"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:02 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d02c35ef-9acf-4f7b-970c-4c895b176739
+      - a9034027-1563-4444-af13-5928b6ca4652
     status: 200 OK
     code: 200
     duration: ""
@@ -239,87 +239,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:01Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "342"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:39:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 547c5468-2897-4c99-b475-21bbb584932a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=e61c12bd-8612-4578-bcdf-64c6fd9c51d8&name=&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"e61c12bd-8612-4578-bcdf-64c6fd9c51d8","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "161"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:39:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a28d9f88-790e-41a7-85f2-11cfbb556bdd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:01Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:16Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:03 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -329,18 +263,84 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b8acf35-59ca-40b3-91d6-ea8d4afafded
+      - 7e9e49df-e288-4432-a737-5371a138e1b8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"e61c12bd-8612-4578-bcdf-64c6fd9c51d8"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=426811cc-37b1-4cb9-a2b3-a4dcf76a5a4e&name=&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"426811cc-37b1-4cb9-a2b3-a4dcf76a5a4e","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "154"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2024e761-e53e-4547-8c3c-651256b97bfc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:16Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9cdc1f83-1640-47c6-be57-dcc7ba961205
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"delete":{"id":"426811cc-37b1-4cb9-a2b3-a4dcf76a5a4e"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records
     method: PATCH
@@ -354,7 +354,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:03 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -364,7 +364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02e45c5c-54bf-40b2-80a4-54b430cee110
+      - 382748c1-3b52-42af-8a09-0f6b0ee3b22a
     status: 200 OK
     code: 200
     duration: ""
@@ -373,21 +373,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"285ffd04-1004-41e5-80ba-542c18eb2078","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"b66ae765-e047-49e7-9073-7ef94ce5e314","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"4e52abba-785d-4a67-9e92-39005f8edcf5","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"63637c54-d7a2-41ea-a26d-029668a81f07","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:03 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -397,7 +397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 660c30ab-6f86-4fcf-93fd-80f5920e99c0
+      - 4bfb23eb-ee34-497b-9435-66f3c8908103
     status: 200 OK
     code: 200
     duration: ""
@@ -406,21 +406,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:03Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:17Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:04 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -430,7 +430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdf04df7-746d-40c5-a8f6-ae2ac5871dae
+      - 878659aa-9f51-41fe-9329-caa5e08b46d3
     status: 200 OK
     code: 200
     duration: ""
@@ -439,21 +439,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic","updated_at":"2023-07-28T09:39:05Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:17Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:09 GMT
+      - Thu, 14 Dec 2023 12:43:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -463,7 +463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bce15dbf-f436-4e9a-ad13-a81f12b4025b
+      - 71306f21-50ba-4abc-92e5-ec3b784ec966
     status: 200 OK
     code: 200
     duration: ""
@@ -472,7 +472,40 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic","updated_at":"2023-12-14T12:43:25Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "351"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e28e3326-c777-442d-8751-3b5f78913417
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -486,7 +519,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:09 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -496,32 +529,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29d1c7ad-f014-437b-ada6-b01cf6e95e62
+      - a7bcd98c-df61-4c9e-a3e1-f55dd303c39b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.1","name":"tf","priority":0,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.1","name":"tf","priority":0,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}]}'
     headers:
       Content-Length:
-      - "146"
+      - "140"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:10 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -531,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84cff665-fdcc-4002-ada9-fb9ae243da2b
+      - 1a48cc08-fead-4848-b3c0-5efe07803cbc
     status: 200 OK
     code: 200
     duration: ""
@@ -540,21 +573,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=tf&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:10 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -564,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67db9e63-20a5-4b41-a420-14da25de7cde
+      - 996528ff-2fe5-457e-88af-00aa4e4f82a6
     status: 200 OK
     code: 200
     duration: ""
@@ -573,21 +606,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=tf&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:10 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31bcdb67-049b-4d7a-b084-76de0e6a6bdd
+      - 0f781079-e5ea-4133-ad81-a6a9737aa03d
     status: 200 OK
     code: 200
     duration: ""
@@ -606,21 +639,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=2a69bf7d-5b2a-4729-ab53-00547a393557&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=7d30906e-c6fa-4b23-84e1-a6adedf72dc5&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:10 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e26c36f7-24fb-43d6-a6b2-20dda59718e8
+      - 941307d0-c0fb-41bf-bacb-fb39167238aa
     status: 200 OK
     code: 200
     duration: ""
@@ -639,21 +672,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:10Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:28Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:10 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50871a78-549d-43ca-99ed-3fbf7ac104d2
+      - 9d7cb0b6-4ac4-4615-9c34-9f4f913674f0
     status: 200 OK
     code: 200
     duration: ""
@@ -672,21 +705,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"43c9bede-1e31-4690-b760-d6a0d4026423","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"2873b5c4-6d57-4ddb-9c1f-c36ed09448f3","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.1","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"dafc9fdc-5336-4ba9-b4e0-15a07571674e","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"8d664466-3534-42fe-913b-13a09d657af3","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.1","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
     headers:
       Content-Length:
-      - "447"
+      - "426"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:10 GMT
+      - Thu, 14 Dec 2023 12:43:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -696,7 +729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5c0974f-4115-46b8-ada2-4d9c9ee5796e
+      - 6cf938eb-c81a-4912-a44b-de6e082578bc
     status: 200 OK
     code: 200
     duration: ""
@@ -705,21 +738,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=2a69bf7d-5b2a-4729-ab53-00547a393557&name=tf&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=7d30906e-c6fa-4b23-84e1-a6adedf72dc5&name=tf&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:11 GMT
+      - Thu, 14 Dec 2023 12:43:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57e42a90-640b-42b5-a3dc-d62fc1863956
+      - 77e0aade-e6a1-4cff-b9cd-7b993f9ede7e
     status: 200 OK
     code: 200
     duration: ""
@@ -738,87 +771,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:10Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "342"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:39:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4fab37d8-2746-4dab-9f0a-2411cc25e2ed
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=2a69bf7d-5b2a-4729-ab53-00547a393557&name=tf&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "163"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:39:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4e00e8ba-728f-4cfd-b74c-3f42f22f5d01
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:10Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:28Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:11 GMT
+      - Thu, 14 Dec 2023 12:43:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -828,32 +795,98 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06a83447-5731-46d3-988c-5a47d24d268c
+      - 30418c51-c9de-49e1-bd3d-60bb9a6c8205
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"set":{"id":"2a69bf7d-5b2a-4729-ab53-00547a393557","records":[{"data":"127.0.0.2","name":"tf","priority":0,"ttl":0,"type":"unknown","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=7d30906e-c6fa-4b23-84e1-a6adedf72dc5&name=tf&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "156"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5fdaa88b-eee7-4a55-b2a5-f668a0efe859
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:28Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 854aa450-6d36-4353-9d66-69439f392b82
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"set":{"id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","records":[{"data":"127.0.0.2","name":"tf","priority":0,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}]}'
     headers:
       Content-Length:
-      - "146"
+      - "140"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:12 GMT
+      - Thu, 14 Dec 2023 12:43:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -863,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abac0bc0-d5f2-444c-a3d3-bf9f387ac671
+      - 6bce6717-0db9-4568-9d6d-d31a3d6acb69
     status: 200 OK
     code: 200
     duration: ""
@@ -872,21 +905,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=tf&order_by=name_asc&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=tf&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:12 GMT
+      - Thu, 14 Dec 2023 12:43:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -896,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e25733dd-4c4e-4c91-8555-331498337ff9
+      - e2f33b75-acb7-4fb2-ac5c-fbbb2a9e13b7
     status: 200 OK
     code: 200
     duration: ""
@@ -905,21 +938,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=2a69bf7d-5b2a-4729-ab53-00547a393557&name=tf&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=7d30906e-c6fa-4b23-84e1-a6adedf72dc5&name=tf&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:12 GMT
+      - Thu, 14 Dec 2023 12:43:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -929,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b729222b-ff51-446a-a801-760782211b08
+      - c1f218b8-55b6-4afb-a882-c778bf06fa5a
     status: 200 OK
     code: 200
     duration: ""
@@ -938,21 +971,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:12Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:30Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:12 GMT
+      - Thu, 14 Dec 2023 12:43:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -962,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 937160d6-990c-4d6d-aa17-ee1eb55c49c4
+      - 9f0e4430-432e-4826-b847-f90de6189dcf
     status: 200 OK
     code: 200
     duration: ""
@@ -971,21 +1004,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"43c9bede-1e31-4690-b760-d6a0d4026423","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"2873b5c4-6d57-4ddb-9c1f-c36ed09448f3","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"dafc9fdc-5336-4ba9-b4e0-15a07571674e","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"8d664466-3534-42fe-913b-13a09d657af3","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
     headers:
       Content-Length:
-      - "447"
+      - "426"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:12 GMT
+      - Thu, 14 Dec 2023 12:43:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -995,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f4b2cd3-f528-40f2-b529-b2897c82b685
+      - ef0207f3-219a-40b5-84d5-d0ba1c9ea389
     status: 200 OK
     code: 200
     duration: ""
@@ -1004,21 +1037,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=2a69bf7d-5b2a-4729-ab53-00547a393557&name=tf&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=7d30906e-c6fa-4b23-84e1-a6adedf72dc5&name=tf&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "163"
+      - "156"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:13 GMT
+      - Thu, 14 Dec 2023 12:43:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1028,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4967b07-6175-4c36-88e7-e7e907fda929
+      - 36b4147c-d38e-429f-8723-8bb268fe7b2f
     status: 200 OK
     code: 200
     duration: ""
@@ -1037,87 +1070,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:12Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "342"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:39:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 08179366-fa41-435d-b43a-73472dbfe011
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=2a69bf7d-5b2a-4729-ab53-00547a393557&name=tf&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "163"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:39:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e45a65a9-72c4-44ac-9b73-3d5ed68ec7ac
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:12Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:30Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:14 GMT
+      - Thu, 14 Dec 2023 12:43:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1127,32 +1094,98 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae54e0c1-eb10-46d5-8e1c-2378b65ad133
+      - 3bebb0b3-7283-417c-8120-a55793dec7c4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"set":{"id":"2a69bf7d-5b2a-4729-ab53-00547a393557","records":[{"data":"","name":"tf","priority":10,"ttl":43200,"type":"unknown","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=7d30906e-c6fa-4b23-84e1-a6adedf72dc5&name=tf&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "156"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a7e5e475-1cdf-40f8-aef0-d8474bec29b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:30Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08a0092a-155f-4d10-ab83-0750e7a0174a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"set":{"id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","records":[{"data":"127.0.0.2","name":"tf","priority":10,"ttl":43200,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":10,"ttl":43200,"type":"A"}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":10,"ttl":43200,"type":"A"}]}'
     headers:
       Content-Length:
-      - "148"
+      - "142"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:14 GMT
+      - Thu, 14 Dec 2023 12:43:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 163ebfb2-5006-4bf7-9681-faa7644f45f0
+      - 89ea3503-025e-450b-a556-6cdc6b964801
     status: 200 OK
     code: 200
     duration: ""
@@ -1171,21 +1204,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=tf&order_by=name_asc&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=tf&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "165"
+      - "158"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:14 GMT
+      - Thu, 14 Dec 2023 12:43:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f84e2e89-0a27-40d4-964c-0563ee62179e
+      - f3e14a32-dbae-4988-bb98-412546a6c489
     status: 200 OK
     code: 200
     duration: ""
@@ -1204,21 +1237,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=2a69bf7d-5b2a-4729-ab53-00547a393557&name=tf&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=7d30906e-c6fa-4b23-84e1-a6adedf72dc5&name=tf&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "165"
+      - "158"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:14 GMT
+      - Thu, 14 Dec 2023 12:43:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b89b353-bb5e-4103-97d8-b91a20f5cdf3
+      - 9d65580c-d7b1-47ae-ba6d-bd1df0d87fdd
     status: 200 OK
     code: 200
     duration: ""
@@ -1237,21 +1270,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:14Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:31Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:14 GMT
+      - Thu, 14 Dec 2023 12:43:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35e30c38-a940-43a8-bb75-e0fec2c3e1a8
+      - 1570f379-e0b2-4c31-ba4d-32af45a1e93b
     status: 200 OK
     code: 200
     duration: ""
@@ -1270,21 +1303,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"43c9bede-1e31-4690-b760-d6a0d4026423","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"2873b5c4-6d57-4ddb-9c1f-c36ed09448f3","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"dafc9fdc-5336-4ba9-b4e0-15a07571674e","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"8d664466-3534-42fe-913b-13a09d657af3","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":3}'
     headers:
       Content-Length:
-      - "449"
+      - "428"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:15 GMT
+      - Thu, 14 Dec 2023 12:43:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 129c0ee7-ef3d-4027-9867-ce97f594caf0
+      - f673991d-3047-46cb-81a4-e9fdf56d3860
     status: 200 OK
     code: 200
     duration: ""
@@ -1303,21 +1336,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=2a69bf7d-5b2a-4729-ab53-00547a393557&name=tf&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=7d30906e-c6fa-4b23-84e1-a6adedf72dc5&name=tf&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "165"
+      - "158"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:15 GMT
+      - Thu, 14 Dec 2023 12:43:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc8a8c2d-4bd2-48e1-87da-173caff082f5
+      - 36390ed5-14f1-48e7-bf69-b2a15de8a0a8
     status: 200 OK
     code: 200
     duration: ""
@@ -1336,87 +1369,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:14Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "342"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:39:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f5c4cff5-44cb-4fe0-9d0d-ab4e9de59dbb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=2a69bf7d-5b2a-4729-ab53-00547a393557&name=tf&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "165"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:39:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f0cf08b9-c0f5-470c-a8ac-1216baa9ef05
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic","updated_at":"2023-07-28T09:39:15Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:31Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:16 GMT
+      - Thu, 14 Dec 2023 12:43:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,32 +1393,98 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78338c96-4763-4813-bbf9-818fdf5c65a1
+      - d2540328-4c9f-4ca3-bb03-945175c3f660
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"ASPMX.L.GOOGLE.COM.","name":"record_mx","priority":1,"ttl":600,"type":"MX","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=7d30906e-c6fa-4b23-84e1-a6adedf72dc5&name=tf&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "158"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 717b941a-cd75-47d3-849c-0c87264e05b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:31Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1edc1075-3d85-4fe0-90bf-e9f94674db90
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"add":{"records":[{"data":"ASPMX.L.GOOGLE.COM.","name":"record_mx","priority":1,"ttl":600,"type":"MX","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"1 aspmx.l.google.com.","id":"212fc317-94ef-4e3b-88be-5acf0d239b3a","name":"record_mx","priority":1,"ttl":600,"type":"MX"}]}'
+    body: '{"records":[{"comment":null,"data":"1 aspmx.l.google.com.","id":"5580a359-32f4-4791-b3d1-7bcef3b9163a","name":"record_mx","priority":1,"ttl":600,"type":"MX"}]}'
     headers:
       Content-Length:
-      - "165"
+      - "159"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:16 GMT
+      - Thu, 14 Dec 2023 12:43:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1461,7 +1494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2c1b6d5-de5b-4cb2-8e1d-a05003a5c838
+      - 054ba8e7-124f-4b2f-8555-e11822e019a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,21 +1503,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=record_mx&order_by=name_asc&type=MX
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1 aspmx.l.google.com.","id":"212fc317-94ef-4e3b-88be-5acf0d239b3a","name":"record_mx","priority":1,"ttl":600,"type":"MX"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1 aspmx.l.google.com.","id":"5580a359-32f4-4791-b3d1-7bcef3b9163a","name":"record_mx","priority":1,"ttl":600,"type":"MX"}],"total_count":1}'
     headers:
       Content-Length:
-      - "182"
+      - "175"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:16 GMT
+      - Thu, 14 Dec 2023 12:43:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1494,7 +1527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 474e71b0-2cbd-4817-8133-edfd59d78a90
+      - 7ab67f20-3725-40df-b85b-3aaa64d91773
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,21 +1536,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=record_mx&order_by=name_asc&page=1&type=MX
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1 aspmx.l.google.com.","id":"212fc317-94ef-4e3b-88be-5acf0d239b3a","name":"record_mx","priority":1,"ttl":600,"type":"MX"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1 aspmx.l.google.com.","id":"5580a359-32f4-4791-b3d1-7bcef3b9163a","name":"record_mx","priority":1,"ttl":600,"type":"MX"}],"total_count":1}'
     headers:
       Content-Length:
-      - "182"
+      - "175"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:16 GMT
+      - Thu, 14 Dec 2023 12:43:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1527,7 +1560,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd31850d-f589-49c8-a8ac-a74a840add03
+      - 4302d127-9226-4ef0-8b54-be1971e57353
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,21 +1569,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=212fc317-94ef-4e3b-88be-5acf0d239b3a&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=5580a359-32f4-4791-b3d1-7bcef3b9163a&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1 aspmx.l.google.com.","id":"212fc317-94ef-4e3b-88be-5acf0d239b3a","name":"record_mx","priority":1,"ttl":600,"type":"MX"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1 aspmx.l.google.com.","id":"5580a359-32f4-4791-b3d1-7bcef3b9163a","name":"record_mx","priority":1,"ttl":600,"type":"MX"}],"total_count":1}'
     headers:
       Content-Length:
-      - "182"
+      - "175"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:16 GMT
+      - Thu, 14 Dec 2023 12:43:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1560,7 +1593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 115eb0b9-fe03-4a82-a311-a19c2cc9da03
+      - 16f3b9e1-4612-43df-a241-8a1821f868e3
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,21 +1602,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic","updated_at":"2023-07-28T09:39:16Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:32Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:16 GMT
+      - Thu, 14 Dec 2023 12:43:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1593,7 +1626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99676835-50ed-47b5-b107-47ea1036f346
+      - 9bdb473f-809c-4e7f-8acd-6a33e8f26d44
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,22 +1635,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"43c9bede-1e31-4690-b760-d6a0d4026423","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"2873b5c4-6d57-4ddb-9c1f-c36ed09448f3","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1
-      aspmx.l.google.com.","id":"212fc317-94ef-4e3b-88be-5acf0d239b3a","name":"record_mx","priority":1,"ttl":600,"type":"MX"},{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":4}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"dafc9fdc-5336-4ba9-b4e0-15a07571674e","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"8d664466-3534-42fe-913b-13a09d657af3","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"1
+      aspmx.l.google.com.","id":"5580a359-32f4-4791-b3d1-7bcef3b9163a","name":"record_mx","priority":1,"ttl":600,"type":"MX"},{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":4}'
     headers:
       Content-Length:
-      - "602"
+      - "574"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:17 GMT
+      - Thu, 14 Dec 2023 12:43:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1627,7 +1660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b52bf2b-4a91-487b-a3bf-32b767f0636e
+      - 1fdd1bd2-c4c9-405f-a801-0c62202183fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,21 +1669,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=2a69bf7d-5b2a-4729-ab53-00547a393557&name=tf&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=5580a359-32f4-4791-b3d1-7bcef3b9163a&name=record_mx&order_by=name_asc&page=1&type=MX
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"2a69bf7d-5b2a-4729-ab53-00547a393557","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"1 aspmx.l.google.com.","id":"5580a359-32f4-4791-b3d1-7bcef3b9163a","name":"record_mx","priority":1,"ttl":600,"type":"MX"}],"total_count":1}'
     headers:
       Content-Length:
-      - "165"
+      - "175"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:17 GMT
+      - Thu, 14 Dec 2023 12:43:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1660,7 +1693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc93c963-b231-43c5-a2bf-992f8be3f433
+      - 41a3491c-41dd-40df-a088-cb11b9dd6f31
     status: 200 OK
     code: 200
     duration: ""
@@ -1669,21 +1702,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=212fc317-94ef-4e3b-88be-5acf0d239b3a&name=record_mx&order_by=name_asc&page=1&type=MX
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?id=7d30906e-c6fa-4b23-84e1-a6adedf72dc5&name=tf&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"1 aspmx.l.google.com.","id":"212fc317-94ef-4e3b-88be-5acf0d239b3a","name":"record_mx","priority":1,"ttl":600,"type":"MX"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5","name":"tf","priority":10,"ttl":43200,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "182"
+      - "158"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:17 GMT
+      - Thu, 14 Dec 2023 12:43:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1693,7 +1726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8e3db46-d6ea-4257-83ed-2e8721b2d66f
+      - fc1708da-b4eb-446e-bd19-27d3af4cf02a
     status: 200 OK
     code: 200
     duration: ""
@@ -1702,54 +1735,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic","updated_at":"2023-07-28T09:39:16Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "341"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:39:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f1fabdea-7d72-4bc1-bc03-275c1be378bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic","updated_at":"2023-07-28T09:39:16Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:32Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:17 GMT
+      - Thu, 14 Dec 2023 12:43:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1759,18 +1759,51 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22fc0a35-3978-4444-8347-6ccd2588c17a
+      - 5af1b027-811e-4b7f-b5d2-73d3818f6f50
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"212fc317-94ef-4e3b-88be-5acf0d239b3a"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:32Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8697f11f-ab93-4491-9cfe-3a92f3c5823e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"delete":{"id":"5580a359-32f4-4791-b3d1-7bcef3b9163a"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records
     method: PATCH
@@ -1784,7 +1817,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:18 GMT
+      - Thu, 14 Dec 2023 12:43:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1794,18 +1827,18 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 336b9b16-29c4-4e4a-be52-8334dc002421
+      - b99d8b83-42d0-4c1d-b928-2b64a79222f8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"2a69bf7d-5b2a-4729-ab53-00547a393557"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"delete":{"id":"7d30906e-c6fa-4b23-84e1-a6adedf72dc5"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records
     method: PATCH
@@ -1819,7 +1852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:18 GMT
+      - Thu, 14 Dec 2023 12:43:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1829,7 +1862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e2cc9b0-f6a9-4306-890c-10d9b77a0ded
+      - 451c6d82-5cd2-44f6-9ac6-08b02a5e3419
     status: 200 OK
     code: 200
     duration: ""
@@ -1838,21 +1871,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"43c9bede-1e31-4690-b760-d6a0d4026423","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"2873b5c4-6d57-4ddb-9c1f-c36ed09448f3","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"dafc9fdc-5336-4ba9-b4e0-15a07571674e","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"8d664466-3534-42fe-913b-13a09d657af3","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:18 GMT
+      - Thu, 14 Dec 2023 12:43:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1862,7 +1895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d0d3e45-10c0-4ed5-bd7c-96b1a2074e4a
+      - 80fa4045-9ca7-40b3-a17a-603718b5fc21
     status: 200 OK
     code: 200
     duration: ""
@@ -1871,21 +1904,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"43c9bede-1e31-4690-b760-d6a0d4026423","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"2873b5c4-6d57-4ddb-9c1f-c36ed09448f3","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"dafc9fdc-5336-4ba9-b4e0-15a07571674e","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"8d664466-3534-42fe-913b-13a09d657af3","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:18 GMT
+      - Thu, 14 Dec 2023 12:43:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1895,7 +1928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37976273-17ce-4f2d-a16c-a4800657f38b
+      - 6306b9f3-8a14-432c-bb21-13dfce3280e7
     status: 200 OK
     code: 200
     duration: ""
@@ -1904,21 +1937,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:18Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:34Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:18 GMT
+      - Thu, 14 Dec 2023 12:43:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1928,7 +1961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e54af651-73a0-4bd9-97f8-e85097f7a31b
+      - 8e22b806-2a98-49fa-a2dd-dbc913af862b
     status: 200 OK
     code: 200
     duration: ""
@@ -1937,21 +1970,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:18Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-12-14T12:43:34Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:18 GMT
+      - Thu, 14 Dec 2023 12:43:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1961,7 +1994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4993c3af-972b-4897-a953-1dd3fb2ce26e
+      - 0d221c4a-3fee-4471-ad42-e35ca1ebf815
     status: 200 OK
     code: 200
     duration: ""
@@ -1970,21 +2003,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:18Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic","updated_at":"2023-12-14T12:43:36Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "351"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:23 GMT
+      - Thu, 14 Dec 2023 12:43:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1994,7 +2027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c65c48dc-1b1c-41d4-8f16-3ca31f4b5a04
+      - ed4894e0-d623-439b-88b1-e67e447e4b55
     status: 200 OK
     code: 200
     duration: ""
@@ -2003,21 +2036,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic","updated_at":"2023-07-28T09:39:18Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic","updated_at":"2023-12-14T12:43:36Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "351"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:23 GMT
+      - Thu, 14 Dec 2023 12:43:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2027,7 +2060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8cf2322a-131f-4dba-9ac8-8c4a5d5d6628
+      - 8b90f525-ac93-4087-99d9-401f6c60db6d
     status: 200 OK
     code: 200
     duration: ""
@@ -2036,73 +2069,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic","updated_at":"2023-07-28T09:39:26Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "341"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:39:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c59807ae-8847-4cd1-af6c-49936527942e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic.scaleway-terraform.com&domain=&order_by=domain_asc
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic","updated_at":"2023-07-28T09:39:26Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "341"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:39:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0eea60b5-b5fd-4f21-8f9a-5dc4d3443b8b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -2116,7 +2083,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:28 GMT
+      - Thu, 14 Dec 2023 12:43:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2126,7 +2093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3313c5b8-d740-4f90-a933-c0e036560d16
+      - 929b055d-bb43-46a2-93ba-9cad94509f67
     status: 200 OK
     code: 200
     duration: ""
@@ -2135,7 +2102,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -2149,7 +2116,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:29 GMT
+      - Thu, 14 Dec 2023 12:43:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2159,7 +2126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abaf4aa3-5c64-4da8-8a48-f35ee1795010
+      - 851f9786-95f5-41ed-a6f0-232469ab9416
     status: 403 Forbidden
     code: 403
     duration: ""
@@ -2168,7 +2135,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
@@ -2182,7 +2149,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:39:30 GMT
+      - Thu, 14 Dec 2023 12:43:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2192,7 +2159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8745b6e5-a7a2-46b0-817d-5f77f9980a4c
+      - 987c6c0c-e879-48e4-8413-987931addce0
     status: 403 Forbidden
     code: 403
     duration: ""

--- a/scaleway/testdata/domain-record-basic2.cassette.yaml
+++ b/scaleway/testdata/domain-record-basic2.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.1","name":"","priority":0,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.1","name":"","priority":0,"ttl":3600,"type":"A","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"23329931-8e76-4f48-898d-de05583064a9","name":"","priority":0,"ttl":3600,"type":"A"}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"4f181290-bce7-456b-8d0e-402b99473b29","name":"","priority":0,"ttl":3600,"type":"A"}]}'
     headers:
       Content-Length:
-      - "144"
+      - "138"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,112 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09b581f8-c2e5-4696-bf14-f3b17f2b722e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"changes":[{"add":{"records":[{"data":"0 mail.scaleway.com.","name":"","priority":0,"ttl":300,"type":"MX","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records
-    method: PATCH
-  response:
-    body: '{"records":[{"comment":null,"data":"0 mail.scaleway.com.","id":"579f546e-2741-4eb9-903e-eaa0fc2e830c","name":"","priority":0,"ttl":300,"type":"MX"}]}'
-    headers:
-      Content-Length:
-      - "155"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fb9432e5-5969-41a2-bfb0-8edfd9fd36ac
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"changes":[{"add":{"records":[{"data":"v=DMARC1; p=quarantine; adkim=s","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records
-    method: PATCH
-  response:
-    body: '{"records":[{"comment":null,"data":"\"v=DMARC1; p=quarantine; adkim=s\"","id":"d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}]}'
-    headers:
-      Content-Length:
-      - "178"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 23f1351c-6183-4d92-8da7-cf37f33e4c37
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"changes":[{"add":{"records":[{"data":"10 feedback-smtp.eu-west-1.amazonses.com.","name":"","priority":0,"ttl":300,"type":"MX","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records
-    method: PATCH
-  response:
-    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"1459c690-b7c8-4a60-acc2-d206caa14b45","name":"","priority":10,"ttl":300,"type":"MX"}]}'
-    headers:
-      Content-Length:
-      - "177"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 070c55f6-aa57-466c-ad59-5aeb95f205ff
+      - b9783937-eb1e-4089-8459-6a2dd75b8e22
     status: 200 OK
     code: 200
     duration: ""
@@ -146,122 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=MX
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"1459c690-b7c8-4a60-acc2-d206caa14b45","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"0
-      mail.scaleway.com.","id":"579f546e-2741-4eb9-903e-eaa0fc2e830c","name":"","priority":0,"ttl":300,"type":"MX"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "337"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 81808611-cfde-4450-a4f9-4a4bf9a92841
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=MX
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"1459c690-b7c8-4a60-acc2-d206caa14b45","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"0
-      mail.scaleway.com.","id":"579f546e-2741-4eb9-903e-eaa0fc2e830c","name":"","priority":0,"ttl":300,"type":"MX"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "337"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e44791b8-ba0d-4c89-a894-76c5d9fe88a4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=_dmarc&order_by=name_asc&type=TXT
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"\"v=DMARC1; p=quarantine; adkim=s\"","id":"d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "195"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8357c2ad-f37d-4cdd-af26-0ea9537d6b30
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"23329931-8e76-4f48-898d-de05583064a9","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"4f181290-bce7-456b-8d0e-402b99473b29","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "161"
+      - "154"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -271,31 +65,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc2e07f1-28c3-4334-9e90-bb4ccbbff8c1
+      - 3c577f93-2b5e-4057-8bb7-eac05002c2a6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"changes":[{"add":{"records":[{"data":"0 mail.scaleway.com.","name":"","priority":0,"ttl":300,"type":"MX","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
+      Content-Type:
+      - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&page=1&type=MX
-    method: GET
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records
+    method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"1459c690-b7c8-4a60-acc2-d206caa14b45","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"0
-      mail.scaleway.com.","id":"579f546e-2741-4eb9-903e-eaa0fc2e830c","name":"","priority":0,"ttl":300,"type":"MX"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"0 mail.scaleway.com.","id":"7d061b82-c0ea-4a69-ad93-039b258a00af","name":"","priority":0,"ttl":300,"type":"MX"}]}'
     headers:
       Content-Length:
-      - "337"
+      - "149"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -305,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a990fada-9139-44d1-9a8b-f9ed7e5d1149
+      - 21bf5e19-5af4-45ac-9ba8-6e871ec4c51a
     status: 200 OK
     code: 200
     duration: ""
@@ -314,21 +109,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"23329931-8e76-4f48-898d-de05583064a9","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"4f181290-bce7-456b-8d0e-402b99473b29","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "161"
+      - "154"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -338,7 +133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d87d494e-ef68-4f9a-8d94-0ed272534726
+      - 0f516ecd-0ee2-4f06-b600-0cd3b6056303
     status: 200 OK
     code: 200
     duration: ""
@@ -347,22 +142,122 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=MX
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"0 mail.scaleway.com.","id":"7d061b82-c0ea-4a69-ad93-039b258a00af","name":"","priority":0,"ttl":300,"type":"MX"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6226d512-e7a5-4d21-986c-310e28d87732
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"add":{"records":[{"data":"v=DMARC1; p=quarantine; adkim=s","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records
+    method: PATCH
+  response:
+    body: '{"records":[{"comment":null,"data":"\"v=DMARC1; p=quarantine; adkim=s\"","id":"63fa3353-4932-4cc2-b21b-dc8107299b03","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}]}'
+    headers:
+      Content-Length:
+      - "172"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 58ee81aa-8693-40d4-9512-30dd9de858fd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=4f181290-bce7-456b-8d0e-402b99473b29&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"4f181290-bce7-456b-8d0e-402b99473b29","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "154"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c5725f32-949e-4c56-a014-378727abc82f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&page=1&type=MX
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"1459c690-b7c8-4a60-acc2-d206caa14b45","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"0
-      mail.scaleway.com.","id":"579f546e-2741-4eb9-903e-eaa0fc2e830c","name":"","priority":0,"ttl":300,"type":"MX"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"0 mail.scaleway.com.","id":"7d061b82-c0ea-4a69-ad93-039b258a00af","name":"","priority":0,"ttl":300,"type":"MX"}],"total_count":1}'
     headers:
       Content-Length:
-      - "337"
+      - "165"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -372,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3d3a24b-3fb7-457f-8e77-c3df7f525927
+      - 69a1caf7-c9b2-4a7d-b75f-d4f958876e62
     status: 200 OK
     code: 200
     duration: ""
@@ -381,21 +276,155 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=_dmarc&order_by=name_asc&type=TXT
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"\"v=DMARC1; p=quarantine; adkim=s\"","id":"63fa3353-4932-4cc2-b21b-dc8107299b03","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "188"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e8f9fb0c-0330-482a-9845-70470c743d1b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"add":{"records":[{"data":"10 feedback-smtp.eu-west-1.amazonses.com.","name":"","priority":0,"ttl":300,"type":"MX","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records
+    method: PATCH
+  response:
+    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"c9b1e8ef-50f3-41d5-bd38-b863737c9448","name":"","priority":10,"ttl":300,"type":"MX"}]}'
+    headers:
+      Content-Length:
+      - "171"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df18b200-e3b1-4f22-b946-bc1feee8e020
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "353"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 63b98bea-d826-419c-8a95-36ca3871b835
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=7d061b82-c0ea-4a69-ad93-039b258a00af&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"0 mail.scaleway.com.","id":"7d061b82-c0ea-4a69-ad93-039b258a00af","name":"","priority":0,"ttl":300,"type":"MX"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8225960a-9446-434a-a611-ee751d104197
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=_dmarc&order_by=name_asc&page=1&type=TXT
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"\"v=DMARC1; p=quarantine; adkim=s\"","id":"d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"\"v=DMARC1; p=quarantine; adkim=s\"","id":"63fa3353-4932-4cc2-b21b-dc8107299b03","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
     headers:
       Content-Length:
-      - "195"
+      - "188"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -405,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fec54ff-abcc-4358-a9b5-4d789aae311f
+      - f545932d-3087-40d7-bcaf-493c6c62b80e
     status: 200 OK
     code: 200
     duration: ""
@@ -414,21 +443,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=579f546e-2741-4eb9-903e-eaa0fc2e830c&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=MX
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"0 mail.scaleway.com.","id":"579f546e-2741-4eb9-903e-eaa0fc2e830c","name":"","priority":0,"ttl":300,"type":"MX"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"0 mail.scaleway.com.","id":"7d061b82-c0ea-4a69-ad93-039b258a00af","name":"","priority":0,"ttl":300,"type":"MX"},{"comment":null,"data":"10
+      feedback-smtp.eu-west-1.amazonses.com.","id":"c9b1e8ef-50f3-41d5-bd38-b863737c9448","name":"","priority":10,"ttl":300,"type":"MX"}],"total_count":2}'
     headers:
       Content-Length:
-      - "172"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -438,7 +468,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8496a92-6111-4e21-8d2a-6330b7476316
+      - 642ab7c6-8ca1-4ad7-af6b-fd720e560403
     status: 200 OK
     code: 200
     duration: ""
@@ -447,120 +477,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=1459c690-b7c8-4a60-acc2-d206caa14b45&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"1459c690-b7c8-4a60-acc2-d206caa14b45","name":"","priority":10,"ttl":300,"type":"MX"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "194"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2ab99a3c-a3a0-4a79-880d-bf42c4d49c7a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=23329931-8e76-4f48-898d-de05583064a9&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"23329931-8e76-4f48-898d-de05583064a9","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "161"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a5d07973-9624-41ff-a832-af2cdf306dcb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c&name=&order_by=name_asc&page=1&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"\"v=DMARC1; p=quarantine; adkim=s\"","id":"d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "195"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - da049410-1739-4901-9913-35c69c15e804
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:48Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "343"
+      - "353"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -570,7 +501,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46bcbfba-867c-4fc2-9d30-dcab0aa4ef4a
+      - 12158520-1952-4306-a10f-422e22232292
     status: 200 OK
     code: 200
     duration: ""
@@ -579,21 +510,88 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=63fa3353-4932-4cc2-b21b-dc8107299b03&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"\"v=DMARC1; p=quarantine; adkim=s\"","id":"63fa3353-4932-4cc2-b21b-dc8107299b03","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "188"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fe25981d-2ec8-465a-b665-78cbdb02c6b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&page=1&type=MX
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"0 mail.scaleway.com.","id":"7d061b82-c0ea-4a69-ad93-039b258a00af","name":"","priority":0,"ttl":300,"type":"MX"},{"comment":null,"data":"10
+      feedback-smtp.eu-west-1.amazonses.com.","id":"c9b1e8ef-50f3-41d5-bd38-b863737c9448","name":"","priority":10,"ttl":300,"type":"MX"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "323"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2f41cad9-1340-4d38-9954-ef36bf81cd31
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:48Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "343"
+      - "353"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -603,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 841dc00c-123d-4749-8ca6-b7505ce9ffc4
+      - 9c60855e-87f1-48a2-a116-7d117d8f8e41
     status: 200 OK
     code: 200
     duration: ""
@@ -612,21 +610,54 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=c9b1e8ef-50f3-41d5-bd38-b863737c9448&name=&order_by=name_asc&page=1&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"c9b1e8ef-50f3-41d5-bd38-b863737c9448","name":"","priority":10,"ttl":300,"type":"MX"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "187"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9961bbb0-e3d7-4397-b7b1-d42cf8723dd5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:48Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "343"
+      - "353"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -636,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f3bdee3-84f6-4c2c-8bfa-7569438bc118
+      - 4da824d4-b174-4c20-a208-7df68063a7c1
     status: 200 OK
     code: 200
     duration: ""
@@ -645,56 +676,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:48Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "343"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a1b4fce3-7d9e-4a6e-a8d9-cceaee8b6f77
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"1459c690-b7c8-4a60-acc2-d206caa14b45","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"0
-      mail.scaleway.com.","id":"579f546e-2741-4eb9-903e-eaa0fc2e830c","name":"","priority":0,"ttl":300,"type":"MX"},{"comment":null,"data":"127.0.0.1","id":"23329931-8e76-4f48-898d-de05583064a9","name":"","priority":0,"ttl":3600,"type":"A"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"dd982ba0-2ab6-4f51-988b-4e85cf2589b8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"33cf28e4-86c0-40eb-9999-62c94243e7ef","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"\"v=DMARC1;
-      p=quarantine; adkim=s\"","id":"d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":6}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"4f181290-bce7-456b-8d0e-402b99473b29","name":"","priority":0,"ttl":3600,"type":"A"},{"comment":null,"data":"0
+      mail.scaleway.com.","id":"7d061b82-c0ea-4a69-ad93-039b258a00af","name":"","priority":0,"ttl":300,"type":"MX"},{"comment":null,"data":"10
+      feedback-smtp.eu-west-1.amazonses.com.","id":"c9b1e8ef-50f3-41d5-bd38-b863737c9448","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"0eecdb67-db65-49ea-8d2c-b098efdf5bb1","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"388d9539-1fe5-4e82-ad14-975e837d3986","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"\"v=DMARC1;
+      p=quarantine; adkim=s\"","id":"63fa3353-4932-4cc2-b21b-dc8107299b03","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":6}'
     headers:
       Content-Length:
-      - "919"
+      - "877"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -704,7 +703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab0a58ac-3b3a-473c-8e73-8d42bf56858c
+      - 164aa9e6-ffa3-4de1-b566-bfd4d3616ed0
     status: 200 OK
     code: 200
     duration: ""
@@ -713,23 +712,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"1459c690-b7c8-4a60-acc2-d206caa14b45","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"0
-      mail.scaleway.com.","id":"579f546e-2741-4eb9-903e-eaa0fc2e830c","name":"","priority":0,"ttl":300,"type":"MX"},{"comment":null,"data":"127.0.0.1","id":"23329931-8e76-4f48-898d-de05583064a9","name":"","priority":0,"ttl":3600,"type":"A"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"dd982ba0-2ab6-4f51-988b-4e85cf2589b8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"33cf28e4-86c0-40eb-9999-62c94243e7ef","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"\"v=DMARC1;
-      p=quarantine; adkim=s\"","id":"d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":6}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"4f181290-bce7-456b-8d0e-402b99473b29","name":"","priority":0,"ttl":3600,"type":"A"},{"comment":null,"data":"0
+      mail.scaleway.com.","id":"7d061b82-c0ea-4a69-ad93-039b258a00af","name":"","priority":0,"ttl":300,"type":"MX"},{"comment":null,"data":"10
+      feedback-smtp.eu-west-1.amazonses.com.","id":"c9b1e8ef-50f3-41d5-bd38-b863737c9448","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"0eecdb67-db65-49ea-8d2c-b098efdf5bb1","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"388d9539-1fe5-4e82-ad14-975e837d3986","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"\"v=DMARC1;
+      p=quarantine; adkim=s\"","id":"63fa3353-4932-4cc2-b21b-dc8107299b03","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":6}'
     headers:
       Content-Length:
-      - "919"
+      - "877"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -739,7 +739,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbacdd2a-1f2a-449d-b3c1-6942ff8a4fa9
+      - 27c8f5a1-7fb8-4e49-bd00-93c3aeda2827
     status: 200 OK
     code: 200
     duration: ""
@@ -748,23 +748,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"1459c690-b7c8-4a60-acc2-d206caa14b45","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"0
-      mail.scaleway.com.","id":"579f546e-2741-4eb9-903e-eaa0fc2e830c","name":"","priority":0,"ttl":300,"type":"MX"},{"comment":null,"data":"127.0.0.1","id":"23329931-8e76-4f48-898d-de05583064a9","name":"","priority":0,"ttl":3600,"type":"A"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"dd982ba0-2ab6-4f51-988b-4e85cf2589b8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"33cf28e4-86c0-40eb-9999-62c94243e7ef","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"\"v=DMARC1;
-      p=quarantine; adkim=s\"","id":"d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":6}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"4f181290-bce7-456b-8d0e-402b99473b29","name":"","priority":0,"ttl":3600,"type":"A"},{"comment":null,"data":"0
+      mail.scaleway.com.","id":"7d061b82-c0ea-4a69-ad93-039b258a00af","name":"","priority":0,"ttl":300,"type":"MX"},{"comment":null,"data":"10
+      feedback-smtp.eu-west-1.amazonses.com.","id":"c9b1e8ef-50f3-41d5-bd38-b863737c9448","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"0eecdb67-db65-49ea-8d2c-b098efdf5bb1","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"388d9539-1fe5-4e82-ad14-975e837d3986","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"\"v=DMARC1;
+      p=quarantine; adkim=s\"","id":"63fa3353-4932-4cc2-b21b-dc8107299b03","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":6}'
     headers:
       Content-Length:
-      - "919"
+      - "877"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -774,7 +775,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd592ce2-02a1-4c19-9f18-636e2c58f942
+      - 364ef21d-cca8-42a4-9a4a-41e2c03c826f
     status: 200 OK
     code: 200
     duration: ""
@@ -783,23 +784,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"1459c690-b7c8-4a60-acc2-d206caa14b45","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"0
-      mail.scaleway.com.","id":"579f546e-2741-4eb9-903e-eaa0fc2e830c","name":"","priority":0,"ttl":300,"type":"MX"},{"comment":null,"data":"127.0.0.1","id":"23329931-8e76-4f48-898d-de05583064a9","name":"","priority":0,"ttl":3600,"type":"A"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"dd982ba0-2ab6-4f51-988b-4e85cf2589b8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"33cf28e4-86c0-40eb-9999-62c94243e7ef","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"\"v=DMARC1;
-      p=quarantine; adkim=s\"","id":"d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":6}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"4f181290-bce7-456b-8d0e-402b99473b29","name":"","priority":0,"ttl":3600,"type":"A"},{"comment":null,"data":"0
+      mail.scaleway.com.","id":"7d061b82-c0ea-4a69-ad93-039b258a00af","name":"","priority":0,"ttl":300,"type":"MX"},{"comment":null,"data":"10
+      feedback-smtp.eu-west-1.amazonses.com.","id":"c9b1e8ef-50f3-41d5-bd38-b863737c9448","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"0eecdb67-db65-49ea-8d2c-b098efdf5bb1","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"388d9539-1fe5-4e82-ad14-975e837d3986","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"\"v=DMARC1;
+      p=quarantine; adkim=s\"","id":"63fa3353-4932-4cc2-b21b-dc8107299b03","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":6}'
     headers:
       Content-Length:
-      - "919"
+      - "877"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:48 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -809,7 +811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d062fd5a-0e71-42e6-90d2-614b8ffb8a0f
+      - 3effb332-4449-4846-a95e-70e2364becee
     status: 200 OK
     code: 200
     duration: ""
@@ -818,21 +820,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=579f546e-2741-4eb9-903e-eaa0fc2e830c&name=&order_by=name_asc&page=1&type=MX
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=4f181290-bce7-456b-8d0e-402b99473b29&name=&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"0 mail.scaleway.com.","id":"579f546e-2741-4eb9-903e-eaa0fc2e830c","name":"","priority":0,"ttl":300,"type":"MX"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"4f181290-bce7-456b-8d0e-402b99473b29","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "172"
+      - "154"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:49 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -842,7 +844,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cc9a671-951f-4060-aa7d-0fd87a19bbc3
+      - aec25700-12bf-4f9e-9022-80a08401fa14
     status: 200 OK
     code: 200
     duration: ""
@@ -851,21 +853,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=1459c690-b7c8-4a60-acc2-d206caa14b45&name=&order_by=name_asc&page=1&type=MX
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=c9b1e8ef-50f3-41d5-bd38-b863737c9448&name=&order_by=name_asc&page=1&type=MX
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"1459c690-b7c8-4a60-acc2-d206caa14b45","name":"","priority":10,"ttl":300,"type":"MX"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"c9b1e8ef-50f3-41d5-bd38-b863737c9448","name":"","priority":10,"ttl":300,"type":"MX"}],"total_count":1}'
     headers:
       Content-Length:
-      - "194"
+      - "187"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:49 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -875,7 +877,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 368bd736-8a81-45a1-9973-356ff31889db
+      - e0ed428b-d029-4ecb-91b3-ac52d1b3980e
     status: 200 OK
     code: 200
     duration: ""
@@ -884,21 +886,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=23329931-8e76-4f48-898d-de05583064a9&name=&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=63fa3353-4932-4cc2-b21b-dc8107299b03&name=_dmarc&order_by=name_asc&page=1&type=TXT
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"23329931-8e76-4f48-898d-de05583064a9","name":"","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"\"v=DMARC1; p=quarantine; adkim=s\"","id":"63fa3353-4932-4cc2-b21b-dc8107299b03","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
     headers:
       Content-Length:
-      - "161"
+      - "188"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:49 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -908,7 +910,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4020954a-8c1b-4590-97ab-14f0425f29e5
+      - 6b48ffc1-e5c1-4388-a1bc-6f995aebe3e8
     status: 200 OK
     code: 200
     duration: ""
@@ -917,21 +919,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c&name=_dmarc&order_by=name_asc&page=1&type=TXT
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?id=7d061b82-c0ea-4a69-ad93-039b258a00af&name=&order_by=name_asc&page=1&type=MX
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"\"v=DMARC1; p=quarantine; adkim=s\"","id":"d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"0 mail.scaleway.com.","id":"7d061b82-c0ea-4a69-ad93-039b258a00af","name":"","priority":0,"ttl":300,"type":"MX"}],"total_count":1}'
     headers:
       Content-Length:
-      - "195"
+      - "165"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:49 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -941,7 +943,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 614e4326-284d-4f5f-b964-38957d058e4d
+      - cb46eccf-5cc3-41e6-9c31-3894f482850b
     status: 200 OK
     code: 200
     duration: ""
@@ -950,54 +952,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:48Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "343"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:45:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 76765802-63b6-45bf-a44b-68a278a9ef84
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:48Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "343"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:49 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1007,7 +976,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2394e42-e4e6-4527-9161-ee2cdfc9da9b
+      - 91e26d10-84d9-4cfe-9d60-8985da2eba3d
     status: 200 OK
     code: 200
     duration: ""
@@ -1016,21 +985,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:48Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "343"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:49 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1040,7 +1009,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39aaf5c4-d966-48ab-a09d-ba7c785f2b22
+      - 80fbfa65-2315-4731-8800-be7986d93daf
     status: 200 OK
     code: 200
     duration: ""
@@ -1049,21 +1018,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:48Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "343"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:49 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1073,18 +1042,51 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8b7ca65-38a3-49c8-8007-a1e2fa44f7d3
+      - 4626db22-dc1c-4f7d-b584-8c90e56dc36f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"1459c690-b7c8-4a60-acc2-d206caa14b45"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 47268b38-568b-4cba-80d6-218427001d4c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"delete":{"id":"7d061b82-c0ea-4a69-ad93-039b258a00af"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records
     method: PATCH
@@ -1098,7 +1100,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:50 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1108,18 +1110,18 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a7828ff-41dc-454e-bbfd-eaf0524c632e
+      - d9e317a0-fa25-4ae1-920b-cd3ac6898bb3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"579f546e-2741-4eb9-903e-eaa0fc2e830c"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"delete":{"id":"63fa3353-4932-4cc2-b21b-dc8107299b03"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records
     method: PATCH
@@ -1133,7 +1135,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:50 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1143,18 +1145,52 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68a46f24-2ed3-4feb-83a6-9883a3b73208
+      - 5ed5adaf-a788-48ac-bfaf-e2ee37196201
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"23329931-8e76-4f48-898d-de05583064a9"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"4f181290-bce7-456b-8d0e-402b99473b29","name":"","priority":0,"ttl":3600,"type":"A"},{"comment":null,"data":"10
+      feedback-smtp.eu-west-1.amazonses.com.","id":"c9b1e8ef-50f3-41d5-bd38-b863737c9448","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"0eecdb67-db65-49ea-8d2c-b098efdf5bb1","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"388d9539-1fe5-4e82-ad14-975e837d3986","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":4}'
+    headers:
+      Content-Length:
+      - "582"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e8ddcc6b-6cf3-43d8-a392-e3a528ae6b9e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"delete":{"id":"4f181290-bce7-456b-8d0e-402b99473b29"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records
     method: PATCH
@@ -1168,7 +1204,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:50 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1178,7 +1214,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0827741-dcbc-4ec4-ad43-9573648a93a0
+      - 4156d90d-d438-4846-a125-abd1a63941b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1187,22 +1223,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.1","id":"23329931-8e76-4f48-898d-de05583064a9","name":"","priority":0,"ttl":3600,"type":"A"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"dd982ba0-2ab6-4f51-988b-4e85cf2589b8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"33cf28e4-86c0-40eb-9999-62c94243e7ef","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"\"v=DMARC1;
-      p=quarantine; adkim=s\"","id":"d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c","name":"_dmarc","priority":0,"ttl":3600,"type":"TXT"}],"total_count":4}'
+    body: '{"records":[{"comment":null,"data":"10 feedback-smtp.eu-west-1.amazonses.com.","id":"c9b1e8ef-50f3-41d5-bd38-b863737c9448","name":"","priority":10,"ttl":300,"type":"MX"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"0eecdb67-db65-49ea-8d2c-b098efdf5bb1","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"388d9539-1fe5-4e82-ad14-975e837d3986","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":3}'
     headers:
       Content-Length:
-      - "611"
+      - "457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:50 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1212,18 +1247,18 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5411682-525c-4b60-94a1-984fb72077fa
+      - 7bb88271-1098-4c52-aab5-a56194082a0a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"d8f154f2-8bf3-41bd-9f55-f6bdcabdcd1c"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"delete":{"id":"c9b1e8ef-50f3-41d5-bd38-b863737c9448"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records
     method: PATCH
@@ -1237,7 +1272,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:50 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1247,7 +1282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2afed0ec-27d1-43e0-883d-5811f32a0bdc
+      - 2432a4d9-cadb-4027-8fcd-85592ef5faf4
     status: 200 OK
     code: 200
     duration: ""
@@ -1256,21 +1291,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"dd982ba0-2ab6-4f51-988b-4e85cf2589b8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"33cf28e4-86c0-40eb-9999-62c94243e7ef","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"0eecdb67-db65-49ea-8d2c-b098efdf5bb1","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"388d9539-1fe5-4e82-ad14-975e837d3986","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:50 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1280,7 +1315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b7af464-b05c-47e7-b913-b4eea1338518
+      - 062bcde5-ada6-4114-9525-30434f6b1bf5
     status: 200 OK
     code: 200
     duration: ""
@@ -1289,21 +1324,54 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:05Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "353"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - db428ad0-258b-4cfd-adde-a29d0de14c47
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"dd982ba0-2ab6-4f51-988b-4e85cf2589b8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"33cf28e4-86c0-40eb-9999-62c94243e7ef","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"0eecdb67-db65-49ea-8d2c-b098efdf5bb1","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"388d9539-1fe5-4e82-ad14-975e837d3986","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:50 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1313,7 +1381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e23f1e1-9144-424b-9a30-d4e040db4454
+      - 20f10607-1780-4e7b-b92c-d7f5f38f6bcf
     status: 200 OK
     code: 200
     duration: ""
@@ -1322,54 +1390,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"dd982ba0-2ab6-4f51-988b-4e85cf2589b8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"33cf28e4-86c0-40eb-9999-62c94243e7ef","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "313"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:45:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a87751ed-e48e-41a1-85e6-4693e8c1dc75
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:50Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:05Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "343"
+      - "353"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:50 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1379,7 +1414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4675270b-06ce-4161-9e74-d88249a4bae9
+      - c1f05987-bc58-47ff-ac9e-f7db38c033a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1388,21 +1423,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:50Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:05Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "343"
+      - "353"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:50 GMT
+      - Thu, 14 Dec 2023 12:43:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1412,7 +1447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23763501-c357-4502-a6c3-75bacc51d48e
+      - 81bc156f-70c8-478e-b8d1-1e16997b103b
     status: 200 OK
     code: 200
     duration: ""
@@ -1421,21 +1456,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:50Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:05Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "353"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:45:50 GMT
+      - Thu, 14 Dec 2023 12:43:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1445,7 +1480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbd955a5-8e0b-4f6f-9aa3-cde1100323ea
+      - 68d455e7-5bac-47d2-bfb1-dd3a1776c703
     status: 200 OK
     code: 200
     duration: ""
@@ -1454,21 +1489,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:51Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:14Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:46:00 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1478,7 +1513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccbb0610-2339-44e1-93d1-a1c04e17a0f6
+      - 6f4e1198-bafd-47bf-85ee-08de54039fe4
     status: 200 OK
     code: 200
     duration: ""
@@ -1487,7 +1522,40 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic2","updated_at":"2023-12-14T12:43:14Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 270b6628-2917-42ca-9fd1-accf37e4e765
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -1501,7 +1569,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:46:01 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1511,7 +1579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8960ad5-8e5c-45e3-803a-e32a052222c9
+      - f44ceb3d-fc81-47a5-800b-52854686245d
     status: 200 OK
     code: 200
     duration: ""
@@ -1520,21 +1588,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic2.scaleway-terraform.com&domain=&order_by=domain_asc
-    method: GET
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
+    method: DELETE
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic2","updated_at":"2023-07-28T09:45:51Z"}],"total_count":1}'
+    body: '{}'
     headers:
       Content-Length:
-      - "342"
+      - "2"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:46:00 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1544,7 +1612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22942561-8222-4480-9735-1059fc1f2f67
+      - c6dadda9-5cd6-4179-bbe1-4460074e9b25
     status: 200 OK
     code: 200
     duration: ""
@@ -1553,73 +1621,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
-    method: DELETE
-  response:
-    body: '{"message":"subdomain not found"}'
-    headers:
-      Content-Length:
-      - "33"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:46:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 345887f5-bbe0-4743-9385-dacdd262d485
-    status: 403 Forbidden
-    code: 403
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
-    method: DELETE
-  response:
-    body: '{"message":"subdomain not found"}'
-    headers:
-      Content-Length:
-      - "33"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:46:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6584f092-38e6-48e2-8b27-d84ecf89f25e
-    status: 403 Forbidden
-    code: 403
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic2.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
@@ -1633,7 +1635,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:46:24 GMT
+      - Thu, 14 Dec 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1643,7 +1645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1b3e440-c16c-4bbb-83a0-d725e69a9011
+      - 0dcd1ab2-1c95-4c34-b99e-8b152f5aa73f
     status: 403 Forbidden
     code: 403
     duration: ""

--- a/scaleway/testdata/domain-record-cname.cassette.yaml
+++ b/scaleway/testdata/domain-record-cname.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"xxx.scw.cloud","name":"tf","priority":0,"ttl":3600,"type":"CNAME","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"xxx.scw.cloud","name":"tf","priority":0,"ttl":3600,"type":"CNAME","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}]}'
+    body: '{"records":[{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}]}'
     headers:
       Content-Length:
-      - "195"
+      - "189"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:44 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9da584fd-d70d-44b5-b3f6-c14d45716d8b
+      - 2d4cc31d-3378-4cf4-b03a-02f7b5b97457
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?name=tf&order_by=name_asc&type=CNAME
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
     headers:
       Content-Length:
-      - "212"
+      - "205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:44 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f2c56ce-8a33-4a87-9c43-17362ed9db17
+      - b1396603-9b60-4438-9f32-404b3c514198
     status: 200 OK
     code: 200
     duration: ""
@@ -74,21 +74,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?name=tf&order_by=name_asc&page=1&type=CNAME
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
     headers:
       Content-Length:
-      - "212"
+      - "205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:44 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6ac1af8-6a61-490f-83b1-318a0592630a
+      - 826f9402-3ca1-49c7-b306-4071e8a104b2
     status: 200 OK
     code: 200
     duration: ""
@@ -107,21 +107,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=a579ce89-4954-42fd-9bfb-bd48b17cc708&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=368fd836-e4bd-440c-8df6-a08950784291&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
     headers:
       Content-Length:
-      - "212"
+      - "205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:44 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c42c27c9-2df0-4180-948d-ccbbb88e7769
+      - cfdb9212-a57d-4b1f-8c55-6fb97cf5bef1
     status: 200 OK
     code: 200
     duration: ""
@@ -140,21 +140,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-07-28T09:33:44Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-12-14T12:43:02Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:44 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d088ec5c-1482-4e7b-9671-fb88d4674119
+      - 63c349a2-7f58-4e39-9047-efc4b313ba93
     status: 200 OK
     code: 200
     duration: ""
@@ -173,21 +173,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"6f8f50ef-2514-4d78-a0da-162743f74035","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"00d750aa-27ca-440c-b028-aa86eac07806","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"89004c7e-0d0d-4f2c-8a9d-0dd0a39567ae","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"4185ff3a-bb65-4f80-b0b3-d31455ae895d","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":3}'
     headers:
       Content-Length:
-      - "496"
+      - "475"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:44 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2358dc7-c1f5-4443-9cdb-7b721820460c
+      - 419075ef-8b2a-49c5-986d-9a3bb9f54093
     status: 200 OK
     code: 200
     duration: ""
@@ -206,21 +206,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=a579ce89-4954-42fd-9bfb-bd48b17cc708&name=tf&order_by=name_asc&page=1&type=CNAME
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=368fd836-e4bd-440c-8df6-a08950784291&name=tf&order_by=name_asc&page=1&type=CNAME
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
     headers:
       Content-Length:
-      - "212"
+      - "205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:44 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f11dfd0-791f-4b93-ad58-5b13d014a930
+      - 1d198bf2-a884-4034-bd10-71f5da57893a
     status: 200 OK
     code: 200
     duration: ""
@@ -239,87 +239,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-07-28T09:33:44Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "348"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 01953d66-377b-470d-bf24-34d487d1e57f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=a579ce89-4954-42fd-9bfb-bd48b17cc708&name=tf&order_by=name_asc&page=1&type=CNAME
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "212"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b9a5e254-e4cd-4e89-a04f-a074c6135a8b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-07-28T09:33:44Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-12-14T12:43:02Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:45 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -329,32 +263,98 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b2c5369-0ccb-498d-ba77-ee3d34f79eb5
+      - c29a9f7d-c5b6-4261-94ab-1a75dacfbf60
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"set":{"id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","records":[{"data":"yyy.scw.cloud","name":"tf","priority":0,"ttl":0,"type":"unknown","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=368fd836-e4bd-440c-8df6-a08950784291&name=tf&order_by=name_asc&page=1&type=CNAME
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"xxx.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "205"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eb756dfb-3f86-40df-b3a8-cd54276863be
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic-cname","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "357"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2ffebdbe-0be1-4821-93f9-d7e1a2ff8ee6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"set":{"id":"368fd836-e4bd-440c-8df6-a08950784291","records":[{"data":"yyy.scw.cloud","name":"tf","priority":0,"ttl":3600,"type":"CNAME","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}]}'
+    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}]}'
     headers:
       Content-Length:
-      - "195"
+      - "189"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:45 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -364,7 +364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e02edba1-b0e3-4971-85b9-f596ac016dd5
+      - c6e5161d-0a90-49d6-b502-ee444e4b326f
     status: 200 OK
     code: 200
     duration: ""
@@ -373,21 +373,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?name=tf&order_by=name_asc&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?name=tf&order_by=name_asc&type=CNAME
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
     headers:
       Content-Length:
-      - "212"
+      - "205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:45 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -397,7 +397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2077fb85-d6b0-499c-9e36-2e1b5306618b
+      - 737327c1-d1ea-4927-824b-2f9733c681d6
     status: 200 OK
     code: 200
     duration: ""
@@ -406,21 +406,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=a579ce89-4954-42fd-9bfb-bd48b17cc708&name=tf&order_by=name_asc&page=1&type=CNAME
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=368fd836-e4bd-440c-8df6-a08950784291&name=tf&order_by=name_asc&page=1&type=CNAME
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
     headers:
       Content-Length:
-      - "212"
+      - "205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -430,7 +430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7a668e0-aeb2-4d43-a3e1-545e2350cb5f
+      - 9e9ab7c2-2706-4cd2-916d-a33b74d262e3
     status: 200 OK
     code: 200
     duration: ""
@@ -439,21 +439,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-07-28T09:33:45Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-12-14T12:43:04Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -463,7 +463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba6d0cec-a2b8-4200-be04-523662be9694
+      - a0dbefcb-2334-46fb-96d5-f070268cddd9
     status: 200 OK
     code: 200
     duration: ""
@@ -472,21 +472,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"6f8f50ef-2514-4d78-a0da-162743f74035","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"00d750aa-27ca-440c-b028-aa86eac07806","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"89004c7e-0d0d-4f2c-8a9d-0dd0a39567ae","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"4185ff3a-bb65-4f80-b0b3-d31455ae895d","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":3}'
     headers:
       Content-Length:
-      - "496"
+      - "475"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -496,7 +496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65d69dd9-180b-433a-bd94-088b7124196f
+      - 2cf75b4e-eaff-44c6-b75f-d8c81739f4ae
     status: 200 OK
     code: 200
     duration: ""
@@ -505,21 +505,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=a579ce89-4954-42fd-9bfb-bd48b17cc708&name=tf&order_by=name_asc&page=1&type=CNAME
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=368fd836-e4bd-440c-8df6-a08950784291&name=tf&order_by=name_asc&page=1&type=CNAME
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
     headers:
       Content-Length:
-      - "212"
+      - "205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -529,7 +529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4e2b68d-170c-4c79-a6c6-e5ee687a95cd
+      - 026d0bf0-8725-4fcf-8dcf-c73312217149
     status: 200 OK
     code: 200
     duration: ""
@@ -538,87 +538,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-07-28T09:33:45Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "348"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 37028932-5751-420b-a74c-40843f4bf4e2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=a579ce89-4954-42fd-9bfb-bd48b17cc708&name=tf&order_by=name_asc&page=1&type=CNAME
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "212"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ad9efdea-e7e6-4de4-a510-8b25e026db59
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-07-28T09:33:45Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-12-14T12:43:04Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:47 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -628,32 +562,98 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f756a0e-0ca9-4ba0-aa6e-b3030887d9b7
+      - 75be51e9-c67d-4238-8937-6960bb4e78db
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"set":{"id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","records":[{"data":"","name":"tf","priority":10,"ttl":43200,"type":"unknown","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=368fd836-e4bd-440c-8df6-a08950784291&name=tf&order_by=name_asc&page=1&type=CNAME
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":0,"ttl":3600,"type":"CNAME"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "205"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c7aded6c-ddef-41dd-94e5-8078a725804c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-12-14T12:43:04Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "358"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fe48a52e-3328-4e39-a0c1-4c048795757a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"set":{"id":"368fd836-e4bd-440c-8df6-a08950784291","records":[{"data":"yyy.scw.cloud","name":"tf","priority":10,"ttl":43200,"type":"CNAME","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":10,"ttl":43200,"type":"CNAME"}]}'
+    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":10,"ttl":43200,"type":"CNAME"}]}'
     headers:
       Content-Length:
-      - "197"
+      - "191"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:48 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cae74147-422c-48a4-9120-f6184a8baa25
+      - fe54bcb5-0883-4227-b10c-2c0ee1c6095f
     status: 200 OK
     code: 200
     duration: ""
@@ -672,21 +672,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?name=tf&order_by=name_asc&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?name=tf&order_by=name_asc&type=CNAME
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":10,"ttl":43200,"type":"CNAME"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":10,"ttl":43200,"type":"CNAME"}],"total_count":1}'
     headers:
       Content-Length:
-      - "214"
+      - "207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:48 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -696,7 +696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80df654c-df08-4dcf-8a94-eb2bcc7c8d86
+      - 9372ae18-6c45-43db-8150-0b80b92dafd6
     status: 200 OK
     code: 200
     duration: ""
@@ -705,21 +705,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=a579ce89-4954-42fd-9bfb-bd48b17cc708&name=tf&order_by=name_asc&page=1&type=CNAME
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=368fd836-e4bd-440c-8df6-a08950784291&name=tf&order_by=name_asc&page=1&type=CNAME
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":10,"ttl":43200,"type":"CNAME"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":10,"ttl":43200,"type":"CNAME"}],"total_count":1}'
     headers:
       Content-Length:
-      - "214"
+      - "207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:48 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,7 +729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f96b4484-4f40-42b4-9e80-c19e76b3e3d7
+      - e6b196d2-7fa9-4764-956e-9b7eb999dd53
     status: 200 OK
     code: 200
     duration: ""
@@ -738,21 +738,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-07-28T09:33:48Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-12-14T12:43:07Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:48 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -762,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75bfadd0-313c-4498-81db-e2666d5c5db6
+      - dab8d474-8388-4401-9784-2d7e50560572
     status: 200 OK
     code: 200
     duration: ""
@@ -771,21 +771,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"6f8f50ef-2514-4d78-a0da-162743f74035","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"00d750aa-27ca-440c-b028-aa86eac07806","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":10,"ttl":43200,"type":"CNAME"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"89004c7e-0d0d-4f2c-8a9d-0dd0a39567ae","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"4185ff3a-bb65-4f80-b0b3-d31455ae895d","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":10,"ttl":43200,"type":"CNAME"}],"total_count":3}'
     headers:
       Content-Length:
-      - "498"
+      - "477"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:48 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -795,7 +795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fa21978-9eee-4ed2-8457-7fe16e7f8b99
+      - bd2f6751-19a6-4e2c-a7b7-0243851abc3c
     status: 200 OK
     code: 200
     duration: ""
@@ -804,21 +804,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=a579ce89-4954-42fd-9bfb-bd48b17cc708&name=tf&order_by=name_asc&page=1&type=CNAME
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?id=368fd836-e4bd-440c-8df6-a08950784291&name=tf&order_by=name_asc&page=1&type=CNAME
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"a579ce89-4954-42fd-9bfb-bd48b17cc708","name":"tf","priority":10,"ttl":43200,"type":"CNAME"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"yyy.scw.cloud.test-basic-cname.scaleway-terraform.com.","id":"368fd836-e4bd-440c-8df6-a08950784291","name":"tf","priority":10,"ttl":43200,"type":"CNAME"}],"total_count":1}'
     headers:
       Content-Length:
-      - "214"
+      - "207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -828,7 +828,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6a74db1-5aff-4b25-bae0-6d4f381236dc
+      - 2d9687eb-50ad-41f7-bd08-53f847dfec85
     status: 200 OK
     code: 200
     duration: ""
@@ -837,21 +837,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-07-28T09:33:48Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-12-14T12:43:07Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -861,18 +861,18 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 099d71e0-542d-4835-9cc1-58a6f79178d9
+      - a4dd814d-2a11-48b8-81b2-18aec83861ec
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"a579ce89-4954-42fd-9bfb-bd48b17cc708"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"delete":{"id":"368fd836-e4bd-440c-8df6-a08950784291"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records
     method: PATCH
@@ -886,7 +886,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -896,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 394632ec-e70d-4026-8f84-ee3648ca29ba
+      - c5ac432a-ec33-43e5-9358-ab459ea8823f
     status: 200 OK
     code: 200
     duration: ""
@@ -905,21 +905,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"6f8f50ef-2514-4d78-a0da-162743f74035","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"00d750aa-27ca-440c-b028-aa86eac07806","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"89004c7e-0d0d-4f2c-8a9d-0dd0a39567ae","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"4185ff3a-bb65-4f80-b0b3-d31455ae895d","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -929,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56e859aa-a6ae-4cfc-b7fc-bdbb25003014
+      - 9179e129-8172-4016-bf25-dd983b55ca67
     status: 200 OK
     code: 200
     duration: ""
@@ -938,21 +938,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-07-28T09:33:49Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-12-14T12:43:08Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -962,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a64672bb-ece5-4967-8c90-21802fbbd0c5
+      - 3af894a3-7fc3-41fe-b56e-df87ed90b681
     status: 200 OK
     code: 200
     duration: ""
@@ -971,21 +971,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic-cname","updated_at":"2023-07-28T09:33:53Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-basic-cname","updated_at":"2023-12-14T12:43:08Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "347"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:54 GMT
+      - Thu, 14 Dec 2023 12:43:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -995,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6492d0f3-8fa6-4882-a3a7-27e0a9c6a851
+      - b9927c97-9a60-493a-9b29-54e66e2e4c9c
     status: 200 OK
     code: 200
     duration: ""
@@ -1004,7 +1004,40 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-basic-cname.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-basic-cname","updated_at":"2023-12-14T12:43:15Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "357"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 35c9c11a-a5d2-4301-b7fb-7fc1d0d36211
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -1018,7 +1051,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:55 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1028,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af3fb296-14a5-4be9-b00d-7b4f32f22b91
+      - 1afc3a33-58f0-40b1-92f3-ab3697619646
     status: 200 OK
     code: 200
     duration: ""
@@ -1037,7 +1070,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-basic-cname.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
@@ -1051,7 +1084,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:55 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1061,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 477ffc59-9f94-498b-bb3f-e84a148b4325
+      - c961bdce-307f-4816-a038-0e51a7e05e3d
     status: 403 Forbidden
     code: 403
     duration: ""

--- a/scaleway/testdata/domain-record-geo-ip.cassette.yaml
+++ b/scaleway/testdata/domain-record-geo-ip.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.2","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A","comment":null,"geo_ip_config":{"matches":[{"countries":["FR"],"continents":["EU"],"data":"1.2.3.4"},{"countries":[],"continents":["NA"],"data":"1.2.3.5"}],"default":"127.0.0.2"},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.2","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A","comment":null,"geo_ip_config":{"matches":[{"countries":["FR"],"continents":["EU"],"data":"1.2.3.4"},{"countries":[],"continents":["NA"],"data":"1.2.3.5"}],"default":"127.0.0.2"},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}]}'
     headers:
       Content-Length:
-      - "324"
+      - "311"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b292f26-5be5-4367-a7cd-788d5a860ced
+      - 9263e714-a7ec-4019-86ca-09d37a79784a
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?name=tf_geo_ip&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebc1a6f9-1d39-4847-8e48-39cc89fb69b8
+      - 0ab14386-9c25-4e6b-a426-4e08c78948ed
     status: 200 OK
     code: 200
     duration: ""
@@ -74,21 +74,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?name=tf_geo_ip&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec622aa8-0f5f-457b-a9f9-79ff57f0688d
+      - 34ea57c7-8b7a-4706-9d31-7046e6cdc0e4
     status: 200 OK
     code: 200
     duration: ""
@@ -107,21 +107,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?id=f980e1ce-03b6-48e6-bd04-7e0284e3747e&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?id=3988d96c-fde8-48e0-8fa9-2468fe56c660&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df3e9f5b-3900-4c6c-948e-668639d2582c
+      - d262e04c-bc85-4246-964f-ad5bcc263fce
     status: 200 OK
     code: 200
     duration: ""
@@ -140,21 +140,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-geoip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-geoip","updated_at":"2023-07-28T09:33:46Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-geoip","updated_at":"2023-12-14T12:43:02Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:46 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf28aeed-6497-42fd-8f5c-397e4fd0ba5c
+      - 136aa76e-612c-4c9a-a972-1ca2d8f43947
     status: 200 OK
     code: 200
     duration: ""
@@ -173,21 +173,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"3f3ce9f2-7b32-41b6-baa3-8e9ed48ea3f1","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"070b6a96-9a03-4f8a-9574-c58f6fd68c6a","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"2fc660cc-2511-4885-9fab-b449d7568dc7","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"614e515e-b0e9-498d-ad48-7b40e4007de5","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
     headers:
       Content-Length:
-      - "625"
+      - "597"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:47 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 310df548-2068-4bc8-97a7-bf9b6c5a5d3d
+      - 4793a60b-4956-4b4b-bc76-2a90eddfff3d
     status: 200 OK
     code: 200
     duration: ""
@@ -206,21 +206,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?id=f980e1ce-03b6-48e6-bd04-7e0284e3747e&name=tf_geo_ip&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?id=3988d96c-fde8-48e0-8fa9-2468fe56c660&name=tf_geo_ip&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:47 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 562ee646-8850-464b-ab50-5ea542c26720
+      - 66bbb17b-b97c-4f09-b8c8-8db4bbf7ad5a
     status: 200 OK
     code: 200
     duration: ""
@@ -239,87 +239,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-geoip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-geoip","updated_at":"2023-07-28T09:33:46Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "342"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 93388bfc-7723-446f-a249-7125176ab124
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?id=f980e1ce-03b6-48e6-bd04-7e0284e3747e&name=tf_geo_ip&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "341"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1e2df809-87c5-4aee-b429-5414ce6f46d1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-geoip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-geoip","updated_at":"2023-07-28T09:33:46Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-geoip","updated_at":"2023-12-14T12:43:02Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:48 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -329,32 +263,98 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cfc27fc-07cb-4c0b-9adb-d58fcec5c093
+      - 77f6d17d-5e0e-44c7-8c48-260fe263c002
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"set":{"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","records":[{"data":"","name":"tf_geo_ip","priority":0,"ttl":0,"type":"unknown","comment":null,"geo_ip_config":{"matches":[{"countries":["FR","AE"],"continents":["EU","AS"],"data":"1.2.3.4"},{"countries":["CI"],"continents":[],"data":"1.2.3.5"}],"default":"127.0.0.2"},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?id=3988d96c-fde8-48e0-8fa9-2468fe56c660&name=tf_geo_ip&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU"],"countries":["FR"],"data":"1.2.3.4"},{"continents":["NA"],"countries":[],"data":"1.2.3.5"}]},"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "327"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 58219204-9e40-422d-96b7-0209732fbb9d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-geoip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-geoip","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "351"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 44827d83-2d41-4bcb-95f4-79b85827cdc9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"set":{"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","records":[{"data":"127.0.0.2","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A","comment":null,"geo_ip_config":{"matches":[{"countries":["FR","AE"],"continents":["EU","AS"],"data":"1.2.3.4"},{"countries":["CI"],"continents":[],"data":"1.2.3.5"}],"default":"127.0.0.2"},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU","AS"],"countries":["FR","AE"],"data":"1.2.3.4"},{"continents":[],"countries":["CI"],"data":"1.2.3.5"}]},"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU","AS"],"countries":["FR","AE"],"data":"1.2.3.4"},{"continents":[],"countries":["CI"],"data":"1.2.3.5"}]},"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}]}'
     headers:
       Content-Length:
-      - "336"
+      - "321"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -364,7 +364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e4a6898-82fb-4ff0-82b7-377894dd83e5
+      - 764b6a9c-c992-4a19-9018-8228cae5c778
     status: 200 OK
     code: 200
     duration: ""
@@ -373,21 +373,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?name=tf_geo_ip&order_by=name_asc&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?name=tf_geo_ip&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU","AS"],"countries":["FR","AE"],"data":"1.2.3.4"},{"continents":[],"countries":["CI"],"data":"1.2.3.5"}]},"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU","AS"],"countries":["FR","AE"],"data":"1.2.3.4"},{"continents":[],"countries":["CI"],"data":"1.2.3.5"}]},"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "353"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -397,7 +397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c90c54c5-e39d-4fd1-8fa8-b0ed02e49089
+      - 753d0fbd-1482-4cad-9d57-f653ba7abc15
     status: 200 OK
     code: 200
     duration: ""
@@ -406,21 +406,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?id=f980e1ce-03b6-48e6-bd04-7e0284e3747e&name=tf_geo_ip&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?id=3988d96c-fde8-48e0-8fa9-2468fe56c660&name=tf_geo_ip&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU","AS"],"countries":["FR","AE"],"data":"1.2.3.4"},{"continents":[],"countries":["CI"],"data":"1.2.3.5"}]},"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU","AS"],"countries":["FR","AE"],"data":"1.2.3.4"},{"continents":[],"countries":["CI"],"data":"1.2.3.5"}]},"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "353"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -430,7 +430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c508804-11d3-4900-8f94-43f8deefd1ca
+      - 1ada8ea8-4f26-4e54-9228-bdd6b93257fe
     status: 200 OK
     code: 200
     duration: ""
@@ -439,21 +439,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-geoip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-geoip","updated_at":"2023-07-28T09:33:49Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-geoip","updated_at":"2023-12-14T12:43:05Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -463,7 +463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ce48742-3d83-46cf-911e-a9b0f663036e
+      - 6f82c58b-de68-4897-845c-e8b5d60e054f
     status: 200 OK
     code: 200
     duration: ""
@@ -472,21 +472,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"3f3ce9f2-7b32-41b6-baa3-8e9ed48ea3f1","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"070b6a96-9a03-4f8a-9574-c58f6fd68c6a","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU","AS"],"countries":["FR","AE"],"data":"1.2.3.4"},{"continents":[],"countries":["CI"],"data":"1.2.3.5"}]},"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"2fc660cc-2511-4885-9fab-b449d7568dc7","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"614e515e-b0e9-498d-ad48-7b40e4007de5","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU","AS"],"countries":["FR","AE"],"data":"1.2.3.4"},{"continents":[],"countries":["CI"],"data":"1.2.3.5"}]},"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
     headers:
       Content-Length:
-      - "637"
+      - "607"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:49 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -496,7 +496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a736f0b2-771a-4ea9-b721-76cffa89c292
+      - fc294679-827d-48e5-9dbc-90341b3fb747
     status: 200 OK
     code: 200
     duration: ""
@@ -505,21 +505,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?id=f980e1ce-03b6-48e6-bd04-7e0284e3747e&name=tf_geo_ip&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?id=3988d96c-fde8-48e0-8fa9-2468fe56c660&name=tf_geo_ip&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU","AS"],"countries":["FR","AE"],"data":"1.2.3.4"},{"continents":[],"countries":["CI"],"data":"1.2.3.5"}]},"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.2","geo_ip_config":{"default":"127.0.0.2","matches":[{"continents":["EU","AS"],"countries":["FR","AE"],"data":"1.2.3.4"},{"continents":[],"countries":["CI"],"data":"1.2.3.5"}]},"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660","name":"tf_geo_ip","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "353"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:50 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -529,7 +529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3a911db-b54a-4dfa-9a23-9f6015d0fd01
+      - dca3a791-74e2-4b86-8eec-0e4110faec95
     status: 200 OK
     code: 200
     duration: ""
@@ -538,21 +538,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-geoip.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-geoip","updated_at":"2023-07-28T09:33:49Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-geoip","updated_at":"2023-12-14T12:43:05Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:50 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -562,18 +562,18 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac2bd15d-2244-44ee-ac5f-aae633d8d59c
+      - c40304f4-1882-417a-9e88-95ff9e81fc0b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"f980e1ce-03b6-48e6-bd04-7e0284e3747e"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"delete":{"id":"3988d96c-fde8-48e0-8fa9-2468fe56c660"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records
     method: PATCH
@@ -587,7 +587,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:50 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6931fbf2-9b3a-4aab-8d8c-e1ab34190767
+      - e5011fd0-325f-4e7e-9831-d49b4ff6eed6
     status: 200 OK
     code: 200
     duration: ""
@@ -606,21 +606,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"3f3ce9f2-7b32-41b6-baa3-8e9ed48ea3f1","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"070b6a96-9a03-4f8a-9574-c58f6fd68c6a","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"2fc660cc-2511-4885-9fab-b449d7568dc7","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"614e515e-b0e9-498d-ad48-7b40e4007de5","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:50 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9686a178-32e1-4c2f-8e81-fd9922012e3c
+      - 72623518-6840-42bc-a89f-c1d6be77749e
     status: 200 OK
     code: 200
     duration: ""
@@ -639,21 +639,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-geoip.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-geoip","updated_at":"2023-07-28T09:33:50Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-geoip","updated_at":"2023-12-14T12:43:06Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:50 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92fe4922-50d4-44cc-b10a-82322e1c796c
+      - c76da690-dc30-4ff5-9596-51a05fe97061
     status: 200 OK
     code: 200
     duration: ""
@@ -672,21 +672,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-geoip.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-geoip","updated_at":"2023-07-28T09:33:53Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-geoip","updated_at":"2023-12-14T12:43:06Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:55 GMT
+      - Thu, 14 Dec 2023 12:43:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -696,7 +696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ca1e468-32da-4fac-83e3-9189c0899824
+      - fed54264-239a-4add-8a83-75b21368a26a
     status: 200 OK
     code: 200
     duration: ""
@@ -705,7 +705,40 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-geoip.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-geoip","updated_at":"2023-12-14T12:43:15Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "351"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ed5c707d-aed1-4ffd-8b1b-576c6fdd1c73
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -719,7 +752,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:56 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88e4e4a2-2117-4389-9aab-a6e4cc4b69dc
+      - 59bd298a-7204-4185-9370-19e80c68ca69
     status: 200 OK
     code: 200
     duration: ""
@@ -738,7 +771,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-geoip.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
@@ -752,7 +785,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:56 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -762,7 +795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f1dac0c-a7e6-4035-81eb-b810f9a21565
+      - 29b3870e-549b-4c81-a3d4-806d1d8e54c4
     status: 403 Forbidden
     code: 403
     duration: ""

--- a/scaleway/testdata/domain-record-http-service.cassette.yaml
+++ b/scaleway/testdata/domain-record-http-service.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.3","name":"tf_http_service","priority":0,"ttl":3600,"type":"A","comment":null,"http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","url":"http://mywebsite.com/health","user_agent":"scw_service_up","strategy":"hashed"},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.3","name":"tf_http_service","priority":0,"ttl":3600,"type":"A","comment":null,"http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","url":"http://mywebsite.com/health","user_agent":"scw_service_up","strategy":"hashed"},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}]}'
     headers:
       Content-Length:
-      - "323"
+      - "311"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fed02a46-8e84-44f7-b130-77887c0ee6af
+      - 1d3a4b73-0c63-45a9-a972-d6ab9f8840e8
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?name=tf_http_service&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "340"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54b5d804-0380-4302-ae1c-11209035d3d7
+      - e735e745-3572-46c3-a430-c6b363214714
     status: 200 OK
     code: 200
     duration: ""
@@ -74,21 +74,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?name=tf_http_service&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "340"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 203b0033-32c4-47b0-9754-b32ff49ceedf
+      - adb115c7-21e8-4b1b-aa89-8808bb9e0c08
     status: 200 OK
     code: 200
     duration: ""
@@ -107,21 +107,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?id=0ea43b52-96d2-4c79-a40e-f34b53747e87&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?id=22d8a36d-f8d2-4db0-b31a-e56d517070db&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "340"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a58063fc-c178-4cff-babe-1ec7027da881
+      - 86b8aa67-1848-40f3-9070-6f3bcd23bbda
     status: 200 OK
     code: 200
     duration: ""
@@ -140,21 +140,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-httpservice.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-httpservice","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-httpservice","updated_at":"2023-12-14T12:43:02Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21f41ab9-ec0b-4bc6-b4a3-64f3b08a019f
+      - 016bfb6e-d126-40e2-8fd5-17a8bfff2578
     status: 200 OK
     code: 200
     duration: ""
@@ -173,21 +173,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"fa27826b-0f0e-4b7c-9fc2-d1c7a4659e26","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"56a50440-5e35-4e8f-be39-49441011d8be","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"aec847d0-cdb7-4ee2-9b60-0750bd14ee8d","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"221b9d88-6179-4dba-ba72-0b9aeee005b0","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
     headers:
       Content-Length:
-      - "624"
+      - "597"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abc3efb8-0bb3-4555-964f-a4e09818109c
+      - a2b9240b-2c87-4e6d-87c5-bf0b62b2573a
     status: 200 OK
     code: 200
     duration: ""
@@ -206,21 +206,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?id=0ea43b52-96d2-4c79-a40e-f34b53747e87&name=tf_http_service&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?id=22d8a36d-f8d2-4db0-b31a-e56d517070db&name=tf_http_service&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "340"
+      - "327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 457fae23-378c-4c1f-9b4a-07db59e66762
+      - 06d94016-c46c-4736-be15-fbc6162a454c
     status: 200 OK
     code: 200
     duration: ""
@@ -239,87 +239,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-httpservice.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-httpservice","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "348"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0eb32f45-feab-44ad-b573-31e253eb227c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?id=0ea43b52-96d2-4c79-a40e-f34b53747e87&name=tf_http_service&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "340"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c03b5c82-f082-4747-abc1-b4effb8e722a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-httpservice.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-httpservice","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-httpservice","updated_at":"2023-12-14T12:43:02Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -329,32 +263,98 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8e98582-efd9-4605-b07b-1a7d5e0e2668
+      - 821fced8-85d9-48d2-b2b7-5ac2cd511a18
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"set":{"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","records":[{"data":"","name":"tf_http_service","priority":0,"ttl":0,"type":"unknown","comment":null,"http_service_config":{"ips":["5.6.7.8"],"must_contain":"online","url":"http://mywebsite.com/healthcheck","user_agent":"scw_service_online","strategy":"random"},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?id=22d8a36d-f8d2-4db0-b31a-e56d517070db&name=tf_http_service&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["1.2.3.4","4.3.2.1"],"must_contain":"up","strategy":"hashed","url":"http://mywebsite.com/health","user_agent":"scw_service_up"},"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "327"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0a5bac51-72f2-4209-8f99-4ff8c8e2a16a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-httpservice.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-httpservice","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "357"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bfa52535-6e52-4607-81e9-94cb90587c3b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"set":{"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","records":[{"data":"127.0.0.3","name":"tf_http_service","priority":0,"ttl":3600,"type":"A","comment":null,"http_service_config":{"ips":["5.6.7.8"],"must_contain":"online","url":"http://mywebsite.com/healthcheck","user_agent":"scw_service_online","strategy":"random"},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["5.6.7.8"],"must_contain":"online","strategy":"random","url":"http://mywebsite.com/healthcheck","user_agent":"scw_service_online"},"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["5.6.7.8"],"must_contain":"online","strategy":"random","url":"http://mywebsite.com/healthcheck","user_agent":"scw_service_online"},"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}]}'
     headers:
       Content-Length:
-      - "325"
+      - "314"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -364,7 +364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6166b699-feef-4cae-8391-ce8e28ba8ad1
+      - 0b426491-6ed2-417a-b1a8-85d3180c61ee
     status: 200 OK
     code: 200
     duration: ""
@@ -373,21 +373,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?name=tf_http_service&order_by=name_asc&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?name=tf_http_service&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["5.6.7.8"],"must_contain":"online","strategy":"random","url":"http://mywebsite.com/healthcheck","user_agent":"scw_service_online"},"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["5.6.7.8"],"must_contain":"online","strategy":"random","url":"http://mywebsite.com/healthcheck","user_agent":"scw_service_online"},"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "330"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -397,7 +397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a3fa4cb-0dc4-4f38-8053-40a537316bd7
+      - 208d05c4-358c-431a-bb55-66aeff349dc5
     status: 200 OK
     code: 200
     duration: ""
@@ -406,21 +406,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?id=0ea43b52-96d2-4c79-a40e-f34b53747e87&name=tf_http_service&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?id=22d8a36d-f8d2-4db0-b31a-e56d517070db&name=tf_http_service&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["5.6.7.8"],"must_contain":"online","strategy":"random","url":"http://mywebsite.com/healthcheck","user_agent":"scw_service_online"},"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["5.6.7.8"],"must_contain":"online","strategy":"random","url":"http://mywebsite.com/healthcheck","user_agent":"scw_service_online"},"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "330"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -430,7 +430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb84ba8f-e3bc-4358-ab61-e1349950d20e
+      - aafc3629-a257-4b2b-9555-12296a4cd140
     status: 200 OK
     code: 200
     duration: ""
@@ -439,21 +439,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-httpservice.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-httpservice","updated_at":"2023-07-28T09:33:40Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-httpservice","updated_at":"2023-12-14T12:43:05Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -463,7 +463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94bff4ca-1e08-43c6-bc28-9c12a82245e7
+      - 3e1b6a3c-7919-4280-85f3-6bb4e43081ac
     status: 200 OK
     code: 200
     duration: ""
@@ -472,21 +472,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"fa27826b-0f0e-4b7c-9fc2-d1c7a4659e26","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"56a50440-5e35-4e8f-be39-49441011d8be","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["5.6.7.8"],"must_contain":"online","strategy":"random","url":"http://mywebsite.com/healthcheck","user_agent":"scw_service_online"},"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"aec847d0-cdb7-4ee2-9b60-0750bd14ee8d","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"221b9d88-6179-4dba-ba72-0b9aeee005b0","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["5.6.7.8"],"must_contain":"online","strategy":"random","url":"http://mywebsite.com/healthcheck","user_agent":"scw_service_online"},"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":3}'
     headers:
       Content-Length:
-      - "626"
+      - "600"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -496,7 +496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45692c96-43d6-4b4e-8f5f-2d284482934e
+      - 989f36d3-d719-40a6-91ed-7a64bffd61f5
     status: 200 OK
     code: 200
     duration: ""
@@ -505,21 +505,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?id=0ea43b52-96d2-4c79-a40e-f34b53747e87&name=tf_http_service&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?id=22d8a36d-f8d2-4db0-b31a-e56d517070db&name=tf_http_service&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["5.6.7.8"],"must_contain":"online","strategy":"random","url":"http://mywebsite.com/healthcheck","user_agent":"scw_service_online"},"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.3","http_service_config":{"ips":["5.6.7.8"],"must_contain":"online","strategy":"random","url":"http://mywebsite.com/healthcheck","user_agent":"scw_service_online"},"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db","name":"tf_http_service","priority":0,"ttl":3600,"type":"A"}],"total_count":1}'
     headers:
       Content-Length:
-      - "342"
+      - "330"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -529,7 +529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a08ae401-d571-4ad1-bd72-3991d64d4ae0
+      - 74e2d1ab-b350-4e8d-8c1b-ec8a3ce8d768
     status: 200 OK
     code: 200
     duration: ""
@@ -538,21 +538,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-httpservice.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-httpservice","updated_at":"2023-07-28T09:33:40Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-httpservice","updated_at":"2023-12-14T12:43:05Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "348"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -562,18 +562,18 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 143b7d84-6d06-4577-afe3-d51769d1907f
+      - f4f09723-3b77-4a40-a644-b53b8cd6deb5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"0ea43b52-96d2-4c79-a40e-f34b53747e87"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"delete":{"id":"22d8a36d-f8d2-4db0-b31a-e56d517070db"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records
     method: PATCH
@@ -587,7 +587,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5370039-97b2-445d-bd5f-194c48e4da55
+      - d4d22450-3086-4ea5-b373-f5fd25438326
     status: 200 OK
     code: 200
     duration: ""
@@ -606,21 +606,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"fa27826b-0f0e-4b7c-9fc2-d1c7a4659e26","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"56a50440-5e35-4e8f-be39-49441011d8be","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"aec847d0-cdb7-4ee2-9b60-0750bd14ee8d","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"221b9d88-6179-4dba-ba72-0b9aeee005b0","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80861c93-24d9-40e1-8bab-b4ada50cfded
+      - 8c02ad61-ef58-4ca0-bf62-7f92ef00a90f
     status: 200 OK
     code: 200
     duration: ""
@@ -639,21 +639,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-httpservice.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-httpservice","updated_at":"2023-07-28T09:33:41Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-httpservice","updated_at":"2023-12-14T12:43:06Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "347"
+      - "358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9006ccc5-9d43-4eef-bd76-6ba8651d030d
+      - fe378ffa-3768-4913-834a-b789c6f12e34
     status: 200 OK
     code: 200
     duration: ""
@@ -672,7 +672,73 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-httpservice.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-httpservice","updated_at":"2023-12-14T12:43:06Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "358"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fe04184c-a766-46b8-b1d7-8e45054ea4be
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-httpservice.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-httpservice","updated_at":"2023-12-14T12:43:15Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "357"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6baac3e0-c8ba-4e5e-a5bd-ca495d55e6d4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -686,7 +752,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:42 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -696,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ac14751-236c-4359-a5c7-dca804e9db23
+      - 480b9d3b-8f0d-44eb-be21-ef5e07bbf26c
     status: 200 OK
     code: 200
     duration: ""
@@ -705,7 +771,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-httpservice.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
@@ -719,7 +785,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:42 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,7 +795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 053df747-1a97-4b75-84fc-7bfc0e302406
+      - 10883084-15a3-4a69-8b23-cab2a58ca98a
     status: 403 Forbidden
     code: 403
     duration: ""

--- a/scaleway/testdata/domain-record-srv-zone.cassette.yaml
+++ b/scaleway/testdata/domain-record-srv-zone.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"100 1 3128 bigbox.example.com.","name":"_proxy-preproduction._tcp","priority":0,"ttl":3600,"type":"SRV","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"100 1 3128 bigbox.example.com.","name":"_proxy-preproduction._tcp","priority":0,"ttl":3600,"type":"SRV","comment":null,"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-srv.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"100 1 3128 bigbox.example.com.","id":"5a550a16-f7b3-4994-aba6-a96e18ec3b4d","name":"_proxy-preproduction._tcp","priority":100,"ttl":3600,"type":"SRV"}]}'
+    body: '{"records":[{"comment":null,"data":"100 1 3128 bigbox.example.com.","id":"28d5b730-c8bd-4a8e-a5d3-141244027550","name":"_proxy-preproduction._tcp","priority":100,"ttl":3600,"type":"SRV"}]}'
     headers:
       Content-Length:
-      - "194"
+      - "188"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cee84038-b779-41f6-8549-b546d5d359d5
+      - 19fd5d5e-12c6-4027-bb23-0df644ab17a1
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-srv.scaleway-terraform.com/records?name=_proxy-preproduction._tcp&order_by=name_asc&type=SRV
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"100 1 3128 bigbox.example.com.","id":"5a550a16-f7b3-4994-aba6-a96e18ec3b4d","name":"_proxy-preproduction._tcp","priority":100,"ttl":3600,"type":"SRV"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"100 1 3128 bigbox.example.com.","id":"28d5b730-c8bd-4a8e-a5d3-141244027550","name":"_proxy-preproduction._tcp","priority":100,"ttl":3600,"type":"SRV"}],"total_count":1}'
     headers:
       Content-Length:
-      - "211"
+      - "204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d2ec95c-3ed1-499c-bc55-acc679237bb2
+      - 2026c49d-dc7b-44d8-b7a1-a4999dffbc5e
     status: 200 OK
     code: 200
     duration: ""
@@ -74,21 +74,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-srv.scaleway-terraform.com/records?name=_proxy-preproduction._tcp&order_by=name_asc&page=1&type=SRV
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"100 1 3128 bigbox.example.com.","id":"5a550a16-f7b3-4994-aba6-a96e18ec3b4d","name":"_proxy-preproduction._tcp","priority":100,"ttl":3600,"type":"SRV"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"100 1 3128 bigbox.example.com.","id":"28d5b730-c8bd-4a8e-a5d3-141244027550","name":"_proxy-preproduction._tcp","priority":100,"ttl":3600,"type":"SRV"}],"total_count":1}'
     headers:
       Content-Length:
-      - "211"
+      - "204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85483ee1-e01b-49e1-917e-4ea85b7db5b2
+      - 2a4e5628-6171-411e-9370-0e5a393722b4
     status: 200 OK
     code: 200
     duration: ""
@@ -107,21 +107,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-srv.scaleway-terraform.com/records?id=5a550a16-f7b3-4994-aba6-a96e18ec3b4d&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-srv.scaleway-terraform.com/records?id=28d5b730-c8bd-4a8e-a5d3-141244027550&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"100 1 3128 bigbox.example.com.","id":"5a550a16-f7b3-4994-aba6-a96e18ec3b4d","name":"_proxy-preproduction._tcp","priority":100,"ttl":3600,"type":"SRV"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"100 1 3128 bigbox.example.com.","id":"28d5b730-c8bd-4a8e-a5d3-141244027550","name":"_proxy-preproduction._tcp","priority":100,"ttl":3600,"type":"SRV"}],"total_count":1}'
     headers:
       Content-Length:
-      - "211"
+      - "204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 178967fc-e2eb-4ed4-8c2b-65776a4b1131
+      - 87102cf6-f4f6-4f5f-b0c1-18beb1d9a4ec
     status: 200 OK
     code: 200
     duration: ""
@@ -140,21 +140,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-srv.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-srv","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-srv","updated_at":"2023-12-14T12:43:02Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "340"
+      - "350"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef5b4a1d-223a-4cf3-9641-cae202907230
+      - ced14d6b-3380-422c-8bdc-56e9bb3bb162
     status: 200 OK
     code: 200
     duration: ""
@@ -173,22 +173,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-srv.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"d053494c-27fc-489b-9702-03e67093ede9","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"dd872a66-d365-491d-ac73-05c2662300c5","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"100
-      1 3128 bigbox.example.com.","id":"5a550a16-f7b3-4994-aba6-a96e18ec3b4d","name":"_proxy-preproduction._tcp","priority":100,"ttl":3600,"type":"SRV"}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"361f56a4-939d-4cc7-a862-d409d9b1aa08","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"cd099817-cb76-4d11-957d-61c89d7938b2","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"100
+      1 3128 bigbox.example.com.","id":"28d5b730-c8bd-4a8e-a5d3-141244027550","name":"_proxy-preproduction._tcp","priority":100,"ttl":3600,"type":"SRV"}],"total_count":3}'
     headers:
       Content-Length:
-      - "495"
+      - "474"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -198,7 +198,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2abfdbdb-1e11-4cc3-a9e9-7c80833af28f
+      - 1aecf7d2-9c2c-4295-ad91-1a58f6ca297a
     status: 200 OK
     code: 200
     duration: ""
@@ -207,21 +207,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-srv.scaleway-terraform.com/records?id=5a550a16-f7b3-4994-aba6-a96e18ec3b4d&name=_proxy-preproduction._tcp&order_by=name_asc&page=1&type=SRV
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-srv.scaleway-terraform.com/records?id=28d5b730-c8bd-4a8e-a5d3-141244027550&name=_proxy-preproduction._tcp&order_by=name_asc&page=1&type=SRV
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"100 1 3128 bigbox.example.com.","id":"5a550a16-f7b3-4994-aba6-a96e18ec3b4d","name":"_proxy-preproduction._tcp","priority":100,"ttl":3600,"type":"SRV"}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"100 1 3128 bigbox.example.com.","id":"28d5b730-c8bd-4a8e-a5d3-141244027550","name":"_proxy-preproduction._tcp","priority":100,"ttl":3600,"type":"SRV"}],"total_count":1}'
     headers:
       Content-Length:
-      - "211"
+      - "204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -231,7 +231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdca5dda-b6d5-42e1-92b5-86e62dea4c0d
+      - 1be5f715-0003-427b-abee-ea2ce665227f
     status: 200 OK
     code: 200
     duration: ""
@@ -240,21 +240,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-srv.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-srv","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-srv","updated_at":"2023-12-14T12:43:02Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "340"
+      - "350"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -264,18 +264,18 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fddba03-83ec-4af5-bc70-9ba66c07a21a
+      - 69616e27-e6e4-47e2-be06-bade05f1cd21
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"5a550a16-f7b3-4994-aba6-a96e18ec3b4d"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"delete":{"id":"28d5b730-c8bd-4a8e-a5d3-141244027550"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-srv.scaleway-terraform.com/records
     method: PATCH
@@ -289,7 +289,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -299,7 +299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4e9e524-08ce-4eef-b7df-dadd12a681ac
+      - dab961a3-44d1-43f9-8d7b-7f1358f205f3
     status: 200 OK
     code: 200
     duration: ""
@@ -308,21 +308,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-srv.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"d053494c-27fc-489b-9702-03e67093ede9","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"dd872a66-d365-491d-ac73-05c2662300c5","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"361f56a4-939d-4cc7-a862-d409d9b1aa08","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"cd099817-cb76-4d11-957d-61c89d7938b2","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -332,7 +332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0991bdb8-6690-4be6-b1a8-62a9b88d4e2c
+      - afb6d048-db62-46a2-820e-f602fd03dae8
     status: 200 OK
     code: 200
     duration: ""
@@ -341,21 +341,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-srv.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-srv","updated_at":"2023-07-28T09:33:39Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-srv","updated_at":"2023-12-14T12:43:04Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "340"
+      - "350"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -365,7 +365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 824929c9-2771-426f-9dba-da99eab8f0a9
+      - aa9c397c-9bf5-460e-88c3-192e46a961a4
     status: 200 OK
     code: 200
     duration: ""
@@ -374,21 +374,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-srv.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-srv","updated_at":"2023-07-28T09:33:42Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-srv","updated_at":"2023-12-14T12:43:04Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "339"
+      - "350"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:44 GMT
+      - Thu, 14 Dec 2023 12:43:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -398,7 +398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ca37c27-0f6a-49f6-97c9-efb16673f145
+      - 08288f9a-fb24-4714-93e5-538cc0de2a51
     status: 200 OK
     code: 200
     duration: ""
@@ -407,7 +407,40 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-srv.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-srv","updated_at":"2023-12-14T12:43:14Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "349"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4e59f769-c87d-4459-b594-6dab73cfa12d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-srv.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -421,7 +454,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:45 GMT
+      - Thu, 14 Dec 2023 12:43:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73a1db73-886a-444a-811a-4dd932aeff11
+      - 4ad3aa71-8700-4b36-ad92-9380ec47e90b
     status: 200 OK
     code: 200
     duration: ""
@@ -440,7 +473,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-srv.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
@@ -454,7 +487,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:45 GMT
+      - Thu, 14 Dec 2023 12:43:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -464,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b426a0f7-09cb-4f26-9495-76816233599a
+      - f52b98ae-b78b-40ea-8485-540c08d574b4
     status: 403 Forbidden
     code: 403
     duration: ""

--- a/scaleway/testdata/domain-record-view.cassette.yaml
+++ b/scaleway/testdata/domain-record-view.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.4","name":"tf_view","priority":0,"ttl":3600,"type":"A","comment":null,"view_config":{"views":[{"subnet":"100.0.0.0/16","data":"1.2.3.4"},{"subnet":"100.1.0.0/16","data":"4.3.2.1"}]},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.4","name":"tf_view","priority":0,"ttl":3600,"type":"A","comment":null,"view_config":{"views":[{"subnet":"100.0.0.0/16","data":"1.2.3.4"},{"subnet":"100.1.0.0/16","data":"4.3.2.1"}]},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"7947e50a-07b9-4457-8b93-5aa194f52bee","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}]}'
     headers:
       Content-Length:
-      - "267"
+      - "257"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91637f1e-da79-4a48-8a09-968d5240c1a5
+      - 8649686c-57e7-466e-878a-ca7c3a40c2f7
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?name=tf_view&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"7947e50a-07b9-4457-8b93-5aa194f52bee","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "284"
+      - "273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 818bdd1d-6122-4205-aeb8-92ada54e36b2
+      - 2129de90-50ad-460b-ab9b-49b7ccd3e4df
     status: 200 OK
     code: 200
     duration: ""
@@ -74,21 +74,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?name=tf_view&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"7947e50a-07b9-4457-8b93-5aa194f52bee","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "284"
+      - "273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7b58947-1220-44e8-9db2-6d80f77a9edb
+      - 42bd69fc-25fe-4cb2-9faf-55db13caf497
     status: 200 OK
     code: 200
     duration: ""
@@ -107,21 +107,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?id=7947e50a-07b9-4457-8b93-5aa194f52bee&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?id=e3f14330-3f05-460c-b4e0-00f4a0e447e4&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"7947e50a-07b9-4457-8b93-5aa194f52bee","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "284"
+      - "273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eed13041-0c88-4dc1-9d32-3c2fb33ad852
+      - 3bcfa83a-ae64-44a9-86e4-bb25ec328892
     status: 200 OK
     code: 200
     duration: ""
@@ -140,21 +140,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-view","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-view","updated_at":"2023-12-14T12:43:17Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "351"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 357c9411-4a94-4704-808b-00ccfa658d8d
+      - 28a3de24-69cd-4c56-9a85-c519f94d5778
     status: 200 OK
     code: 200
     duration: ""
@@ -173,21 +173,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"ca96b890-7ea5-4549-95aa-bf21d06c58bd","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"8501a857-d555-46c6-9985-49bb2d9c3c8a","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.4","id":"7947e50a-07b9-4457-8b93-5aa194f52bee","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"2f21e434-6669-4ad1-91e9-520115dd709b","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"976aec60-1080-4685-a1a0-eafda9e8baa5","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.4","id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":3}'
     headers:
       Content-Length:
-      - "568"
+      - "543"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77084610-020d-4536-bfa9-4e8085100bf8
+      - c0257796-fd86-400d-9cfb-e50ea4b4d870
     status: 200 OK
     code: 200
     duration: ""
@@ -206,21 +206,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?id=7947e50a-07b9-4457-8b93-5aa194f52bee&name=tf_view&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?id=e3f14330-3f05-460c-b4e0-00f4a0e447e4&name=tf_view&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"7947e50a-07b9-4457-8b93-5aa194f52bee","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "284"
+      - "273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abc79402-c536-4226-b7e0-da4a994083a0
+      - cc4d7837-c579-429f-9315-e1ce02b7a732
     status: 200 OK
     code: 200
     duration: ""
@@ -239,87 +239,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-view","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "341"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5e48193d-dece-401d-8360-1835ebcaba5b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?id=7947e50a-07b9-4457-8b93-5aa194f52bee&name=tf_view&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"7947e50a-07b9-4457-8b93-5aa194f52bee","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "284"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - da5c47cb-0ab6-403f-b149-6578a25ae56f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-view","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-view","updated_at":"2023-12-14T12:43:17Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "351"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -329,32 +263,98 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6dcdabd-a177-4c11-b294-8a609002c887
+      - b3b0ad85-e5df-46fb-9852-a6496874d77a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"set":{"id":"7947e50a-07b9-4457-8b93-5aa194f52bee","records":[{"data":"","name":"tf_view","priority":0,"ttl":0,"type":"unknown","comment":null,"view_config":{"views":[{"subnet":"100.0.0.0/16","data":"1.2.3.4"},{"subnet":"90.1.0.0/32","data":"4.3.2.2"},{"subnet":"1.1.1.1/16","data":"2.2.2.2"}]},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?id=e3f14330-3f05-460c-b4e0-00f4a0e447e4&name=tf_view&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.1","subnet":"100.1.0.0/16"}]}}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "273"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9d7b2c03-3110-4073-a49a-31281e520d7a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-view","updated_at":"2023-12-14T12:43:17Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "351"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 92096400-aaf0-4c6c-8afd-7255e144316a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"set":{"id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","records":[{"data":"127.0.0.4","name":"tf_view","priority":0,"ttl":3600,"type":"A","comment":null,"view_config":{"views":[{"subnet":"100.0.0.0/16","data":"1.2.3.4"},{"subnet":"90.1.0.0/32","data":"4.3.2.2"},{"subnet":"1.1.1.1/16","data":"2.2.2.2"}]},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"7947e50a-07b9-4457-8b93-5aa194f52bee","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.2","subnet":"90.1.0.0/32"},{"data":"2.2.2.2","subnet":"1.1.1.1/16"}]}}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.2","subnet":"90.1.0.0/32"},{"data":"2.2.2.2","subnet":"1.1.1.1/16"}]}}]}'
     headers:
       Content-Length:
-      - "309"
+      - "297"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -364,7 +364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4709b86-dd5c-460f-b926-cfc2ae56131f
+      - 4b686f78-835d-4843-abde-b640ee9863d6
     status: 200 OK
     code: 200
     duration: ""
@@ -373,21 +373,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?name=tf_view&order_by=name_asc&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?name=tf_view&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"7947e50a-07b9-4457-8b93-5aa194f52bee","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.2","subnet":"90.1.0.0/32"},{"data":"2.2.2.2","subnet":"1.1.1.1/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.2","subnet":"90.1.0.0/32"},{"data":"2.2.2.2","subnet":"1.1.1.1/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "326"
+      - "313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -397,7 +397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c9f8acd-7c88-480b-977d-46ed642d1e3b
+      - 13e42f10-8f96-4d8c-aab3-5f658bea691f
     status: 200 OK
     code: 200
     duration: ""
@@ -406,21 +406,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?id=7947e50a-07b9-4457-8b93-5aa194f52bee&name=tf_view&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?id=e3f14330-3f05-460c-b4e0-00f4a0e447e4&name=tf_view&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"7947e50a-07b9-4457-8b93-5aa194f52bee","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.2","subnet":"90.1.0.0/32"},{"data":"2.2.2.2","subnet":"1.1.1.1/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.2","subnet":"90.1.0.0/32"},{"data":"2.2.2.2","subnet":"1.1.1.1/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "326"
+      - "313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -430,7 +430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b09857be-90dc-4d03-9fdb-dc3f6f88e1a3
+      - 567d2a90-efb1-49d6-9624-a9ae0a4cd4ff
     status: 200 OK
     code: 200
     duration: ""
@@ -439,21 +439,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-view","updated_at":"2023-07-28T09:33:40Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-view","updated_at":"2023-12-14T12:43:18Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "351"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -463,7 +463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17fce37d-546d-4d14-933a-95e133c32936
+      - dfa07e56-52c7-4020-95ba-58a72dc199f2
     status: 200 OK
     code: 200
     duration: ""
@@ -472,21 +472,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"ca96b890-7ea5-4549-95aa-bf21d06c58bd","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"8501a857-d555-46c6-9985-49bb2d9c3c8a","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.4","id":"7947e50a-07b9-4457-8b93-5aa194f52bee","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.2","subnet":"90.1.0.0/32"},{"data":"2.2.2.2","subnet":"1.1.1.1/16"}]}}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"2f21e434-6669-4ad1-91e9-520115dd709b","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"976aec60-1080-4685-a1a0-eafda9e8baa5","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.4","id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.2","subnet":"90.1.0.0/32"},{"data":"2.2.2.2","subnet":"1.1.1.1/16"}]}}],"total_count":3}'
     headers:
       Content-Length:
-      - "610"
+      - "583"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -496,7 +496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a75df556-be82-4082-9578-25868c048ecd
+      - 49c8e146-4f5b-4dbc-a96b-8d49b46e0e97
     status: 200 OK
     code: 200
     duration: ""
@@ -505,21 +505,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?id=7947e50a-07b9-4457-8b93-5aa194f52bee&name=tf_view&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?id=e3f14330-3f05-460c-b4e0-00f4a0e447e4&name=tf_view&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"7947e50a-07b9-4457-8b93-5aa194f52bee","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.2","subnet":"90.1.0.0/32"},{"data":"2.2.2.2","subnet":"1.1.1.1/16"}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.4","id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4","name":"tf_view","priority":0,"ttl":3600,"type":"A","view_config":{"views":[{"data":"1.2.3.4","subnet":"100.0.0.0/16"},{"data":"4.3.2.2","subnet":"90.1.0.0/32"},{"data":"2.2.2.2","subnet":"1.1.1.1/16"}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "326"
+      - "313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -529,7 +529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4836923e-293e-47a4-86ee-f7eb315236ea
+      - 672de44d-c0e8-4cfd-8eb4-853d8333aabf
     status: 200 OK
     code: 200
     duration: ""
@@ -538,21 +538,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-view.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-view","updated_at":"2023-07-28T09:33:40Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-view","updated_at":"2023-12-14T12:43:18Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "341"
+      - "351"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -562,18 +562,18 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae6a1c2f-0319-47b7-ac31-579459018984
+      - 2b3f6271-ed8f-4107-b98d-0cad3453e071
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"7947e50a-07b9-4457-8b93-5aa194f52bee"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"delete":{"id":"e3f14330-3f05-460c-b4e0-00f4a0e447e4"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records
     method: PATCH
@@ -587,7 +587,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fee043d-ad9c-4c37-ab97-5e3be8eb2856
+      - 4519228b-15b4-40ca-92b5-76b933ea2f21
     status: 200 OK
     code: 200
     duration: ""
@@ -606,21 +606,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"ca96b890-7ea5-4549-95aa-bf21d06c58bd","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"8501a857-d555-46c6-9985-49bb2d9c3c8a","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"2f21e434-6669-4ad1-91e9-520115dd709b","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"976aec60-1080-4685-a1a0-eafda9e8baa5","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60c7d7d1-4f9e-4ded-b87d-431ff901aaf0
+      - 493034b5-b365-48bd-90d4-2c0346ca22dd
     status: 200 OK
     code: 200
     duration: ""
@@ -639,21 +639,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-view.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-view","updated_at":"2023-07-28T09:33:41Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-view","updated_at":"2023-12-14T12:43:19Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "340"
+      - "351"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5058271c-d9e8-415d-a46a-ec30e7dc4c0b
+      - 4112a18b-a63e-4b1e-b165-779866af9af7
     status: 200 OK
     code: 200
     duration: ""
@@ -672,7 +672,73 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-view.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-view","updated_at":"2023-12-14T12:43:19Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "351"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c8cbf112-2f18-4397-8f9b-1335f8a1ab83
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-view.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-view","updated_at":"2023-12-14T12:43:25Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "350"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8de76995-a064-41bf-95fa-02da88723c96
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -686,7 +752,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:42 GMT
+      - Thu, 14 Dec 2023 12:43:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -696,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36b984d7-49f2-4242-b805-c755f93ce64a
+      - 1bff66ad-a638-4136-974b-bcb1b875abed
     status: 200 OK
     code: 200
     duration: ""
@@ -705,7 +771,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-view.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
@@ -719,7 +785,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:42 GMT
+      - Thu, 14 Dec 2023 12:43:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,7 +795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0ef97e5-36f0-4756-af76-9144cc03d481
+      - 07470b08-dfb2-4d68-a9fc-c530f388f8c7
     status: 403 Forbidden
     code: 403
     duration: ""

--- a/scaleway/testdata/domain-record-weighted.cassette.yaml
+++ b/scaleway/testdata/domain-record-weighted.cassette.yaml
@@ -2,27 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","comment":null,"weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"add":{"records":[{"data":"127.0.0.5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","comment":null,"weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}]}'
     headers:
       Content-Length:
-      - "252"
+      - "242"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c8c31e8-96fb-4d96-b8d4-182f4b1617ff
+      - 6a37b40c-7ae1-4c99-922e-696b314b5158
     status: 200 OK
     code: 200
     duration: ""
@@ -41,21 +41,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?name=tf_weighted&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "269"
+      - "258"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4d84b84-dba2-4cea-9d73-7a7ad42bda5b
+      - 86f6b71d-0174-473b-8669-d9a8c429f8fb
     status: 200 OK
     code: 200
     duration: ""
@@ -74,21 +74,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?name=tf_weighted&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "269"
+      - "258"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afb30a0b-9380-42e3-a7ef-0e94e39b442d
+      - 5cc696ac-5b60-40de-aef0-9506d2e5914a
     status: 200 OK
     code: 200
     duration: ""
@@ -107,21 +107,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?id=8558bd31-ba16-4627-a644-136f7a9ff6a9&name=&order_by=name_asc&page=1&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?id=fee43880-6a49-4f9d-bf44-25bb65ec493a&name=&order_by=name_asc&page=1&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "269"
+      - "258"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:37 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 936a4f13-60f7-4d59-9675-f6852a0955a2
+      - 07c56f7a-f8af-4920-965b-685ee03364ed
     status: 200 OK
     code: 200
     duration: ""
@@ -140,21 +140,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-weighted","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-weighted","updated_at":"2023-12-14T12:43:02Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "345"
+      - "355"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 660e0227-59e1-4311-b52d-9fdc4735d5fe
+      - 833f81cc-884d-4ee9-8b3c-8f29d57a289f
     status: 200 OK
     code: 200
     duration: ""
@@ -173,21 +173,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"f3f3e777-3d56-49c6-ac51-cda56f316787","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"b5e84375-1ddd-4152-971b-ce71f5f2bee8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.5","id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"a9803f70-d57e-4c22-8917-2b80c296aaf8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"0713e105-eeab-4486-926f-594475f2c467","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.5","id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":3}'
     headers:
       Content-Length:
-      - "553"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9c251a8-8b51-4bc7-9c73-d7cd4e6b878e
+      - 3355b2ee-8d4a-43eb-8cc2-4d539f190b50
     status: 200 OK
     code: 200
     duration: ""
@@ -206,21 +206,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?id=8558bd31-ba16-4627-a644-136f7a9ff6a9&name=tf_weighted&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?id=fee43880-6a49-4f9d-bf44-25bb65ec493a&name=tf_weighted&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "269"
+      - "258"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a45044c7-9564-4fdc-bb2d-dc566ee0155e
+      - c250fe06-c9e7-47ad-9af0-4832af4ef42e
     status: 200 OK
     code: 200
     duration: ""
@@ -239,87 +239,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
-    method: GET
-  response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-weighted","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "345"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 23e5488d-953d-4818-9c8c-87ae1661b29c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?id=8558bd31-ba16-4627-a644-136f7a9ff6a9&name=tf_weighted&order_by=name_asc&page=1&type=A
-    method: GET
-  response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "269"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2412a28d-01fd-4171-aeec-db8b5e4befb8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-weighted","updated_at":"2023-07-28T09:33:37Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-weighted","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "345"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:39 GMT
+      - Thu, 14 Dec 2023 12:43:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -329,32 +263,98 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c555f04e-7da5-4bcf-8a75-d9fad100975a
+      - eb1478f4-fd41-413f-91e9-0703c4bce93c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"set":{"id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","records":[{"data":"","name":"tf_weighted","priority":0,"ttl":0,"type":"unknown","comment":null,"weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":2},{"ip":"4.3.2.1","weight":1},{"ip":"5.6.7.8","weight":999}]},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?id=fee43880-6a49-4f9d-bf44-25bb65ec493a&name=tf_weighted&order_by=name_asc&page=1&type=A
+    method: GET
+  response:
+    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":1},{"ip":"4.3.2.1","weight":2}]}}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "258"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2db64cba-f4e1-4f6d-af14-6bed9e9e629f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-weighted","updated_at":"2023-12-14T12:43:03Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "354"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5052a993-038e-43ff-a9ba-40adbab5fe0c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"changes":[{"set":{"id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","records":[{"data":"127.0.0.5","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","comment":null,"weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":2},{"ip":"4.3.2.1","weight":1},{"ip":"5.6.7.8","weight":999}]},"id":""}]}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records
     method: PATCH
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":2},{"ip":"4.3.2.1","weight":1},{"ip":"5.6.7.8","weight":999}]}}]}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":2},{"ip":"4.3.2.1","weight":1},{"ip":"5.6.7.8","weight":999}]}}]}'
     headers:
       Content-Length:
-      - "284"
+      - "272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -364,7 +364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8dbe0cb1-8098-4b71-8de5-d82ac43077bd
+      - 179217c9-12f8-4a4a-8933-e399ca0e7595
     status: 200 OK
     code: 200
     duration: ""
@@ -373,21 +373,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?name=tf_weighted&order_by=name_asc&type=unknown
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?name=tf_weighted&order_by=name_asc&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":2},{"ip":"4.3.2.1","weight":1},{"ip":"5.6.7.8","weight":999}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":2},{"ip":"4.3.2.1","weight":1},{"ip":"5.6.7.8","weight":999}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "301"
+      - "288"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -397,7 +397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e59ae15-68bc-41a0-98be-b73891f0b78a
+      - 05dd4c5d-fcc1-413a-8d39-dbee795eca04
     status: 200 OK
     code: 200
     duration: ""
@@ -406,21 +406,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?id=8558bd31-ba16-4627-a644-136f7a9ff6a9&name=tf_weighted&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?id=fee43880-6a49-4f9d-bf44-25bb65ec493a&name=tf_weighted&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":2},{"ip":"4.3.2.1","weight":1},{"ip":"5.6.7.8","weight":999}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":2},{"ip":"4.3.2.1","weight":1},{"ip":"5.6.7.8","weight":999}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "301"
+      - "288"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -430,7 +430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26a50ad0-6ff5-4d0c-8dff-ba0d5dc0b26a
+      - 3c2d55a8-4760-4dd5-b5e6-4c1b9ba094a0
     status: 200 OK
     code: 200
     duration: ""
@@ -439,21 +439,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-weighted","updated_at":"2023-07-28T09:33:40Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-weighted","updated_at":"2023-12-14T12:43:05Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "345"
+      - "355"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -463,7 +463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 032a010c-338d-4c3e-8e44-a2805b037875
+      - ca1f2fca-59f2-4826-91cb-c287f8a479fc
     status: 200 OK
     code: 200
     duration: ""
@@ -472,21 +472,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"f3f3e777-3d56-49c6-ac51-cda56f316787","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"b5e84375-1ddd-4152-971b-ce71f5f2bee8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.5","id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":2},{"ip":"4.3.2.1","weight":1},{"ip":"5.6.7.8","weight":999}]}}],"total_count":3}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"a9803f70-d57e-4c22-8917-2b80c296aaf8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"0713e105-eeab-4486-926f-594475f2c467","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"127.0.0.5","id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":2},{"ip":"4.3.2.1","weight":1},{"ip":"5.6.7.8","weight":999}]}}],"total_count":3}'
     headers:
       Content-Length:
-      - "585"
+      - "558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:40 GMT
+      - Thu, 14 Dec 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -496,7 +496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71e16c5a-c715-42db-aa84-a730fc52635f
+      - ec6666b8-a42a-44b6-b1e8-308e6847f26c
     status: 200 OK
     code: 200
     duration: ""
@@ -505,21 +505,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?id=8558bd31-ba16-4627-a644-136f7a9ff6a9&name=tf_weighted&order_by=name_asc&page=1&type=A
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?id=fee43880-6a49-4f9d-bf44-25bb65ec493a&name=tf_weighted&order_by=name_asc&page=1&type=A
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"8558bd31-ba16-4627-a644-136f7a9ff6a9","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":2},{"ip":"4.3.2.1","weight":1},{"ip":"5.6.7.8","weight":999}]}}],"total_count":1}'
+    body: '{"records":[{"comment":null,"data":"127.0.0.5","id":"fee43880-6a49-4f9d-bf44-25bb65ec493a","name":"tf_weighted","priority":0,"ttl":3600,"type":"A","weighted_config":{"weighted_ips":[{"ip":"1.2.3.4","weight":2},{"ip":"4.3.2.1","weight":1},{"ip":"5.6.7.8","weight":999}]}}],"total_count":1}'
     headers:
       Content-Length:
-      - "301"
+      - "288"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -529,7 +529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30ce85e6-8850-4785-bc91-41cf909dea6f
+      - 91088163-7b6f-48fa-81b6-2e1953790f4a
     status: 200 OK
     code: 200
     duration: ""
@@ -538,21 +538,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-weighted.scaleway-terraform.com&domain=&order_by=domain_asc&page=1
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-weighted","updated_at":"2023-07-28T09:33:40Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-weighted","updated_at":"2023-12-14T12:43:05Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "345"
+      - "355"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -562,18 +562,18 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7ff2c14-a57b-474e-bfc6-8e4298f19d39
+      - a6763cc0-f7d4-4420-a175-761189731d9e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"changes":[{"delete":{"id":"8558bd31-ba16-4627-a644-136f7a9ff6a9"}}],"return_all_records":false,"disallow_new_zone_creation":false,"serial":null}'
+    body: '{"changes":[{"delete":{"id":"fee43880-6a49-4f9d-bf44-25bb65ec493a"}}],"return_all_records":false,"disallow_new_zone_creation":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records
     method: PATCH
@@ -587,7 +587,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a8f68c8-5db3-45d8-8ec8-b26e5834a89e
+      - ab5a9e61-581e-40c0-8693-bb6150f90d89
     status: 200 OK
     code: 200
     duration: ""
@@ -606,21 +606,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
   response:
-    body: '{"records":[{"comment":null,"data":"ns1.dom.scw.cloud.","id":"f3f3e777-3d56-49c6-ac51-cda56f316787","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns0.dom.scw.cloud.","id":"b5e84375-1ddd-4152-971b-ce71f5f2bee8","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
+    body: '{"records":[{"comment":null,"data":"ns0.dom.scw.cloud.","id":"a9803f70-d57e-4c22-8917-2b80c296aaf8","name":"","priority":0,"ttl":1800,"type":"NS"},{"comment":null,"data":"ns1.dom.scw.cloud.","id":"0713e105-eeab-4486-926f-594475f2c467","name":"","priority":0,"ttl":1800,"type":"NS"}],"total_count":2}'
     headers:
       Content-Length:
-      - "313"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a22e808f-cfdc-47aa-aab9-219f0daebb37
+      - 2d835695-ca6f-4733-9c7c-04f1d119ab2c
     status: 200 OK
     code: 200
     duration: ""
@@ -639,21 +639,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-weighted.scaleway-terraform.com&domain=&order_by=domain_asc
     method: GET
   response:
-    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-weighted","updated_at":"2023-07-28T09:33:41Z"}],"total_count":1}'
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-weighted","updated_at":"2023-12-14T12:43:06Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "344"
+      - "355"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:41 GMT
+      - Thu, 14 Dec 2023 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ed46fac-2aeb-4b78-b342-9f59e12b07dd
+      - 30f9d4df-edbe-4174-93dc-05ab64f02716
     status: 200 OK
     code: 200
     duration: ""
@@ -672,7 +672,73 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-weighted.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"pending","subdomain":"test-weighted","updated_at":"2023-12-14T12:43:06Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "355"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 03f5d3a0-d963-4ffe-aae1-732435dddc3e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/domain/v2beta1/dns-zones?dns_zone=test-weighted.scaleway-terraform.com&domain=&order_by=domain_asc
+    method: GET
+  response:
+    body: '{"dns_zones":[{"domain":"scaleway-terraform.com","linked_products":[],"message":null,"ns":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_default":["ns0.dom.scw.cloud","ns1.dom.scw.cloud"],"ns_master":[],"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"active","subdomain":"test-weighted","updated_at":"2023-12-14T12:43:15Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "354"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 14 Dec 2023 12:43:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 52a447c8-8725-4f7c-ab6b-946a613ce315
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com?project_id=105bdce1-64c0-48ab-899d-868455867ecf
     method: DELETE
@@ -686,7 +752,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:42 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -696,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81372033-bfc4-418f-b8ad-cd8ef649bebf
+      - 6f554195-ee8f-4d80-9666-62d46bb905b5
     status: 200 OK
     code: 200
     duration: ""
@@ -705,7 +771,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/domain/v2beta1/dns-zones/test-weighted.scaleway-terraform.com/records?name=&order_by=name_asc&type=unknown
     method: GET
@@ -719,7 +785,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 28 Jul 2023 09:33:42 GMT
+      - Thu, 14 Dec 2023 12:43:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,7 +795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35634ba7-16c3-4816-82b6-5c62b26099f6
+      - 2ae7ed58-9e9e-4846-a00e-cabca134206f
     status: 403 Forbidden
     code: 403
     duration: ""


### PR DESCRIPTION
Always send the full record content when updating it to avoid losing dynamic types (geoIP, etc.)